### PR TITLE
Add examples for docs and simplify custom address resolver

### DIFF
--- a/neo4j/error.go
+++ b/neo4j/error.go
@@ -35,6 +35,10 @@ func (err *driverError) Error() string {
 	return err.message
 }
 
+func IsServiceUnavailable(err error) bool {
+	return gobolt.IsServiceUnavailable(err)
+}
+
 func IsDriverError(err error) bool {
 	_, ok := err.(*driverError)
 	return ok

--- a/neo4j/test-integration/bookmark_test.go
+++ b/neo4j/test-integration/bookmark_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Bookmark", func() {
 				Skip("this test is targeted for server version less than neo4j 3.5.0")
 			}
 
-			result, err = session.Run("CREATE (p:Person { Name: 'Test'})", nil)
+			result, err = session.Run("CREATE (p:Person { name: 'Test'})", nil)
 			Expect(err).To(BeNil())
 
 			summary, err = result.Consume()
@@ -111,7 +111,7 @@ var _ = Describe("Bookmark", func() {
 				Skip("this test is targeted for server version after neo4j 3.5.0")
 			}
 
-			result, err = session.Run("CREATE (p:Person { Name: 'Test'})", nil)
+			result, err = session.Run("CREATE (p:Person { name: 'Test'})", nil)
 			Expect(err).To(BeNil())
 
 			summary, err = result.Consume()
@@ -124,7 +124,7 @@ var _ = Describe("Bookmark", func() {
 			tx, err := session.BeginTransaction()
 			Expect(err).To(BeNil())
 
-			result, err = tx.Run("CREATE (p:Person { Name: 'Test'})", nil)
+			result, err = tx.Run("CREATE (p:Person { name: 'Test'})", nil)
 			Expect(err).To(BeNil())
 
 			summary, err = result.Consume()
@@ -140,7 +140,7 @@ var _ = Describe("Bookmark", func() {
 			tx, err := session.BeginTransaction()
 			Expect(err).To(BeNil())
 
-			result, err = tx.Run("CREATE (p:Person { Name: 'Test'})", nil)
+			result, err = tx.Run("CREATE (p:Person { name: 'Test'})", nil)
 			Expect(err).To(BeNil())
 
 			summary, err = result.Consume()
@@ -154,7 +154,7 @@ var _ = Describe("Bookmark", func() {
 
 		Specify("when a node is created in transaction function, last bookmark should not be empty", func() {
 			result, err := session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
-				result, err := tx.Run("CREATE (p:Person { Name: 'Test'})", nil)
+				result, err := tx.Run("CREATE (p:Person { name: 'Test'})", nil)
 				Expect(err).To(BeNil())
 
 				summary, err = result.Consume()
@@ -171,7 +171,7 @@ var _ = Describe("Bookmark", func() {
 		Specify("when a node is created in transaction function and rolled back, last bookmark should be empty", func() {
 			failWith := fmt.Errorf("some error")
 			result, err := session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
-				result, err := tx.Run("CREATE (p:Person { Name: 'Test'})", nil)
+				result, err := tx.Run("CREATE (p:Person { name: 'Test'})", nil)
 				Expect(err).To(BeNil())
 
 				summary, err = result.Consume()

--- a/neo4j/test-integration/examples_test.go
+++ b/neo4j/test-integration/examples_test.go
@@ -104,6 +104,16 @@ var _ = Describe("Examples", func() {
 			Expect(err).To(BeNil())
 		})
 
+		Specify("Config - Address Resolver", func() {
+			driver, err := createDriverWithAddressResolver(uri, username, password)
+			Expect(err).To(BeNil())
+			Expect(driver).NotTo(BeNil())
+
+			err = driver.Close()
+			Expect(err).To(BeNil())
+		})
+
+
 		Specify("Service Unavailable", func() {
 			driver, err := createDriverWithMaxRetryTime("bolt://localhost:8080", username, password)
 			Expect(err).To(BeNil())
@@ -178,7 +188,7 @@ var _ = Describe("Examples", func() {
 			Expect(id).To(BeNumerically(">=", 0))
 		})
 
-		FSpecify("Get People", func() {
+		Specify("Get People", func() {
 			driver, err := createDriverWithMaxRetryTime(uri, username, password)
 			Expect(err).To(BeNil())
 			Expect(driver).NotTo(BeNil())
@@ -296,6 +306,22 @@ func createDriverWithTrustStrategy(uri, username, password string) (neo4j.Driver
 }
 
 // end::config-trust[]
+
+// tag::config-custom-resolver[]
+func createDriverWithAddressResolver(uri, username, password string) (neo4j.Driver, error) {
+	// Address resolver is only valid for bolt+routing uri
+	return neo4j.NewDriver(uri, neo4j.BasicAuth(username, password, ""), func(config *neo4j.Config) {
+		config.AddressResolver = func(address neo4j.ServerAddress) []neo4j.ServerAddress {
+			return []neo4j.ServerAddress{
+				neo4j.NewServerAddress("server1.my.domain", "7675"),
+				neo4j.NewServerAddress("server2.my.domain", "7675"),
+				neo4j.NewServerAddress("server3.my.domain", "7675"),
+			}
+		}
+	})
+}
+
+// end::config-custom-resolver[]
 
 // tag::config-connection-pool[]
 
@@ -660,7 +686,3 @@ func getPeople(driver neo4j.Driver) ([]string, error) {
 // tag::result-retain[]
 
 // end::result-retain[]
-
-// tag::custom-resolver[]
-
-// end::custom-resolver[]

--- a/neo4j/test-integration/routing_test.go
+++ b/neo4j/test-integration/routing_test.go
@@ -78,13 +78,12 @@ var _ = Describe("Routing", func() {
 		})
 
 		Specify("should successfully execute read/write when initial address contains unusable items", func() {
-			var resolvedTo []neo4j.ServerAddress
-			resolvedTo = append(resolvedTo, cluster.ReadReplicaAddresses()...)
-			resolvedTo = append(resolvedTo, cluster.LeaderAddress())
-
 			driver, err := neo4j.NewDriver("bolt+routing://localhost", cluster.AuthToken(), cluster.Config(), func(config *neo4j.Config) {
-				config.AddressResolver = &testResolver{
-					addresses: resolvedTo,
+				config.AddressResolver = func(address neo4j.ServerAddress) []neo4j.ServerAddress {
+					var resolvedTo []neo4j.ServerAddress
+					resolvedTo = append(resolvedTo, cluster.ReadReplicaAddresses()...)
+					resolvedTo = append(resolvedTo, cluster.LeaderAddress())
+					return resolvedTo
 				}
 			})
 			Expect(err).To(BeNil())
@@ -172,11 +171,3 @@ var _ = Describe("Routing", func() {
 	})
 
 })
-
-type testResolver struct {
-	addresses []neo4j.ServerAddress
-}
-
-func (resolver *testResolver) Resolve(address neo4j.ServerAddress) []neo4j.ServerAddress {
-	return resolver.addresses
-}

--- a/neo4j/test-integration/session_test.go
+++ b/neo4j/test-integration/session_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Session", func() {
 		})
 
 		Specify("when a node is created, summary should contain correct counter values", func() {
-			result, err = session.Run("CREATE (p:Person { Name: 'Test'})", nil)
+			result, err = session.Run("CREATE (p:Person { name: 'Test'})", nil)
 			Expect(err).To(BeNil())
 
 			summary, err = result.Consume()
@@ -246,7 +246,7 @@ var _ = Describe("Session", func() {
 		})
 
 		Specify("when a node is created, summary should contain correct timer values", func() {
-			result, err = session.Run("CREATE (p:Person { Name: 'Test'})", nil)
+			result, err = session.Run("CREATE (p:Person { name: 'Test'})", nil)
 			Expect(err).To(BeNil())
 
 			summary, err = result.Consume()


### PR DESCRIPTION
This PR adds examples for inclusion into the developer manual.

It also updates the `ServerAddressResolver` interface to be a function type instead since it will be much easier to pass it as a function.