### PR TITLE
Rename function NewPoint

### DIFF
--- a/neo4j/error.go
+++ b/neo4j/error.go
@@ -24,5 +24,5 @@ import (
 )
 
 func isRetriableError(err error) bool {
-	return gobolt.IsServiceUnavailable(err) || gobolt.IsTransientError(err)
+	return gobolt.IsServiceUnavailable(err) || gobolt.IsTransientError(err) || gobolt.IsWriteError(err)
 }

--- a/neo4j/integration-tests/values_spatial_test.go
+++ b/neo4j/integration-tests/values_spatial_test.go
@@ -134,11 +134,11 @@ var _ = Describe("Spatial Types", func() {
 
 		switch sequence % 4 {
 		case 0:
-			return NewPoint(WGS84SrId, randomDouble(), randomDouble())
+			return NewPoint2D(WGS84SrId, randomDouble(), randomDouble())
 		case 1:
 			return NewPoint3D(WGS843DSrId, randomDouble(), randomDouble(), randomDouble())
 		case 2:
-			return NewPoint(CartesianSrId, randomDouble(), randomDouble())
+			return NewPoint2D(CartesianSrId, randomDouble(), randomDouble())
 		case 3:
 			return NewPoint3D(Cartesian3DSrId, randomDouble(), randomDouble(), randomDouble())
 		default:
@@ -179,7 +179,7 @@ var _ = Describe("Spatial Types", func() {
 	})
 
 	It("should be able to send points", func() {
-		point1 := NewPoint(WGS84SrId, 51.5044585, -0.105658)
+		point1 := NewPoint2D(WGS84SrId, 51.5044585, -0.105658)
 		point2 := NewPoint3D(WGS843DSrId, 51.5044585, -0.105658, 35.120)
 
 		result, err = session.Run("CREATE (n:POI { location1: $point1, location2: $point2 }) RETURN n", &map[string]interface{}{
@@ -210,7 +210,7 @@ var _ = Describe("Spatial Types", func() {
 	})
 
 	It("should be able to send points - pass by value", func() {
-		point1 := NewPoint(WGS84SrId, 51.5044585, -0.105658)
+		point1 := NewPoint2D(WGS84SrId, 51.5044585, -0.105658)
 		point2 := NewPoint3D(WGS843DSrId, 51.5044585, -0.105658, 35.120)
 
 		result, err = session.Run("CREATE (n:POI { location1: $point1, location2: $point2 }) RETURN n", &map[string]interface{}{
@@ -241,9 +241,9 @@ var _ = Describe("Spatial Types", func() {
 	})
 
 	It("should send and receive point", func() {
-		testSendAndReceive(NewPoint(WGS84SrId, 51.24923585, 0.92723724))
+		testSendAndReceive(NewPoint2D(WGS84SrId, 51.24923585, 0.92723724))
 		testSendAndReceive(NewPoint3D(WGS843DSrId, 22.86211019, 171.61820439, 0.1230987))
-		testSendAndReceive(NewPoint(CartesianSrId, 39.111748, -76.775635))
+		testSendAndReceive(NewPoint2D(CartesianSrId, 39.111748, -76.775635))
 		testSendAndReceive(NewPoint3D(Cartesian3DSrId, 39.111748, -76.775635, 19.2937302840))
 	})
 

--- a/neo4j/integration-tests/values_unsupported_test.go
+++ b/neo4j/integration-tests/values_unsupported_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Unsupported Types [V1]", func() {
 
 	Context("Send", func() {
 		It("should fail sending Point (2D)", func() {
-			testSend(NewPoint(WGS84SrId, 1.0, 1.0))
+			testSend(NewPoint2D(WGS84SrId, 1.0, 1.0))
 		})
 
 		It("should fail sending Point (3D)", func() {

--- a/neo4j/values_spatial.go
+++ b/neo4j/values_spatial.go
@@ -32,7 +32,7 @@ type Point struct {
 	z         float64
 }
 
-func NewPoint(srId int, x float64, y float64) *Point {
+func NewPoint2D(srId int, x float64, y float64) *Point {
 	return &Point{
 		dimension: 2,
 		srId:      srId,

--- a/neo4j/values_spatial_test.go
+++ b/neo4j/values_spatial_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Spatial Types", func() {
 
 	Context("Point", func() {
 		When("constructed with 2 coordinates", func() {
-			point := NewPoint(1, 1.0, 2.0)
+			point := NewPoint2D(1, 1.0, 2.0)
 
 			It("should have a dimension of 2", func() {
 				Expect(point.dimension).To(Equal(2))


### PR DESCRIPTION
This PR renames function `NewPoint` to `NewPoint2D` for consistency with the other option named `NewPoint3D`.

Based on #14.