### PR TITLE
Add TLS related configuration options

### DIFF
--- a/neo4j/config.go
+++ b/neo4j/config.go
@@ -28,6 +28,9 @@ import (
 type Config struct {
 	// Whether to turn on/off TLS encryption (default: true)
 	Encrypted bool
+	// Sets how the driver establishes trust with the Neo4j instance
+	// it is connected to.
+	TrustStrategy TrustStrategy
 	// Logging target the driver will send its log outputs
 	Log Logging
 	// Resolver that would be used to resolve initial router address. This may
@@ -44,6 +47,7 @@ type Config struct {
 func defaultConfig() *Config {
 	return &Config{
 		Encrypted:                   true,
+		TrustStrategy:               TrustAny(false),
 		Log:                         NoOpLogger(),
 		AddressResolver:             nil,
 		MaxTransactionRetryDuration: 30 * time.Second,

--- a/neo4j/config_trust.go
+++ b/neo4j/config_trust.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package neo4j
+
+import "crypto/x509"
+
+// TrustStrategy defines how the driver will establish trust with the neo4j instance
+type TrustStrategy struct {
+	certificates       []*x509.Certificate
+	skipVerify         bool
+	skipVerifyHostname bool
+}
+
+// TrustAny returns a trust strategy which skips trust verification (trusts any certificate
+// provided) and whose hostname verification can be enabled/disabled based on the provided
+// parameter
+func TrustAny(verifyHostname bool) TrustStrategy {
+	return TrustStrategy{
+		certificates:       nil,
+		skipVerify:         true,
+		skipVerifyHostname: !verifyHostname,
+	}
+}
+
+// TrustSystem returns a trust strategy which uses system provided certificates for
+// trust verification and whose hostname verification can be enabled/disabled based
+// on the provided parameter
+func TrustSystem(verifyHostname bool) TrustStrategy {
+	return TrustStrategy{
+		certificates:       nil,
+		skipVerify:         false,
+		skipVerifyHostname: !verifyHostname,
+	}
+}
+
+// TrustOnly returns a trust strategy which uses provided certificates for trust
+// verification and whose hostname verification can be enabled/disabled based
+// on the provided parameter
+func TrustOnly(verifyHostname bool, certs ...*x509.Certificate) TrustStrategy {
+	return TrustStrategy{
+		certificates:       certs,
+		skipVerify:         false,
+		skipVerifyHostname: !verifyHostname,
+	}
+}

--- a/neo4j/gobolt_driver.go
+++ b/neo4j/gobolt_driver.go
@@ -37,7 +37,10 @@ type goboltDriver struct {
 
 func configToGoboltConfig(config *Config) *gobolt.Config {
 	return &gobolt.Config{
-		Encryption:      config.Encrypted,
+		Encryption:            config.Encrypted,
+		TLSCertificates:       config.TrustStrategy.certificates,
+		TLSSkipVerify:         config.TrustStrategy.skipVerify,
+		TLSSkipVerifyHostname: config.TrustStrategy.skipVerifyHostname,
 		Log:             config.Log,
 		AddressResolver: wrapAddressResolverOrNil(config.AddressResolver),
 		MaxPoolSize:     config.MaxConnectionPoolSize,

--- a/neo4j/test-integration/control/single-instance.go
+++ b/neo4j/test-integration/control/single-instance.go
@@ -21,6 +21,10 @@ package control
 
 import (
 	"bufio"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"path"
 	"strings"
 	"sync"
 
@@ -107,6 +111,29 @@ func newSingleInstance(path string) (*SingleInstance, error) {
 	}
 
 	return result, nil
+}
+
+func (server *SingleInstance) Path() string {
+	return server.path
+}
+
+func (server *SingleInstance) TLSCertificate() *x509.Certificate {
+	bytes, err := ioutil.ReadFile(path.Join(server.path, "neo4jhome", "certificates", "neo4j.cert"))
+	if err != nil {
+		return nil
+	}
+
+	der, _ := pem.Decode(bytes)
+	if der == nil {
+		return nil
+	}
+
+	cert, err := x509.ParseCertificate(der.Bytes)
+	if err != nil {
+		return nil
+	}
+
+	return cert
 }
 
 func (server *SingleInstance) BoltUri() string {

--- a/neo4j/test-integration/tls_test.go
+++ b/neo4j/test-integration/tls_test.go
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package test_integration
+
+import (
+	"github.com/neo4j/neo4j-go-driver/neo4j"
+	"github.com/neo4j/neo4j-go-driver/neo4j/test-integration/control"
+	"github.com/neo4j/neo4j-go-driver/neo4j/utils/test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Trust", func() {
+	var err error
+	var server *control.SingleInstance
+
+	BeforeEach(func() {
+		server, err = control.EnsureSingleInstance()
+		Expect(err).To(BeNil())
+		Expect(server).NotTo(BeNil())
+	})
+
+	verifySuccessfulConnection := func(uri string, strategy neo4j.TrustStrategy) {
+		var driver neo4j.Driver
+		var session neo4j.Session
+		var result neo4j.Result
+		var resultSummary neo4j.ResultSummary
+		var err error
+
+		driver, err = neo4j.NewDriver(uri, server.AuthToken(), server.Config(), func(config *neo4j.Config) {
+			config.TrustStrategy = strategy
+		})
+		Expect(err).To(BeNil())
+		Expect(driver).NotTo(BeNil())
+		defer driver.Close()
+
+		session, err = driver.Session(neo4j.AccessModeRead)
+		Expect(err).To(BeNil())
+		Expect(session).NotTo(BeNil())
+		defer session.Close()
+
+		result, err = session.Run("RETURN 1", nil)
+		Expect(err).To(BeNil())
+		Expect(result).NotTo(BeNil())
+
+		resultSummary, err = result.Consume()
+		Expect(err).To(BeNil())
+		Expect(resultSummary).NotTo(BeNil())
+	}
+
+	verifyFailedConnection := func(uri string, strategy neo4j.TrustStrategy, expectedCode uint32) {
+		var driver neo4j.Driver
+		var session neo4j.Session
+		var err error
+
+		driver, err = neo4j.NewDriver(uri, server.AuthToken(), server.Config(), func(config *neo4j.Config) {
+			config.TrustStrategy = strategy
+		})
+		Expect(err).To(BeNil())
+		Expect(driver).NotTo(BeNil())
+		defer driver.Close()
+
+		session, err = driver.Session(neo4j.AccessModeRead)
+		Expect(err).To(BeNil())
+		Expect(session).NotTo(BeNil())
+		defer session.Close()
+
+		_, err = session.Run("RETURN 1", nil)
+		Expect(err).To(test.BeConnectorErrorWithCode(expectedCode))
+	}
+
+	Context("TrustAny", func() {
+		It("should connect when hostname verification is enabled", func() {
+			verifySuccessfulConnection("bolt://localhost:7687", neo4j.TrustAny(true))
+		})
+
+		It("should not connect when hostname verification is enabled", func() {
+			verifyFailedConnection("bolt://127.0.0.1:7687", neo4j.TrustAny(true), 13)
+		})
+
+		It("should connect when hostname verification is disabled", func() {
+			verifySuccessfulConnection("bolt://localhost:7687", neo4j.TrustAny(false))
+		})
+
+		It("should connect when hostname verification is disabled", func() {
+			verifySuccessfulConnection("bolt://127.0.0.1:7687", neo4j.TrustAny(false))
+		})
+	})
+
+	Context("TrustOnly", func() {
+		It("should not connect when certificate is not provided - bolt://127.0.0.1:7687", func() {
+			verifyFailedConnection("bolt://127.0.0.1:7687", neo4j.TrustOnly(false), 13)
+		})
+
+		It("should not connect when certificate is not provided - bolt://localhost:7687", func() {
+			verifyFailedConnection("bolt://localhost:7687", neo4j.TrustOnly(false), 13)
+		})
+
+		It("should connect when hostname verification is enabled", func() {
+			verifySuccessfulConnection("bolt://localhost:7687", neo4j.TrustOnly(true, server.TLSCertificate()))
+		})
+
+		It("should not connect when hostname verification is enabled", func() {
+			verifyFailedConnection("bolt://127.0.0.1:7687", neo4j.TrustOnly(true, server.TLSCertificate()), 13)
+		})
+
+		It("should connect when hostname verification is disabled", func() {
+			verifySuccessfulConnection("bolt://localhost:7687", neo4j.TrustOnly(false, server.TLSCertificate()))
+		})
+
+		It("should connect when hostname verification is disabled", func() {
+			verifySuccessfulConnection("bolt://127.0.0.1:7687", neo4j.TrustOnly(false, server.TLSCertificate()))
+		})
+	})
+})


### PR DESCRIPTION
This PR adds `TrustStrategy` configuration option to specify how driver will establish trust with the neo4j instance it connects.

There are only three predefined strategies which can be created through the following functions;

1. `neo4j.TrustAny(verifyHostname bool)`: in this mode driver connects to any neo4j instance with any presented certificate, without any verification.
2. `neo4j.TrustSystem(verifyHostname bool)`: in this mode driver connects to neo4j instances whose certificates are trusted with regard to trusted issuers that are pointed to by `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables.
3. `neo4j.TrustOnly(verifyHostname bool, certs ...*x509.Certificate)`: in this mode driver connects to neo4j instances whose certificates are trusted with regard to provided ones.

Each trust strategy can additionally be configured to verify hostnames against certificates subject and/or subject alternative names.