### PR TITLE
Add tests for nil pointer values

### DIFF
--- a/neo4j/test-integration/driver_test.go
+++ b/neo4j/test-integration/driver_test.go
@@ -22,6 +22,7 @@ package test_integration
 import (
 	"github.com/neo4j/neo4j-go-driver/neo4j"
 	"github.com/neo4j/neo4j-go-driver/neo4j/test-integration/control"
+	"math"
 	"time"
 
 	. "github.com/neo4j/neo4j-go-driver/neo4j/utils/test"
@@ -188,7 +189,7 @@ var _ = Describe("Driver", func() {
 			_, err = session3.Run("UNWIND RANGE(1, 100) AS N RETURN N", nil)
 			elapsed := time.Since(start)
 			Expect(err).To(BeConnectorErrorWithCode(0x601))
-			Expect(elapsed / time.Second).To(BeNumerically(">=", 10))
+			Expect(math.Round(float64(elapsed / time.Second))).To(BeNumerically(">=", 10))
 		})
 	})
 })

--- a/neo4j/test-integration/types_test.go
+++ b/neo4j/test-integration/types_test.go
@@ -22,10 +22,10 @@ package test_integration
 import (
 	"github.com/neo4j/neo4j-go-driver/neo4j"
 	"github.com/neo4j/neo4j-go-driver/neo4j/test-integration/control"
-	"math/rand"
-
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"math/rand"
 )
 
 var _ = Describe("Types", func() {
@@ -399,4 +399,36 @@ var _ = Describe("Types", func() {
 		Expect(result.Err()).To(BeNil())
 	})
 
+	DescribeTable("should be able to send and receive nil pointer property",
+		func(value interface{}) {
+			result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+			Expect(err).To(BeNil())
+
+			if result.Next() {
+				Expect(result.Record().GetByIndex(0)).To(BeNil())
+			}
+			Expect(result.Next()).To(BeFalse())
+			Expect(result.Err()).To(BeNil())
+		},
+		Entry("boolean", (*bool)(nil)),
+		Entry("byte", (*byte)(nil)),
+		Entry("int8", (*int8)(nil)),
+		Entry("int16", (*int16)(nil)),
+		Entry("int32", (*int32)(nil)),
+		Entry("int64", (*int64)(nil)),
+		Entry("int", (*int)(nil)),
+		Entry("float32", (*float32)(nil)),
+		Entry("float64", (*float64)(nil)),
+		Entry("string", (*string)(nil)),
+		Entry("boolean array", (*[]bool)(nil)),
+		Entry("byte array", (*[]byte)(nil)),
+		Entry("int8 array", (*[]int8)(nil)),
+		Entry("int16 array", (*[]int16)(nil)),
+		Entry("int32 array", (*[]int32)(nil)),
+		Entry("int64 array", (*[]int64)(nil)),
+		Entry("int array", (*[]int)(nil)),
+		Entry("float32 array", (*[]float32)(nil)),
+		Entry("float64 array", (*[]float64)(nil)),
+		Entry("string array", (*[]string)(nil)),
+	)
 })

--- a/neo4j/test-integration/values_spatial_test.go
+++ b/neo4j/test-integration/values_spatial_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "github.com/neo4j/neo4j-go-driver/neo4j/utils/test"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -259,4 +260,18 @@ var _ = Describe("Spatial Types", func() {
 			testSendAndReceiveList(randomPointList(i, 100))
 		}
 	})
+
+	DescribeTable("should be able to send and receive nil pointer property",
+		func(value interface{}) {
+			result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+			Expect(err).To(BeNil())
+
+			if result.Next() {
+				Expect(result.Record().GetByIndex(0)).To(BeNil())
+			}
+			Expect(result.Next()).To(BeFalse())
+			Expect(result.Err()).To(BeNil())
+		},
+		Entry("Point", (*neo4j.Point)(nil)),
+	)
 })

--- a/neo4j/test-integration/values_temporal_test.go
+++ b/neo4j/test-integration/values_temporal_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/neo4j/test-integration/control"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -497,4 +498,23 @@ var _ = Describe("Temporal Types", func() {
 			testSendAndReceiveValue(list)
 		})
 	})
+
+	DescribeTable("should be able to send and receive nil pointer property",
+		func(value interface{}) {
+			result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+			Expect(err).To(BeNil())
+
+			if result.Next() {
+				Expect(result.Record().GetByIndex(0)).To(BeNil())
+			}
+			Expect(result.Next()).To(BeFalse())
+			Expect(result.Err()).To(BeNil())
+		},
+		Entry("Duration", (*neo4j.Duration)(nil)),
+		Entry("Date", (*neo4j.Date)(nil)),
+		Entry("LocalTime", (*neo4j.LocalTime)(nil)),
+		Entry("OffsetTime", (*neo4j.OffsetTime)(nil)),
+		Entry("LocalDateTime", (*neo4j.LocalDateTime)(nil)),
+		Entry("DateTime{Offset|Zoned}", (*time.Time)(nil)),
+	)
 })


### PR DESCRIPTION
Previously sending nil values of a pointer type caused panic on gobolt. Actual behaviour was fixed with https://github.com/neo4j-drivers/gobolt/pull/1 and this PR adds integration tests to guard against this behaviour.

Fixes #35.
