### PR TITLE
Avoid large values during random duration generation

### DIFF
--- a/neo4j/test-integration/values_temporal_test.go
+++ b/neo4j/test-integration/values_temporal_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"math"
 	"math/rand"
 	"time"
 
@@ -77,9 +78,9 @@ var _ = Describe("Temporal Types", func() {
 		}
 
 		return DurationOf(
-			sign*rand.Int63(),
-			sign*rand.Int63(),
-			sign*rand.Int63(),
+			sign*rand.Int63n(math.MaxInt32),
+			sign*rand.Int63n(math.MaxInt32),
+			sign*rand.Int63n(math.MaxInt32),
 			rand.Intn(1000000000))
 	}
 


### PR DESCRIPTION
Large values generated for duration fields can cause overflow errors on the server side. This PR makes random value generation to pick values across `0 < n < max.MaxInt32`.