### PR TITLE
Initial routing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,65 @@ The mapping between Cypher types and the types used by this driver (to represent
 | Float| float |
 | String| string |
 | ByteArray| []byte |
-| Node| Node |
-| Relationship| Relationship |
-| Path| _not supported yet_ |
+| Node| neo4j.Node |
+| Relationship| neo4j.Relationship |
+| Path| neo4j.Path |
 
+#### Spatial Types - Point
+
+| Cypher Type | Driver Type
+| ---: | :--- |
+| Point| neo4j.Point |
+
+The temporal types are introduced in Neo4j 3.4 series.
+
+You can create a 2-dimensional `Point` value using;
+
+```go
+point := NewPoint(srId, 1.0, 2.0)
+```
+
+or a 3-dimensional `Point` value using;
+
+```go
+point := NewPoint3D(srId, 1.0, 2.0, 3.0)
+```
+
+NOTE:
+* For a list of supported `srId` values, please refer to the docs [here](https://neo4j.com/docs/developer-manual/current/cypher/functions/spatial/).
+
+#### Temporal Types - Date and Time
+
+The temporal types are introduced in Neo4j 3.4 series. Given the fact that database supports a range of different temporal types, most of them are backed by custom types defined at the driver level.
+
+The mapping among the Cypher temporal types and actual exposed types are as follows:
+
+| Cypher Type | Driver Type |
+| :----------: | :-----------: |
+| Date | neo4j.Date | 
+| Time | neo4j.OffsetTime |
+| LocalTime| neo4j.LocalTime |
+| DateTime | time.Time |
+| LocalDateTime | neo4j.LocalDateTime |
+| Duration | neo4j.Duration |
+
+
+Receiving a temporal value as driver type:
+```go
+dateValue := record.GetByIndex(0).(neo4j.Date)
+```
+
+All custom temporal types can be constructing from a `time.Time` value using `<Type>Of()` (`DateOf`, `OffsetTimeOf`, ...) functions.
+
+```go
+dateValue := DateOf(time.Date(2005, time.December, 16, 0, 0, 0, 0, time.Local)`
+```
+
+Converting a custom temporal value into `time.Time` (all `neo4j` temporal types expose `Time()` function to gets its corresponding `time.Time` value):
+```go
+dateValueAsTime := dateValue.Time()
+```
+
+Note:
+* When `neo4j.OffsetTime` is converted into `time.Time` or constructed through `OffsetTimeOf(time.Time)`, its `Location` is given a fixed name of `Offset` (i.e. assigned `time.FixedZone("Offset", offsetTime.offset)`).
+* When `time.Time` values are sent/received through the driver, if its `Zone()` returns a name of `Offset` the value is stored with its offset value and with its zone name otherwise.

--- a/driver.go
+++ b/driver.go
@@ -57,6 +57,14 @@ func NewDriver(target string, auth AuthToken, configurers ...func(*Config)) (Dri
 		return nil, err
 	}
 
+	if parsed.Scheme != "bolt" && parsed.Scheme != "bolt+routing" {
+		return nil, fmt.Errorf("url scheme %s is not supported", parsed.Scheme)
+	}
+
+	if parsed.Scheme == "bolt" && len(parsed.RawQuery) > 0 {
+		return nil, fmt.Errorf("routing context is not supported for direct driver")
+	}
+
 	config := defaultConfig()
 	for _, configurer := range configurers {
 		configurer(config)
@@ -66,9 +74,5 @@ func NewDriver(target string, auth AuthToken, configurers ...func(*Config)) (Dri
 		return nil, err
 	}
 
-	if parsed.Scheme == "bolt" {
-		return newDirectDriver(parsed, auth, config)
-	}
-
-	return nil, fmt.Errorf("URL scheme %s is not supported", parsed.Scheme)
+	return newSeaboltDriver(parsed, auth, config)
 }

--- a/integration-tests/causal_clustering_test.go
+++ b/integration-tests/causal_clustering_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration_tests
+
+import (
+	"github.com/neo4j/neo4j-go-driver"
+	"github.com/neo4j/neo4j-go-driver/integration-tests/control"
+	"github.com/neo4j/neo4j-go-driver/internal/testing"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Causal Clustering", func() {
+	var cluster *control.Cluster
+
+	var driver neo4j.Driver
+	var session *neo4j.Session
+	var result *neo4j.Result
+	var summary *neo4j.ResultSummary
+	var err error
+
+	BeforeEach(func() {
+		cluster, err = control.EnsureCluster()
+		Expect(err).To(BeNil())
+		Expect(cluster).NotTo(BeNil())
+	})
+
+	testReadAndWriteOnSameSession := func(member *control.ClusterMember, name string) {
+		Expect(member).NotTo(BeNil())
+
+		driver, err = neo4j.NewDriver(member.RoutingUri(), cluster.AuthToken(), cluster.Config())
+		Expect(err).To(BeNil())
+
+		session, err = driver.Session(neo4j.AccessModeWrite)
+		Expect(err).To(BeNil())
+
+		result, err = session.Run("CREATE (n:Person {name: $name})", &map[string]interface{}{"name": name})
+		Expect(err).To(BeNil())
+
+		summary, err = result.Consume()
+		Expect(err).To(BeNil())
+		Expect(summary).NotTo(BeNil())
+
+		result, err = session.Run("MATCH (n:Person {name: $name}) RETURN COUNT(*) AS count", &map[string]interface{}{"name": name})
+		Expect(err).To(BeNil())
+
+		if result.Next() {
+			Expect(result.Record().GetByIndex(0)).To(BeNumerically("==", 1))
+		}
+		Expect(result.Err()).To(BeNil())
+	}
+
+	Context("Discovery", func() {
+		Specify("should successfully execute read/write when initial address points to leader", func() {
+			testReadAndWriteOnSameSession(cluster.Leader(), "Jane")
+		})
+
+		Specify("should successfully execute read/write when initial address points to follower", func() {
+			testReadAndWriteOnSameSession(cluster.AnyFollower(), "Jack")
+		})
+
+		Specify("should fail if initial address points to read-replica", func() {
+			readReplica := cluster.AnyReadReplica()
+			Expect(readReplica).NotTo(BeNil())
+
+			driver, err = neo4j.NewDriver(readReplica.RoutingUri(), cluster.AuthToken(), cluster.Config())
+			Expect(err).To(BeNil())
+
+			session, err = driver.Session(neo4j.AccessModeRead)
+			Expect(err).To(BeNil())
+
+			result, err = session.Run("RETURN 1", nil)
+			Expect(err).To(drivertest.BeConnectorErrorWithCode(0x800))
+		})
+	})
+
+	Context("Routing", func() {
+		Specify("writes should be visible on followers", func() {
+			var readCount, writeCount interface{}
+
+			leader := cluster.Leader()
+			Expect(leader).NotTo(BeNil())
+
+			driver, err = neo4j.NewDriver(leader.RoutingUri(), cluster.AuthToken(), cluster.Config())
+			Expect(err).To(BeNil())
+
+			session, err = driver.Session(neo4j.AccessModeWrite)
+			Expect(err).To(BeNil())
+
+			writeCount, err = session.WriteTransaction(func(tx *neo4j.Transaction) (interface{}, error) {
+				writeResult, err := tx.Run("MERGE (n:Person {name: 'John'}) RETURN 1", nil)
+				if err != nil {
+					return nil, err
+				}
+
+				if writeResult.Next() {
+					return writeResult.Record().GetByIndex(0), nil
+				}
+
+				if err := writeResult.Err(); err != nil {
+					return nil, err
+				}
+
+				return 0, nil
+			})
+			Expect(err).To(BeNil())
+			Expect(writeCount).To(BeNumerically("==", 1))
+
+			readCount, err = session.ReadTransaction(func(tx *neo4j.Transaction) (interface{}, error) {
+				readResult, err := tx.Run("MATCH (n:Person {name: 'John'}) RETURN COUNT(*) AS count", nil)
+				if err != nil {
+					return nil, err
+				}
+
+				if readResult.Next() {
+					return readResult.Record().GetByIndex(0), nil
+				}
+
+				if err := readResult.Err(); err != nil {
+					return nil, err
+				}
+
+				return 0, nil
+			})
+			Expect(err).To(BeNil())
+			Expect(readCount).To(BeNumerically("==", 1))
+		})
+
+	})
+
+})

--- a/integration-tests/control/causal-cluster-controller.go
+++ b/integration-tests/control/causal-cluster-controller.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package control
+
+import "strconv"
+
+func installCluster(version string, cores int, readReplicas int, password string, port int, path string) error {
+	_, err := executeCommand("neoctrl-cluster", "install",
+		"--cores", strconv.Itoa(cores),
+		"--read-replicas", strconv.Itoa(readReplicas),
+		"--password", password,
+		"--initial-port", strconv.Itoa(port),
+		version,
+		path)
+
+	return err
+}
+
+func startCluster(path string) (string, error) {
+	return executeCommand("neoctrl-cluster", "start", path)
+}
+
+func startClusterMember(path string) (string, error) {
+	return executeCommand("neoctrl-start", path)
+}
+
+func stopCluster(path string) error {
+	_, err := executeCommand("neoctrl-cluster", "stop", path)
+	return err
+}
+
+func stopClusterMember(path string) error {
+	_, err := executeCommand("neoctrl-stop", path)
+	return err
+}
+
+func killCluster(path string) error {
+	_, err := executeCommand("neoctrl-cluster", "stop", "--kill", path)
+	return err
+}
+
+func killClusterMember(path string) error {
+	_, err := executeCommand("neoctrl-stop", "--kill", path)
+	return err
+}

--- a/integration-tests/control/causal-cluster.go
+++ b/integration-tests/control/causal-cluster.go
@@ -1,0 +1,457 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package control
+
+import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver"
+)
+
+type ClusterMemberRole string
+
+const (
+	LEADER       ClusterMemberRole = "LEADER"
+	FOLLOWER     ClusterMemberRole = "FOLLOWER"
+	READ_REPLICA ClusterMemberRole = "READ_REPLICA"
+)
+
+type configFunc func(config *neo4j.Config)
+
+type ClusterMember struct {
+	path            string
+	hostnameAndPort string
+	boltUri         string
+	routingUri      string
+}
+
+type Cluster struct {
+	path           string
+	authToken      neo4j.AuthToken
+	config         configFunc
+	members        []*ClusterMember
+	offlineMembers []*ClusterMember
+	drivers        clusterDrivers
+}
+
+type clusterDrivers struct {
+	driverMap sync.Map
+	authToken neo4j.AuthToken
+	config    configFunc
+}
+
+const (
+	clusterStartupTimeout = 120 * time.Second
+	clusterCheckInterval  = 500 * time.Millisecond
+)
+
+var lock sync.Mutex
+var cluster *Cluster
+var clusterErr error
+
+func EnsureCluster() (*Cluster, error) {
+	if cluster == nil && clusterErr == nil {
+		lock.Lock()
+		defer lock.Unlock()
+		if cluster == nil {
+			var clusterPath string = os.TempDir()
+
+			if _, file, _, ok := runtime.Caller(1); ok {
+				clusterPath = path.Join(path.Dir(file), "build")
+			}
+
+			cluster, clusterErr = newCluster(clusterPath)
+		}
+	}
+
+	return cluster, clusterErr
+}
+
+func StopCluster() {
+	if cluster != nil {
+		lock.Lock()
+		defer lock.Unlock()
+
+		stopCluster(cluster.path)
+	}
+}
+
+func newCluster(path string) (*Cluster, error) {
+	var output string
+	var err error
+	var clusterMember *ClusterMember
+	var clusterMembers []*ClusterMember
+
+	if _, err = os.Stat(path); os.IsNotExist(err) {
+		// there isn't any cluster installation
+		if err = installCluster(neo4jVersionToTestAgainst(), 3, 2, "password", 20000, path); err != nil {
+			return nil, err
+		}
+	}
+
+	if output, err = startCluster(path); err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		paramsScanner := bufio.NewScanner(strings.NewReader(scanner.Text()))
+		paramsScanner.Split(bufio.ScanWords)
+
+		index := 0
+		memberBoltUri := ""
+		memberPath := ""
+		for paramsScanner.Scan() {
+			switch index {
+			case 0:
+				break
+			case 1:
+				memberBoltUri = paramsScanner.Text()
+			case 2:
+				memberPath = paramsScanner.Text()
+			default:
+				memberPath = memberPath + " " + paramsScanner.Text()
+			}
+
+			index++
+		}
+		if err = paramsScanner.Err(); err != nil {
+			return nil, err
+		}
+
+		if clusterMember, err = newClusterMember(memberBoltUri, memberPath); err != nil {
+			return nil, err
+		}
+
+		clusterMembers = append(clusterMembers, clusterMember)
+	}
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	authToken := neo4j.BasicAuth("neo4j", "password", "")
+	config := func(config *neo4j.Config) {
+
+	}
+
+	result := &Cluster{
+		path:           path,
+		authToken:      authToken,
+		config:         config,
+		members:        clusterMembers,
+		offlineMembers: nil,
+		drivers: clusterDrivers{
+			driverMap: sync.Map{},
+			authToken: authToken,
+			config:    config,
+		},
+	}
+
+	if err = result.waitMembersToBeOnline(); err != nil {
+		return result, err
+	}
+
+	if err = result.deleteData(); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (cluster *Cluster) AuthToken() neo4j.AuthToken {
+	return cluster.authToken
+}
+
+func (cluster *Cluster) Config() func(config *neo4j.Config) {
+	return func(config *neo4j.Config) {
+		config.Log = neo4j.ConsoleLogger(neo4j.DEBUG)
+	}
+}
+
+func (cluster *Cluster) Leader() *ClusterMember {
+	var leaders, _ = cluster.membersWithRole(LEADER)
+	if len(leaders) > 0 {
+		return leaders[0]
+	}
+	return nil
+}
+
+func (cluster *Cluster) Cores() []*ClusterMember {
+	var cores []*ClusterMember
+
+	cores = append(cores, cluster.Leader())
+	cores = append(cores, cluster.Followers()...)
+
+	return cores
+}
+
+func (cluster *Cluster) Followers() []*ClusterMember {
+	filtered, _ := cluster.membersWithRole(FOLLOWER)
+	return filtered
+}
+
+func (cluster *Cluster) AnyFollower() *ClusterMember {
+	followers := cluster.Followers()
+	if len(followers) > 0 {
+		followerSelected := rand.Intn(len(followers))
+		return followers[followerSelected]
+	}
+	return nil
+}
+
+func (cluster *Cluster) ReadReplicas() []*ClusterMember {
+	filtered, _ := cluster.membersWithRole(READ_REPLICA)
+	return filtered
+}
+
+func (cluster *Cluster) AnyReadReplica() *ClusterMember {
+	readReplicas := cluster.ReadReplicas()
+	if len(readReplicas) > 0 {
+		readReplicaSelected := rand.Intn(len(readReplicas))
+		return readReplicas[readReplicaSelected]
+	}
+	return nil
+}
+
+func (cluster *Cluster) memberWithAddress(address string) *ClusterMember {
+	for _, member := range cluster.members {
+		if member.BoltUri() == address {
+			return member
+		}
+	}
+
+	return nil
+}
+
+func (cluster *Cluster) deleteData() error {
+	driver, err := cluster.driverToLeader()
+	if err != nil {
+		return err
+	}
+
+	session, err := driver.Session(neo4j.AccessModeWrite)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	for {
+		result, err := session.Run("MATCH (n) WITH n LIMIT 10000 DETACH DELETE n RETURN count(n)", nil)
+		if err != nil {
+			return err
+		}
+
+		if result.Next() {
+			deleted := result.Record().GetByIndex(0).(int64)
+			if deleted == 0 {
+				break
+			}
+		}
+
+		if err := result.Err(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (cluster *Cluster) waitMembersToBeOnline() error {
+	var err, lastErr error
+	var allMembers map[string]bool
+	var onlineMembers map[string]ClusterMemberRole
+
+	lastErr = nil
+	startTime := time.Now()
+	for time.Since(startTime) < clusterStartupTimeout {
+		allMembers = make(map[string]bool, len(cluster.members))
+		for _, member := range cluster.members {
+			allMembers[member.boltUri] = false
+		}
+
+		if onlineMembers, err = cluster.discoverOnlineMembers(); err != nil {
+			lastErr = err
+		} else {
+			for memberBoltAddress, _ := range onlineMembers {
+				delete(allMembers, memberBoltAddress)
+			}
+
+			if len(allMembers) == 0 {
+				return nil
+			}
+		}
+
+		time.Sleep(clusterCheckInterval)
+	}
+
+	return fmt.Errorf("timed out waiting for the cluster members to be online: %v", lastErr)
+}
+
+func (cluster *Cluster) membersWithRole(role ClusterMemberRole) ([]*ClusterMember, error) {
+	var err error
+	var onlineMembers map[string]ClusterMemberRole
+
+	if onlineMembers, err = cluster.discoverOnlineMembers(); err != nil {
+		return nil, err
+	}
+
+	var discoveredMembers []*ClusterMember
+	for memberBoltAddress, memberRole := range onlineMembers {
+		if memberRole == role {
+			member := cluster.memberWithAddress(memberBoltAddress)
+			if member != nil {
+				discoveredMembers = append(discoveredMembers, member)
+			} else {
+				return nil, fmt.Errorf("unable to locate member with address %s", memberBoltAddress)
+			}
+		}
+	}
+	return discoveredMembers, nil
+}
+
+func (cluster *Cluster) discoverOnlineMembers() (map[string]ClusterMemberRole, error) {
+	var discoveredMembers = make(map[string]ClusterMemberRole, 0)
+
+	driver, err := cluster.driverToAnyCore()
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := driver.Session(neo4j.AccessModeRead)
+	if err != nil {
+		return nil, err
+	}
+	defer session.Close()
+
+	result, err := session.Run("CALL dbms.cluster.overview()", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for result.Next() {
+		memberRole, _ := result.Record().Get("role")
+		memberAddresses, _ := result.Record().Get("addresses")
+		memberBoltAddress := memberAddresses.([]interface{})[0].(string)
+
+		discoveredMembers[memberBoltAddress] = ClusterMemberRole(memberRole.(string))
+	}
+
+	return discoveredMembers, nil
+}
+
+func (cluster *Cluster) driverToLeader() (neo4j.Driver, error) {
+	return cluster.drivers.driverFor(cluster.Leader())
+}
+
+func (cluster *Cluster) driverToAnyCore() (neo4j.Driver, error) {
+	if len(cluster.members) == 0 {
+		return nil, fmt.Errorf("there are no members present in the cluster")
+	}
+
+	for _, member := range cluster.members {
+		driver, err := cluster.drivers.driverFor(member)
+		if err != nil {
+			continue
+		}
+
+		session, err := driver.Session(neo4j.AccessModeRead)
+		if err != nil {
+			continue
+		}
+
+		result, err := session.Run("CALL dbms.cluster.role()", nil)
+		if err != nil {
+			continue
+		}
+		defer session.Close()
+
+		if result.Next() {
+			role, _ := result.Record().Get("role")
+			if role.(string) != string(READ_REPLICA) {
+				return driver, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("unable to get a driver to a core")
+}
+
+func (drivers *clusterDrivers) driverFor(member *ClusterMember) (neo4j.Driver, error) {
+	if stored, ok := drivers.driverMap.Load(member.hostnameAndPort); ok {
+		return stored.(neo4j.Driver), nil
+	}
+
+	driver, err := neo4j.NewDriver(member.BoltUri(), drivers.authToken, drivers.config)
+	if err != nil {
+		return nil, err
+	}
+
+	if stored, loaded := drivers.driverMap.LoadOrStore(member.hostnameAndPort, driver); loaded {
+		driver.Close()
+
+		return stored.(neo4j.Driver), nil
+	}
+
+	return driver, nil
+}
+
+func (member *ClusterMember) Path() string {
+	return member.path
+}
+
+func (member *ClusterMember) BoltUri() string {
+	return member.boltUri
+}
+
+func (member *ClusterMember) RoutingUri() string {
+	return member.routingUri
+}
+
+func (member *ClusterMember) String() string {
+	return fmt.Sprintf("ClusterMember{boltUri=%s, boltAddress=%s, path=%s}", member.boltUri, member.hostnameAndPort, member.path)
+}
+
+func newClusterMember(uri string, path string) (*ClusterMember, error) {
+	parsedUri, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	port := parsedUri.Port()
+	if port == "" {
+		port = "7687"
+	}
+
+	return &ClusterMember{
+		path:            path,
+		hostnameAndPort: fmt.Sprintf("%s:%s", parsedUri.Hostname(), port),
+		boltUri:         fmt.Sprintf("bolt://%s:%s", parsedUri.Hostname(), port),
+		routingUri:      fmt.Sprintf("bolt+routing://%s:%s", parsedUri.Hostname(), port),
+	}, nil
+}

--- a/integration-tests/control/controller.go
+++ b/integration-tests/control/controller.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package control
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func neo4jVersionAndEditionToTestAgainst() string {
+	if val, ok := os.LookupEnv("NEOCTRLARGS"); ok {
+		return val
+	}
+
+	return "-e 3.4.6"
+}
+
+func neo4jVersionToTestAgainst() string {
+	if val, ok := os.LookupEnv("NEOCTRLARGS"); ok {
+		return strings.TrimSpace(strings.Replace(val, "-e", "", -1))
+	}
+
+	return "3.4.6"
+}
+
+func neo4jEditionToTestAgainst() string {
+	if val, ok := os.LookupEnv("NEOCTRLARGS"); ok {
+		if strings.Index(val, "-e") < 0 {
+			return ""
+		}
+	}
+
+	return "-e"
+}
+
+func executeCommand(command string, arguments ...string) (string, error) {
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	cmd := exec.Command(command, arguments...)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("command execution (program: %s, arguments: %v) failed with error %s", command, arguments, stderrBuf.String())
+	}
+
+	return stdoutBuf.String(), nil
+}

--- a/integration-tests/control/single-instance.go
+++ b/integration-tests/control/single-instance.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package control

--- a/integration-tests/driver_test.go
+++ b/integration-tests/driver_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Driver", func() {
 			Expect(err).To(BeNil())
 
 			_, err = session3.Run("UNWIND RANGE(1, 100) AS N RETURN N", nil)
-			Expect(err).To(BePoolFullError())
+			Expect(err).To(BeConnectorErrorWithCode(0x600))
 		})
 	})
 

--- a/integration-tests/it_test.go
+++ b/integration-tests/it_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	. "github.com/neo4j/neo4j-go-driver"
+	"github.com/neo4j/neo4j-go-driver/integration-tests/control"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -64,4 +65,8 @@ var _ = BeforeSuite(func() {
 
 	_, err = result.Consume()
 	Expect(err).To(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	control.StopCluster()
 })

--- a/internal/mocking/factory.go
+++ b/internal/mocking/factory.go
@@ -22,34 +22,20 @@ package mocking
 import "github.com/neo4j-drivers/neo4j-go-connector"
 
 type mockConnector struct {
-	pool *mockPool
-}
-
-type mockPool struct {
 	connection *MockConnection
 }
 
-func (connector *mockConnector) GetPool() (seabolt.Pool, error) {
-	return connector.pool, nil
+func (connector *mockConnector) Acquire(mode seabolt.AccessMode) (seabolt.Connection, error) {
+	return connector.connection, nil
 }
 
 func (connector *mockConnector) Close() error {
-	return connector.pool.Close()
-}
-
-func (pool *mockPool) Acquire() (seabolt.Connection, error) {
-	return pool.connection, nil
-}
-
-func (pool *mockPool) Close() error {
-	return pool.connection.Close()
+	return connector.connection.Close()
 }
 
 // MockedConnector returns a mocked connector with the provided mocked connection
 func MockedConnector(connection *MockConnection) seabolt.Connector {
 	return &mockConnector{
-		pool: &mockPool{
-			connection: connection,
-		},
+		connection: connection,
 	}
 }

--- a/internal/mocking/mock_connector.go
+++ b/internal/mocking/mock_connector.go
@@ -67,14 +67,14 @@ func (mr *MockConnectorMockRecorder) Close() *gomock.Call {
 }
 
 // GetPool connector-mocks base method
-func (m *MockConnector) GetPool() (seabolt.Pool, error) {
-	ret := m.ctrl.Call(m, "GetPool")
-	ret0, _ := ret[0].(seabolt.Pool)
+func (m *MockConnector) Acquire(arg0 seabolt.AccessMode) (seabolt.Connection, error) {
+	ret := m.ctrl.Call(m, "Acquire", arg0)
+	ret0, _ := ret[0].(seabolt.Connection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPool indicates an expected call of GetPool
-func (mr *MockConnectorMockRecorder) GetPool() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPool", reflect.TypeOf((*MockConnector)(nil).GetPool))
+func (mr *MockConnectorMockRecorder) Acquire(arg0 seabolt.AccessMode) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Acquire", reflect.TypeOf((*MockConnector)(nil).Acquire), arg0)
 }

--- a/internal/testing/omega_error_matchers.go
+++ b/internal/testing/omega_error_matchers.go
@@ -58,13 +58,6 @@ func BeServiceUnavailableError() types.GomegaMatcher {
 	return &serviceUnavailableErrorMatcher{}
 }
 
-func BePoolFullError() types.GomegaMatcher {
-	return &poolErrorMatcher{
-		expected: 1,
-		expectedText: "Pool full",
-	}
-}
-
 func BeConnectorErrorWithState(state uint32) types.GomegaMatcher {
 	return &connectorErrorMatcher{
 		stateMatcher: gomega.BeNumerically("==", state),
@@ -103,11 +96,6 @@ type databaseErrorMatcher struct {
 }
 
 type serviceUnavailableErrorMatcher struct {
-}
-
-type poolErrorMatcher struct {
-	expected uint32
-	expectedText string
 }
 
 type connectorErrorMatcher struct {
@@ -204,33 +192,6 @@ func (matcher *serviceUnavailableErrorMatcher) NegatedFailureMessage(actual inte
 	}
 
 	return fmt.Sprintf("Expected\n\t%#v\nnot to be a ServiceUnavailableError", actual)
-}
-
-func (matcher *poolErrorMatcher) Match(actual interface{}) (success bool, err error) {
-	poolError, ok := actual.(*seabolt.PoolError)
-	if !ok {
-		return false, nil
-	}
-
-	return poolError.Code() == matcher.expected, nil
-}
-
-func (matcher *poolErrorMatcher) FailureMessage(actual interface{}) (message string) {
-	_, ok := actual.(*seabolt.PoolError)
-	if !ok {
-		return fmt.Sprintf("Expected\n\t%#v\nto be a pool error", actual)
-	}
-
-	return fmt.Sprintf("Expected\n\t%#v\nto be a pool error with code: %d (%s)", actual, matcher.expected, matcher.expectedText)
-}
-
-func (matcher *poolErrorMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	_, ok := actual.(*seabolt.PoolError)
-	if !ok {
-		return fmt.Sprintf("Expected\n\t%#v\nnot to be a pool error", actual)
-	}
-
-	return fmt.Sprintf("Expected\n\t%#v\nnot to be a pool error with code: %d (%s)", actual, matcher.expected, matcher.expectedText)
 }
 
 func (matcher *connectorErrorMatcher) Match(actual interface{}) (success bool, err error) {

--- a/logging_impl.go
+++ b/logging_impl.go
@@ -56,10 +56,10 @@ func NoOpLogger() Logging {
 func ConsoleLogger(level LogLevel) Logging {
 	return &internalLogger{
 		level:         level,
-		errorLogger:   log.New(os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Lmicroseconds),
+		errorLogger:   log.New(os.Stderr, "ERROR  : ", log.Ldate|log.Ltime|log.Lmicroseconds),
 		warningLogger: log.New(os.Stdout, "WARNING: ", log.Ldate|log.Ltime|log.Lmicroseconds),
-		infoLogger:    log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lmicroseconds),
-		debugLogger:   log.New(os.Stdout, "DEBUG: ", log.Ldate|log.Ltime|log.Lmicroseconds),
+		infoLogger:    log.New(os.Stdout, "INFO   : ", log.Ldate|log.Ltime|log.Lmicroseconds),
+		debugLogger:   log.New(os.Stdout, "DEBUG  : ", log.Ldate|log.Ltime|log.Lmicroseconds),
 	}
 }
 

--- a/runner.go
+++ b/runner.go
@@ -90,7 +90,7 @@ func handleRunPhase(runner *statementRunner, activeResult *Result) error {
 			return err
 		}
 
-		if received != seabolt.METADATA {
+		if received != seabolt.FetchTypeMetadata {
 			return errors.New("unexpected response received while waiting for a METADATA")
 		}
 
@@ -120,7 +120,7 @@ func handleRecordsPhase(runner *statementRunner, activeResult *Result) error {
 		}
 
 		switch received {
-		case seabolt.METADATA:
+		case seabolt.FetchTypeMetadata:
 			metadata, err := runner.connection.Metadata()
 			if err != nil {
 				return err
@@ -128,14 +128,14 @@ func handleRecordsPhase(runner *statementRunner, activeResult *Result) error {
 
 			activeResult.collectMetadata(metadata)
 			activeResult.resultCompleted = true
-		case seabolt.RECORD:
+		case seabolt.FetchTypeRecord:
 			fields, err := runner.connection.Data()
 			if err != nil {
 				return err
 			}
 
 			activeResult.collectRecord(fields)
-		case seabolt.ERROR:
+		case seabolt.FetchTypeError:
 			return errors.New("unable to fetch from connection")
 		}
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Runner", func() {
 		It("should invoke run on connection", func() {
 			mockConnection := mocking.NewMockConnection(mockCtrl)
 			mockConnector := mocking.MockedConnector(mockConnection)
-			mockDriver := newDirectWithConnector("bolt://localhost", mockConnector)
+			mockDriver := newSeaboltWithConnector("bolt://localhost", mockConnector)
 			runner := newRunner(mockDriver, AccessModeWrite, true)
 
 			gomock.InOrder(

--- a/seabolt_driver_test.go
+++ b/seabolt_driver_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/neo4j-drivers/neo4j-go-connector"
 )
 
-func newDirectWithConnector(target string, connector seabolt.Connector) Driver {
+func newSeaboltWithConnector(target string, connector seabolt.Connector) Driver {
 	targetURL, err := url.Parse(target)
 	if err != nil {
 		return nil
 	}
 
-	return &directDriver{
+	return &seaboltDriver{
 		target:    *targetURL,
 		connector: connector,
 		open:      1,

--- a/seabolt_stub_test.go
+++ b/seabolt_stub_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/neo4j/neo4j-go-driver/internal/testing"
 )
 
-var _ = Describe("Direct Driver", func() {
+var _ = Describe("Seabolt Driver", func() {
 	Context("with Stub Server", func() {
 		type TestCase struct {
 			script   string
@@ -55,7 +55,7 @@ var _ = Describe("Direct Driver", func() {
 })
 
 func consumeShouldFailOnServerDisconnects() {
-	driver := createDirectDriver()
+	driver := createSeaboltDriver()
 	defer driver.Close()
 
 	session := createSession(driver)
@@ -71,7 +71,7 @@ func consumeShouldFailOnServerDisconnects() {
 }
 
 func shouldExecuteReturn1() {
-	driver := createDirectDriver()
+	driver := createSeaboltDriver()
 	defer driver.Close()
 
 	session := createSession(driver)
@@ -91,7 +91,7 @@ func shouldExecuteReturn1() {
 	Expect(count).To(BeIdenticalTo(int64(1)))
 }
 
-func createDirectDriver() Driver {
+func createSeaboltDriver() Driver {
 	driver, err := NewDriver("bolt://localhost:9001", NoAuth(), func(config *Config) {
 		config.Encrypted = false
 		config.Log = ConsoleLogger(DEBUG)

--- a/session.go
+++ b/session.go
@@ -161,7 +161,13 @@ func beginTransactionInternal(session *Session, mode AccessMode) (*Transaction, 
 		return nil, err
 	}
 
-	beginResult, err := session.runner.beginTransaction(session.bookmarks)
+	var computedBookmarks []string
+	computedBookmarks = append(computedBookmarks, session.bookmarks...)
+	if session.lastBookmark != "" {
+		computedBookmarks = append(computedBookmarks, session.lastBookmark)
+	}
+
+	beginResult, err := session.runner.beginTransaction(computedBookmarks)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR mostly includes changes to make use of latest `neo4j-go-connector` and `seabolt` changes (which are mostly related to `bolt+routing` scheme), and also makes driver level defined logger to be used across all layers.