### PR TITLE
Add tests for unsupported types

### DIFF
--- a/integration-tests/values_unsupported_test.go
+++ b/integration-tests/values_unsupported_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration_tests
+
+import (
+	"time"
+
+	. "github.com/neo4j/neo4j-go-driver"
+	"github.com/neo4j/neo4j-go-driver/internal/testing"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Unsupported Types [V1]", func() {
+	const (
+		WGS84SrId int = 4326
+		WGS843DSrId int = 4979
+		CartesianSrId int = 7203
+		Cartesian3DSrId int = 9157
+	)
+
+	var (
+		err     error
+		driver  Driver
+		session *Session
+		result  *Result
+	)
+
+	BeforeEach(func() {
+		driver, err = NewDriver(singleInstanceUri, BasicAuth(username, password, ""))
+		Expect(err).To(BeNil())
+		Expect(driver).NotTo(BeNil())
+
+		if VersionOfDriver(driver).GreaterThanOrEqual(V3_4_0) {
+			Skip("this test is targeted for server version less than neo4j 3.4.0")
+		}
+
+		session, err = driver.Session(AccessModeWrite)
+		Expect(err).To(BeNil())
+		Expect(session).NotTo(BeNil())
+	})
+
+	AfterEach(func() {
+		if session != nil {
+			session.Close()
+		}
+
+		if driver != nil {
+			driver.Close()
+		}
+	})
+
+	testSend := func(data interface{}) {
+		result, err = session.Run("WITH $x RETURN 1", &map[string]interface{}{"x": data})
+		Expect(err).To(drivertest.BeConnectorErrorWithCode(0x501))
+		Expect(err).To(drivertest.BeConnectorErrorWithDescription("unable to generate RUN message"))
+	}
+
+	Context("Send", func() {
+		It("should fail sending Point (2D)", func() {
+			testSend(NewPoint(WGS84SrId, 1.0, 1.0))
+		})
+
+		It("should fail sending Point (3D)", func() {
+			testSend(NewPoint3D(WGS843DSrId, 1.0, 1.0, 1.0))
+		})
+
+		It("should fail sending Duration", func() {
+			testSend(DurationOf(1, 1, 1, 1))
+		})
+
+		It("should fail sending Date", func() {
+			testSend(DateOf(time.Now()))
+		})
+
+		It("should fail sending LocalDateTime", func() {
+			testSend(LocalDateTimeOf(time.Now()))
+		})
+
+		It("should fail sending LocalTime", func() {
+			testSend(LocalTimeOf(time.Now()))
+		})
+
+		It("should fail sending OffsetTime", func() {
+			testSend(OffsetTimeOf(time.Now()))
+		})
+
+		It("should fail sending DateTime with Offset", func() {
+			testSend(time.Now().In(time.FixedZone("Offset", 2400)))
+		})
+
+		It("should fail sending DateTime with Zone", func() {
+			testSend(time.Now().In(time.Local))
+		})
+	})
+})

--- a/internal/testing/omega_error_matchers.go
+++ b/internal/testing/omega_error_matchers.go
@@ -65,6 +65,24 @@ func BePoolFullError() types.GomegaMatcher {
 	}
 }
 
+func BeConnectorErrorWithState(state uint32) types.GomegaMatcher {
+	return &connectorErrorMatcher{
+		stateMatcher: gomega.BeNumerically("==", state),
+	}
+}
+
+func BeConnectorErrorWithCode(code uint32) types.GomegaMatcher {
+	return &connectorErrorMatcher{
+		codeMatcher: gomega.BeNumerically("==", code),
+	}
+}
+
+func BeConnectorErrorWithDescription(description string) types.GomegaMatcher {
+	return &connectorErrorMatcher{
+		descriptionMatcher: gomega.ContainSubstring(description),
+	}
+}
+
 func BeAuthenticationError() types.GomegaMatcher {
 	return &connectorErrorMatcher{
 		stateMatcher: gomega.BeEquivalentTo(4),
@@ -95,6 +113,7 @@ type poolErrorMatcher struct {
 type connectorErrorMatcher struct {
 	stateMatcher types.GomegaMatcher
 	codeMatcher  types.GomegaMatcher
+	descriptionMatcher types.GomegaMatcher
 }
 
 func (matcher *databaseErrorMatcher) Match(actual interface{}) (success bool, err error) {
@@ -228,6 +247,10 @@ func (matcher *connectorErrorMatcher) Match(actual interface{}) (success bool, e
 		return matcher.codeMatcher.Match(connectorError.Code())
 	}
 
+	if matcher.descriptionMatcher != nil {
+		return matcher.descriptionMatcher.Match(connectorError.Description())
+	}
+
 	return true, nil
 }
 
@@ -245,6 +268,10 @@ func (matcher *connectorErrorMatcher) FailureMessage(actual interface{}) (messag
 		return fmt.Sprintf("Expected\n\t%#v\nto have its code to match %s", actual, matcher.codeMatcher.FailureMessage(connectorError.Code()))
 	}
 
+	if matcher.descriptionMatcher != nil {
+		return fmt.Sprintf("Expected\n\t%#v\nto have its description to match %s", actual, matcher.descriptionMatcher.FailureMessage(connectorError.Description()))
+	}
+
 	return fmt.Sprintf("Unexpected condition in matcher")
 }
 
@@ -260,6 +287,10 @@ func (matcher *connectorErrorMatcher) NegatedFailureMessage(actual interface{}) 
 
 	if matcher.codeMatcher != nil {
 		return fmt.Sprintf("Expected\n\t%#v\nnot to have its code to match %s", actual, matcher.codeMatcher.FailureMessage(connectorError.Code()))
+	}
+
+	if matcher.descriptionMatcher != nil {
+		return fmt.Sprintf("Expected\n\t%#v\nnot to have its description to match %s", actual, matcher.descriptionMatcher.FailureMessage(connectorError.Description()))
 	}
 
 	return fmt.Sprintf("Unexpected condition in matcher")


### PR DESCRIPTION
This PR adds tests that verifies Bolt V1 generates errors when unsupported types are being sent over.