### PR TITLE
Buffer pending results on session close

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to the Neo4j Ecosystem
+
+At [Neo4j](http://neo4j.com/), we develop our software in the open at GitHub.
+This provides transparency for you, our users, and allows you to fork the software to make your own additions and enhancements.
+We also provide areas specifically for community contributions, in particular the [neo4j-contrib](https://github.com/neo4j-contrib) space.
+
+There's an active [Neo4j Online Community](https://community.neo4j.com/) where we work directly with the community.
+If you're not already a member, sign up!
+
+We love our community and wouldn't be where we are without you.
+
+
+## Need to raise an issue?
+
+Where you raise an issue depends largely on the nature of the problem.
+
+Firstly, if you are an Enterprise customer, you might want to head over to our [Customer Support Portal](http://support.neo4j.com/).
+
+There are plenty of public channels available too, though.
+If you simply want to get started or have a question on how to use a particular feature, ask a question in [Neo4j Online Community](https://community.neo4j.com/).
+If you think you might have hit a bug in our software (it happens occasionally!) or you have specific feature request then use the issue feature on the relevant GitHub repository.
+Check first though as someone else may have already raised something similar.
+
+[StackOverflow](http://stackoverflow.com/questions/tagged/neo4j) also hosts a ton of questions and might already have a discussion around your problem.
+Make sure you have a look there too.
+
+Include as much information as you can in any request you make:
+
+- Which versions of our products are you using?
+- Which language (and which version of that language) are you developing with?
+- What operating system are you on?
+- Are you working with a cluster or on a single machine?
+- What code are you running?
+- What errors are you seeing?
+- What solutions have you tried already?
+
+
+## Want to contribute?
+
+If you want to contribute a pull request, we have a little bit of process you'll need to follow:
+
+- Do all your work in a personal fork of the original repository
+- [Rebase](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request), don't merge (we prefer to keep our history clean)
+- Create a branch (with a useful name) for your contribution
+- Make sure you're familiar with the appropriate coding style (this varies by language so ask if you're in doubt)
+- Include unit tests if appropriate (obviously not necessary for documentation changes)
+- Take a moment to read and sign our [CLA](http://neo4j.com/developer/cla)
+
+We can't guarantee that we'll accept pull requests and may ask you to make some changes before they go in.
+Occasionally, we might also have logistical, commercial, or legal reasons why we can't accept your work but we'll try to find an alternative way for you to contribute in that case.
+Remember that many community members have become regular contributors and some are now even Neo employees!
+
+
+## Got an idea for a new project?
+
+If you have an idea for a new tool or library, start by talking to other people in the community.
+Chances are that someone has a similar idea or may have already started working on it.
+The best software comes from getting like minds together to solve a problem.
+And we'll do our best to help you promote and co-ordinate your Neo ecosystem projects.
+
+
+## Further reading
+
+If you want to find out more about how you can contribute, head over to our website for [more information](http://neo4j.com/developer/contributing-code/).

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,48 @@
+## Guidelines
+
+Firstly, if you are an Enterprise customer, you might want to head over to our [Customer Support Portal](http://support.neo4j.com/).
+
+If you think you might have **hit a bug** in our software (it happens occasionally!) or you have specific **feature request** then use the issue feature on the relevant GitHub repository.
+Check first though as someone else may have already raised something similar.
+
+If you simply want to get started or have a question on how to use a particular feature, ask a question in [Neo4j Online Community](https://community.neo4j.com/) instead.
+[StackOverflow](http://stackoverflow.com/questions/tagged/neo4j) also hosts a ton of questions and might already have a discussion around your problem.
+Make sure you have a look there too.
+
+If you want to make a feature request, please prefix your issue title with `[Feature Request]` so that it is clear to us. 
+If you have a bug report however, please continue reading.  
+To help us understand your issue, please specify important details, primarily:
+
+- Neo4j version: Community/Enterprise X.Y.Z
+- Neo4j Mode: Single instance/HA cluster with X members/Casual cluster with X core Y read-replica
+- Driver version: X lanaguage driver X.Y.Z (If you use some other library that wraps around this driver, you might want to raise an issue there first)
+- Operating system: (for example Windows 10/Ubuntu 16.10 on AWS)
+- **Steps to reproduce**
+- Expected behavior
+- Actual behavior
+
+Additionally, include (as appropriate) log-files, stacktraces, and other debug output.
+Always check the server logs to see if there is any stacktrace related to the driver error too.
+Aslo add any solutions you've tried to solve the problem yourself.
+
+## Example bug report
+
+I got connection reset by peer errors.
+
+**Neo4j Version:** 3.4.10 Community  
+**Neo4j Mode**: Single instance  
+**Driver version**: JS driver 1.7.1  
+**Operating System:** Ubuntu 16.10 on AWS  
+
+### Steps to reproduce
+1. Start Neo4j on a AWS instance
+2. Run a query with the driver
+3. Put the driver idle for 2h
+4. Run another query
+### Expected behavior
+The second query shall run successfully
+### Actual behavior
+The client failed to run the second query with a `connection reset by peer` stacktrace.  
+*attach the stacktrace*  
+Meanwhile, in the server log, I found this stacktrace that happened at the same time when the driver failed.  
+*attach the stacktrace*  

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -31,7 +31,7 @@ I got connection reset by peer errors.
 
 **Neo4j Version:** 3.4.10 Community  
 **Neo4j Mode**: Single instance  
-**Driver version**: JS driver 1.7.1  
+**Driver version**: Go driver 1.7.1  
 **Operating System:** Ubuntu 16.10 on AWS  
 
 ### Steps to reproduce

--- a/neo4j/Gopkg.lock
+++ b/neo4j/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = "UT"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:bc38c7c481812e178d85160472e231c5e1c9a7f5845d67e23ee4e706933c10d8"
   name = "github.com/golang/mock"
   packages = ["gomock"]
@@ -24,12 +32,12 @@
   revision = "a1dbeea552b7c8df4b542c66073e393de198a800"
 
 [[projects]]
-  digest = "1:57935a0e860bff559496c114a5bda0229591f8a9f96b67fc7ed76171f7bcb3d7"
+  digest = "1:1475284f4da1954edf470db7a1a4c02273b575df44e423a70c9252809ceff644"
   name = "github.com/neo4j-drivers/gobolt"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0a4bbb30cf673c3ab6d5a46dbb780782fc242c59"
-  version = "v1.7.0-rc03"
+  revision = "5c8150e392c88792913393e416a1a63124f03daf"
+  version = "v1.7.1"
 
 [[projects]]
   digest = "1:f37a92358921891d53d5375ff7fa57739ba65d5b3c311d96a460609bfc1b4999"
@@ -87,6 +95,22 @@
   pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = "UT"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
@@ -170,6 +194,7 @@
     "github.com/onsi/gomega",
     "github.com/onsi/gomega/types",
     "github.com/pkg/errors",
+    "github.com/stretchr/testify/assert",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/neo4j/Gopkg.toml
+++ b/neo4j/Gopkg.toml
@@ -48,3 +48,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.2.2"

--- a/neo4j/result_impl.go
+++ b/neo4j/result_impl.go
@@ -38,7 +38,7 @@ type neoResult struct {
 	resultCompleted bool
 }
 
-func (result *neoResult) collectMetadata(metadata map[string]interface{}) {
+var collectMetadata = func(result *neoResult, metadata map[string]interface{}) {
 	if metadata != nil {
 		if resultAvailabilityTimer, ok := metadata["result_available_after"]; ok {
 			result.summary.resultAvailableAfter = time.Duration(resultAvailabilityTimer.(int64)) / time.Millisecond
@@ -97,7 +97,7 @@ func (result *neoResult) collectMetadata(metadata map[string]interface{}) {
 	}
 }
 
-func (result *neoResult) collectRecord(fields []interface{}) {
+var collectRecord = func(result *neoResult, fields []interface{}) {
 	if fields != nil {
 		result.records = append(result.records, &neoRecord{keys: result.keys, values: fields})
 	}

--- a/neo4j/runner_test.go
+++ b/neo4j/runner_test.go
@@ -20,45 +20,1120 @@
 package neo4j
 
 import (
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"fmt"
+	"testing"
 	"time"
+
+	"github.com/neo4j-drivers/gobolt"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 )
 
-var _ = Describe("Runner", func() {
-	var (
-		mockCtrl *gomock.Controller
-	)
+func TestRunner(t *testing.T) {
+	createMocksWithParams := func(t *testing.T, mode AccessMode, autoClose bool) (*gomock.Controller, *MockConnection, *statementRunner) {
+		ctrl := gomock.NewController(t)
+		connection := NewMockConnection(ctrl)
+		connector := MockedConnector(connection)
+		driver := newGoboltWithConnector("bolt://localhost", connector)
+		runner := newRunner(driver, mode, autoClose)
 
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
+		connection.EXPECT().RemoteAddress().Return("localhost:7687").AnyTimes()
+		connection.EXPECT().Server().Return("neo4j/3.5.0").AnyTimes()
+
+		return ctrl, connection, runner
+	}
+
+	createMocks := func(t *testing.T) (*gomock.Controller, *MockConnection, *statementRunner) {
+		return createMocksWithParams(t, AccessModeWrite, true)
+	}
+
+	t.Run("shouldStartWithNilConnection", func(t *testing.T) {
+		ctrl, _, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		assert.Nil(t, runner.connection)
 	})
 
-	AfterEach(func() {
-		mockCtrl.Finish()
+	t.Run("shouldStartWithEmptyBookmark", func(t *testing.T) {
+		ctrl, _, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		bookmark := runner.lastBookmark
+
+		assert.Empty(t, bookmark)
 	})
 
-	Context("runStatement", func() {
-		It("should invoke run on connection", func() {
-			mockConnection := NewMockConnection(mockCtrl)
-			mockConnector := MockedConnector(mockConnection)
-			mockDriver := newGoboltWithConnector("bolt://localhost", mockConnector)
-			runner := newRunner(mockDriver, AccessModeWrite, true)
+	t.Run("shouldFailWhenConnectionIsNilOnAssertConnection", func(t *testing.T) {
+		ctrl, _, runner := createMocks(t)
+		defer ctrl.Finish()
 
-			emptyMap := map[string]interface{}(nil)
+		err := runner.assertConnection()
 
-			gomock.InOrder(
-				mockConnection.EXPECT().Run("RETURN 1", emptyMap, nil, 0*time.Second, nil).Times(1),
-				mockConnection.EXPECT().PullAll().Times(1),
-				mockConnection.EXPECT().Flush().Times(1),
-				mockConnection.EXPECT().RemoteAddress(),
-				mockConnection.EXPECT().Server(),
-			)
+		assert.EqualError(t, err, "unexpected state: expected an active connection bound to this runner")
+	})
 
-			_, err := runner.runStatement(&neoStatement{text: "RETURN 1"}, nil, TransactionConfig{})
+	t.Run("shouldNotFailWhenConnectionIsNotNilOnAssertConnection", func(t *testing.T) {
+		ctrl, connection, runner := createMocks(t)
+		defer ctrl.Finish()
+		runner.connection = connection
 
-			Expect(err).To(BeNil())
+		assert.NoError(t, runner.assertConnection())
+	})
+
+	t.Run("shouldFailWhenConnectionIsNotNilOnAssertNoConnection", func(t *testing.T) {
+		ctrl, _, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		assert.NoError(t, runner.assertNoConnection())
+	})
+
+	t.Run("shouldNotFailWhenConnectionIsNotNilOnAssertNoConnection", func(t *testing.T) {
+		ctrl, connection, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		runner.connection = connection
+
+		err := runner.assertNoConnection()
+
+		assert.EqualError(t, err, "unexpected state: expected no connection bound to this runner")
+	})
+
+	t.Run("shouldConstructConnectionOnEnsureConnection", func(t *testing.T) {
+		ctrl, connection, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		err := runner.ensureConnection()
+
+		assert.NoError(t, err)
+		assert.Equal(t, runner.connection, connection)
+	})
+
+	t.Run("shouldPropagateErrorOnEnsureConnection", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		connector := NewMockConnector(mockCtrl)
+		driver := newGoboltWithConnector("bolt://localhost", connector)
+		runner := newRunner(driver, AccessModeWrite, true)
+
+		failure := fmt.Errorf("an unexpected error")
+
+		connector.EXPECT().Acquire(gobolt.AccessModeWrite).Return(nil, failure)
+
+		err := runner.ensureConnection()
+
+		assert.Equal(t, err, failure)
+	})
+
+	t.Run("shouldNotFailWhenConnectionIsNilOnClose", func(t *testing.T) {
+		ctrl, _, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		assert.NoError(t, runner.close())
+	})
+
+	t.Run("shouldQueryLastBookmarkAndCloseConnectionOnClose", func(t *testing.T) {
+		ctrl, connection, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		_ = runner.ensureConnection()
+
+		gomock.InOrder(
+			connection.EXPECT().LastBookmark().Return("a bookmark"),
+			connection.EXPECT().Close(),
+		)
+
+		// When
+		err := runner.close()
+
+		// Expect
+		assert.NoError(t, err)
+		assert.Nil(t, runner.connection)
+		assert.Equal(t, runner.lastBookmark, "a bookmark")
+	})
+
+	t.Run("shouldReturnEmptyWhenInitialisedOnLastSeenBookmark", func(t *testing.T) {
+		ctrl, _, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		bookmark := runner.lastSeenBookmark()
+
+		assert.Empty(t, bookmark)
+	})
+
+	t.Run("shouldReturnStoredBookmarkOnLastSeenBookmark", func(t *testing.T) {
+		ctrl, _, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		runner.lastBookmark = "a bookmark"
+
+		bookmark := runner.lastSeenBookmark()
+
+		assert.Equal(t, bookmark, "a bookmark")
+	})
+
+	t.Run("shouldReturnBookmarkFromConnectionOnLastSeenBookmark", func(t *testing.T) {
+		ctrl, connection, runner := createMocks(t)
+		defer ctrl.Finish()
+
+		_ = runner.ensureConnection()
+
+		runner.lastBookmark = "a bookmark 1"
+		connection.EXPECT().LastBookmark().Return("a bookmark 2")
+
+		bookmark := runner.lastSeenBookmark()
+
+		assert.Equal(t, bookmark, "a bookmark 2")
+	})
+
+	t.Run("closeAll", func(t *testing.T) {
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldCallReceiveAll", func(t *testing.T) {
+			receiveAllCalls := 0
+			receiveAllOverride := func(runner *statementRunner) error {
+				receiveAllCalls++
+				return nil
+			}
+
+			ctrl, _, runner := createMocks(t)
+			runner.receiveAllHandler = receiveAllOverride
+			defer ctrl.Finish()
+
+			assert.NoError(t, runner.receiveAllAndClose())
+			assert.Equal(t, receiveAllCalls, 1)
+		})
+
+		t.Run("shouldCallReceiveAllAndPropogateError", func(t *testing.T) {
+			receiveAllOverride := func(runner *statementRunner) error {
+				return failure
+			}
+
+			ctrl, _, runner := createMocks(t)
+			runner.receiveAllHandler = receiveAllOverride
+			defer ctrl.Finish()
+
+			assert.Equal(t, runner.receiveAllAndClose(), failure)
+		})
+
+		t.Run("shouldCallCloseConnection", func(t *testing.T) {
+			closeConnectionCalls := 0
+			closeConnectionOverride := func(runner *statementRunner) error {
+				closeConnectionCalls++
+				return nil
+			}
+
+			ctrl, _, runner := createMocks(t)
+			runner.closeHandler = closeConnectionOverride
+			defer ctrl.Finish()
+
+			assert.NoError(t, runner.receiveAllAndClose())
+			assert.Equal(t, closeConnectionCalls, 1)
+		})
+
+		t.Run("shouldCallCloseConnectionAndPropogateError", func(t *testing.T) {
+			closeConnectionOverride := func(runner *statementRunner) error {
+				return failure
+			}
+
+			ctrl, _, runner := createMocks(t)
+			runner.closeHandler = closeConnectionOverride
+			defer ctrl.Finish()
+
+			assert.Equal(t, runner.receiveAllAndClose(), failure)
+		})
+
+		t.Run("shouldGivePrecedenceToReceiveAllErrors", func(t *testing.T) {
+			receiveAllOverride := func(runner *statementRunner) error {
+				return failure
+			}
+			closeConnectionOverride := func(runner *statementRunner) error {
+				return fmt.Errorf("some other unexpected error")
+			}
+
+			ctrl, _, runner := createMocks(t)
+			runner.receiveAllHandler = receiveAllOverride
+			runner.closeHandler = closeConnectionOverride
+			defer ctrl.Finish()
+
+			assert.Equal(t, runner.receiveAllAndClose(), failure)
 		})
 	})
-})
+
+	t.Run("runStatement", func(t *testing.T) {
+		statementText := "some cypher statement"
+		statementParams := map[string]interface{}{"param1": 1, "param2": false, "param3": "string"}
+		statement := neoStatement{text: statementText, params: statementParams}
+		bookmarks := []string{"bookmark 1", "bookmark 2"}
+		txTimeout := 1 * time.Minute
+		txMetadata := map[string]interface{}{"a": 1, "b": true, "c": "something"}
+		txConfig := TransactionConfig{Timeout: txTimeout, Metadata: txMetadata}
+		runHandle := gobolt.RequestHandle(1)
+		pullAllHandle := gobolt.RequestHandle(2)
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldFailWhenEnsureConnectionFails", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			connector := NewMockConnector(ctrl)
+			driver := newGoboltWithConnector("bolt://localhost", connector)
+			runner := newRunner(driver, AccessModeWrite, true)
+
+			connector.EXPECT().Acquire(gobolt.AccessModeWrite).Return(nil, failure)
+
+			result, err := runner.runStatement(&statement, bookmarks, txConfig)
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenRunFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			connection.EXPECT().Run(statementText, statementParams, bookmarks, txTimeout, txMetadata).Return(runHandle, failure)
+
+			result, err := runner.runStatement(&statement, bookmarks, txConfig)
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenPullAllFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			gomock.InOrder(
+				connection.EXPECT().Run(statementText, statementParams, bookmarks, txTimeout, txMetadata).Return(runHandle, nil),
+				connection.EXPECT().PullAll().Return(pullAllHandle, failure),
+			)
+
+			result, err := runner.runStatement(&statement, bookmarks, txConfig)
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenFlushFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			gomock.InOrder(
+				connection.EXPECT().Run(statementText, statementParams, bookmarks, txTimeout, txMetadata).Return(runHandle, nil),
+				connection.EXPECT().PullAll().Return(pullAllHandle, nil),
+				connection.EXPECT().Flush().Return(failure),
+			)
+
+			result, err := runner.runStatement(&statement, bookmarks, txConfig)
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldInvokeRunPullAllAndFlush", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			gomock.InOrder(
+				connection.EXPECT().Run(statementText, statementParams, bookmarks, txTimeout, txMetadata).Return(runHandle, nil),
+				connection.EXPECT().PullAll().Return(pullAllHandle, nil),
+				connection.EXPECT().Flush(),
+			)
+
+			result, err := runner.runStatement(&statement, bookmarks, txConfig)
+
+			assert.NoError(t, err)
+
+			assert.NotNil(t, result)
+			assert.Equal(t, result.runHandle, runHandle)
+			assert.Equal(t, result.resultHandle, pullAllHandle)
+			assert.Equal(t, result.summary.server.Address(), "localhost:7687")
+			assert.Equal(t, result.summary.server.Version(), "neo4j/3.5.0")
+		})
+
+	})
+
+	t.Run("beginTransaction", func(t *testing.T) {
+		bookmarks := []string{"bookmark 1", "bookmark 2"}
+		txTimeout := 1 * time.Minute
+		txMetadata := map[string]interface{}{"a": 1, "b": true, "c": "something"}
+		beginHandle := gobolt.RequestHandle(1)
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldFailWhenThereIsActiveConnection", func(t *testing.T) {
+			ctrl, _, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			_ = runner.ensureConnection()
+
+			result, err := runner.beginTransaction(bookmarks, TransactionConfig{Timeout: txTimeout, Metadata: txMetadata})
+
+			assert.EqualError(t, err, "unexpected state: expected no connection bound to this runner")
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenEnsureConnectionFails", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			connector := NewMockConnector(ctrl)
+			driver := newGoboltWithConnector("bolt://localhost", connector)
+			runner := newRunner(driver, AccessModeWrite, true)
+
+			connector.EXPECT().Acquire(gobolt.AccessModeWrite).Return(nil, failure)
+
+			result, err := runner.beginTransaction(bookmarks, TransactionConfig{Timeout: txTimeout, Metadata: txMetadata})
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenBeginFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			gomock.InOrder(
+				connection.EXPECT().Begin(bookmarks, txTimeout, txMetadata).Return(beginHandle, failure),
+				connection.EXPECT().LastBookmark(),
+				connection.EXPECT().Close())
+
+			result, err := runner.beginTransaction(bookmarks, TransactionConfig{Timeout: txTimeout, Metadata: txMetadata})
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenFlushFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			gomock.InOrder(
+				connection.EXPECT().Begin(bookmarks, txTimeout, txMetadata).Return(beginHandle, nil),
+				connection.EXPECT().Flush().Return(failure),
+				connection.EXPECT().LastBookmark(),
+				connection.EXPECT().Close())
+
+			result, err := runner.beginTransaction(bookmarks, TransactionConfig{Timeout: txTimeout, Metadata: txMetadata})
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldInvokeBeginAndFlush", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			gomock.InOrder(
+				connection.EXPECT().Begin(bookmarks, txTimeout, txMetadata).Return(beginHandle, nil),
+				connection.EXPECT().Flush())
+
+			result, err := runner.beginTransaction(bookmarks, TransactionConfig{Timeout: txTimeout, Metadata: txMetadata})
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, result.resultHandle, beginHandle)
+		})
+	})
+
+	t.Run("commitTransaction", func(t *testing.T) {
+		commitHandle := gobolt.RequestHandle(1)
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldFailWhenThereIsNoActiveConnection", func(t *testing.T) {
+			ctrl, _, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result, err := runner.commitTransaction()
+
+			assert.EqualError(t, err, "unexpected state: expected an active connection bound to this runner")
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenCommitFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			runner.connection = connection
+
+			connection.EXPECT().Commit().Return(commitHandle, failure)
+
+			result, err := runner.commitTransaction()
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenFlushFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			runner.connection = connection
+
+			gomock.InOrder(
+				connection.EXPECT().Commit().Return(commitHandle, nil),
+				connection.EXPECT().Flush().Return(failure),
+			)
+
+			result, err := runner.commitTransaction()
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldInvokeCommitAndFlush", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			runner.connection = connection
+
+			gomock.InOrder(
+				connection.EXPECT().Commit().Return(commitHandle, nil),
+				connection.EXPECT().Flush(),
+			)
+
+			result, err := runner.commitTransaction()
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, result.resultHandle, commitHandle)
+		})
+	})
+
+	t.Run("rollbackTransaction", func(t *testing.T) {
+		rollbackHandle := gobolt.RequestHandle(1)
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldFailWhenThereIsNoActiveConnection", func(t *testing.T) {
+			ctrl, _, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result, err := runner.rollbackTransaction()
+
+			assert.EqualError(t, err, "unexpected state: expected an active connection bound to this runner")
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenRollbackFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			runner.connection = connection
+
+			connection.EXPECT().Rollback().Return(rollbackHandle, failure)
+
+			result, err := runner.rollbackTransaction()
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenFlushFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			runner.connection = connection
+
+			gomock.InOrder(
+				connection.EXPECT().Rollback().Return(rollbackHandle, nil),
+				connection.EXPECT().Flush().Return(failure),
+			)
+
+			result, err := runner.rollbackTransaction()
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldInvokeRollbackAndFlush", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			runner.connection = connection
+
+			gomock.InOrder(
+				connection.EXPECT().Rollback().Return(rollbackHandle, nil),
+				connection.EXPECT().Flush(),
+			)
+
+			result, err := runner.rollbackTransaction()
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, result.resultHandle, rollbackHandle)
+		})
+	})
+
+	t.Run("transformError", func(t *testing.T) {
+		notALeaderError := newDatabaseError("ClientError", "Neo.ClientError.Cluster.NotALeader", "a message")
+		forbiddenOnReadOnlyDatabaseError := newDatabaseError("ClientError", "Neo.ClientError.General.ForbiddenOnReadOnlyDatabase", "a message")
+
+		t.Run("shouldTransformWriteErrors", func(t *testing.T) {
+			var errors = []struct {
+				name string
+				err  error
+			}{
+				{"notALeader", notALeaderError},
+				{"forbiddenOnReadOnlyDatabase", forbiddenOnReadOnlyDatabaseError},
+			}
+
+			t.Run("readAccessMode", func(t *testing.T) {
+				for _, testCase := range errors {
+					t.Run(testCase.name, func(t *testing.T) {
+						ctrl, _, runner := createMocksWithParams(t, AccessModeRead, true)
+						defer ctrl.Finish()
+
+						err := transformError(runner, testCase.err)
+
+						assert.EqualError(t, err, "write queries cannot be performed in read access mode")
+					})
+				}
+			})
+
+			t.Run("writeAccessMode", func(t *testing.T) {
+				t.Run("withConnection", func(t *testing.T) {
+					for _, testCase := range errors {
+						t.Run(testCase.name, func(t *testing.T) {
+							ctrl, connection, runner := createMocksWithParams(t, AccessModeWrite, true)
+							defer ctrl.Finish()
+
+							runner.connection = connection
+
+							err := transformError(runner, testCase.err)
+
+							assert.EqualError(t, err, "server at localhost:7687 no longer accepts writes")
+						})
+					}
+				})
+
+				t.Run("withoutConnection", func(t *testing.T) {
+					for _, testCase := range errors {
+						t.Run(testCase.name, func(t *testing.T) {
+							ctrl, _, runner := createMocksWithParams(t, AccessModeWrite, true)
+							defer ctrl.Finish()
+
+							err := transformError(runner, testCase.err)
+
+							assert.EqualError(t, err, "server at unknown no longer accepts writes")
+						})
+					}
+				})
+			})
+		})
+
+		t.Run("shouldReturnOriginal", func(t *testing.T) {
+			var errors = []struct {
+				name string
+				err  error
+			}{
+				{"an ordinary error", fmt.Errorf("an unknown error")},
+				{"a driver error", newDriverError("a driver error")},
+				{"a session expired error", newSessionExpiredError("a session expired error")},
+				{"a connector error", newConnectorError(1, 1, "text", "context", "description")},
+			}
+
+			for _, testCase := range errors {
+				t.Run(testCase.name, func(t *testing.T) {
+					ctrl, _, runner := createMocksWithParams(t, AccessModeWrite, true)
+					defer ctrl.Finish()
+
+					err := transformError(runner, testCase.err)
+
+					assert.Equal(t, err, testCase.err)
+				})
+			}
+
+		})
+	})
+
+	createResult := func(runner *statementRunner) *neoResult {
+		return &neoResult{
+			keys:            []string{},
+			records:         []Record{},
+			current:         nil,
+			summary:         &neoResultSummary{},
+			runner:          runner,
+			err:             nil,
+			runHandle:       1,
+			runCompleted:    false,
+			resultHandle:    2,
+			resultCompleted: false,
+		}
+	}
+
+	createResultWithConn := func(runner *statementRunner) *neoResult {
+		_ = runner.ensureConnection()
+
+		return createResult(runner)
+	}
+
+	t.Run("handleRunPhase", func(t *testing.T) {
+		fields := []string{"Field 1", "Field 2"}
+		metadata := map[string]interface{}{"type": "r"}
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldSkipIfRunIsCompleted", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+			result.runCompleted = true
+
+			connection.EXPECT().Fetch(gomock.Any()).Times(0)
+			connection.EXPECT().Fields().Times(0)
+			connection.EXPECT().Metadata().Times(0)
+
+			assert.NoError(t, runner.handleRunPhase(result))
+		})
+
+		t.Run("shouldFailWhenFetchFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.runHandle).Return(gobolt.FetchType(0), failure)
+			connection.EXPECT().Fields().Times(0)
+			connection.EXPECT().Metadata().Times(0)
+
+			assert.Equal(t, runner.handleRunPhase(result), failure)
+		})
+
+		t.Run("shouldFailWhenFetchReturnsRecord", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.runHandle).Return(gobolt.FetchTypeRecord, nil)
+			connection.EXPECT().Fields().Times(0)
+			connection.EXPECT().Metadata().Times(0)
+
+			assert.EqualError(t, runner.handleRunPhase(result), "unexpected response received while waiting for a METADATA")
+		})
+
+		t.Run("shouldFailWhenFetchReturnsError", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.runHandle).Return(gobolt.FetchTypeError, nil)
+			connection.EXPECT().Fields().Times(0)
+			connection.EXPECT().Metadata().Times(0)
+
+			assert.EqualError(t, runner.handleRunPhase(result), "unexpected response received while waiting for a METADATA")
+		})
+
+		t.Run("shouldFailWhenFieldsReturnsError", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.runHandle).Return(gobolt.FetchTypeMetadata, nil)
+			connection.EXPECT().Fields().Return(nil, failure)
+			connection.EXPECT().Metadata().Times(0)
+
+			assert.Equal(t, runner.handleRunPhase(result), failure)
+		})
+
+		t.Run("shouldFailWhenMetadataReturnsError", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.runHandle).Return(gobolt.FetchTypeMetadata, nil)
+			connection.EXPECT().Fields().Return([]string{"a"}, nil)
+			connection.EXPECT().Metadata().Return(nil, failure)
+
+			assert.Equal(t, runner.handleRunPhase(result), failure)
+		})
+
+		t.Run("shouldExecuteRunPhase", func(t *testing.T) {
+			var collectedResult *neoResult
+			var collectedMetadata map[string]interface{}
+			collectMetadata = func(result *neoResult, metadata map[string]interface{}) {
+				collectedResult = result
+				collectedMetadata = metadata
+			}
+
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.runHandle).Return(gobolt.FetchTypeMetadata, nil)
+			connection.EXPECT().Fields().Return(fields, nil)
+			connection.EXPECT().Metadata().Return(metadata, nil)
+
+			assert.NoError(t, runner.handleRunPhase(result))
+
+			assert.Equal(t, result.keys, fields)
+			assert.Equal(t, collectedResult, result)
+			assert.Equal(t, collectedMetadata, metadata)
+			assert.True(t, result.runCompleted)
+		})
+	})
+
+	t.Run("handleRecordsPhase", func(t *testing.T) {
+		record := []interface{}{true, 1, "data"}
+		metadata := map[string]interface{}{"result_consumed_after": 1}
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldSkipIfRunIsCompleted", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+			result.resultCompleted = true
+
+			connection.EXPECT().Fetch(gomock.Any()).Times(0)
+			connection.EXPECT().Metadata().Times(0)
+			connection.EXPECT().Data().Times(0)
+
+			assert.NoError(t, runner.handleRecordsPhase(result))
+		})
+
+		t.Run("shouldFailWhenFetchFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.resultHandle).Return(gobolt.FetchType(0), failure)
+			connection.EXPECT().Metadata().Times(0)
+			connection.EXPECT().Data().Times(0)
+
+			assert.Equal(t, runner.handleRecordsPhase(result), failure)
+		})
+
+		t.Run("shouldFailOnFetchError", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.resultHandle).Return(gobolt.FetchTypeError, nil)
+			connection.EXPECT().Metadata().Times(0)
+			connection.EXPECT().Data().Times(0)
+
+			assert.EqualError(t, runner.handleRecordsPhase(result), "unable to fetch from connection")
+		})
+
+		t.Run("shouldFailWhenMetadataFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.resultHandle).Return(gobolt.FetchTypeMetadata, nil)
+			connection.EXPECT().Metadata().Return(nil, failure)
+			connection.EXPECT().Data().Times(0)
+
+			assert.Equal(t, runner.handleRecordsPhase(result), failure)
+		})
+
+		t.Run("shouldCompleteRecordPhaseOnMetadata", func(t *testing.T) {
+			var cmResult *neoResult
+			var cmMetadata map[string]interface{}
+			collectMetadata = func(result *neoResult, metadata map[string]interface{}) {
+				cmResult = result
+				cmMetadata = metadata
+			}
+
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.resultHandle).Return(gobolt.FetchTypeMetadata, nil)
+			connection.EXPECT().Metadata().Return(metadata, nil)
+
+			assert.NoError(t, runner.handleRecordsPhase(result))
+
+			assert.Equal(t, cmResult, result)
+			assert.Equal(t, cmMetadata, metadata)
+			assert.True(t, result.resultCompleted)
+		})
+
+		t.Run("shouldFailWhenDataFails", func(t *testing.T) {
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.resultHandle).Return(gobolt.FetchTypeRecord, nil)
+			connection.EXPECT().Data().Return(nil, failure)
+
+			assert.Equal(t, runner.handleRecordsPhase(result), failure)
+		})
+
+		t.Run("shouldCollectRecord", func(t *testing.T) {
+			var collectedResult *neoResult
+			var collectedFields []interface{}
+			collectRecord = func(result *neoResult, fields []interface{}) {
+				collectedResult = result
+				collectedFields = fields
+			}
+
+			ctrl, connection, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+
+			connection.EXPECT().Fetch(result.resultHandle).Return(gobolt.FetchTypeRecord, nil)
+			connection.EXPECT().Data().Return(record, nil)
+
+			assert.NoError(t, runner.handleRecordsPhase(result))
+			assert.Equal(t, collectedResult, result)
+			assert.Equal(t, collectedFields, record)
+		})
+	})
+
+	t.Run("receive", func(t *testing.T) {
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldFailWhenNoPendingResults", func(t *testing.T) {
+			ctrl, _, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			result, err := runner.receive()
+
+			assert.EqualError(t, err, "unexpected state: no pending results registered on session")
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenNoActiveConnection", func(t *testing.T) {
+			ctrl, _, runner := createMocks(t)
+			defer ctrl.Finish()
+
+			runner.pendingResults = append(runner.pendingResults, createResult(runner))
+
+			result, err := runner.receive()
+
+			assert.EqualError(t, err, "unexpected state: no open connection to perform receive")
+			assert.Nil(t, result)
+		})
+
+		t.Run("shouldFailWhenRunPhaseFails", func(t *testing.T) {
+			runPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				return failure
+			}
+			recordsPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				assert.Fail(t, "handleRecordPhase call is not expected")
+				return nil
+			}
+
+			ctrl, _, runner := createMocks(t)
+			runner.runPhaseHandler = runPhaseOverride
+			runner.recordsPhaseHandler = recordsPhaseOverride
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+			runner.pendingResults = append(runner.pendingResults, result)
+
+			recvdResult, err := runner.receive()
+
+			assert.Equal(t, err, failure)
+			assert.Nil(t, recvdResult)
+			assert.True(t, result.runCompleted)
+			assert.Equal(t, result.err, failure)
+		})
+
+		t.Run("shouldFailWhenRecordPhaseFails", func(t *testing.T) {
+			runPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				result.runCompleted = true
+				return nil
+			}
+			recordsPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				return failure
+			}
+
+			var testCases = []struct {
+				name      string
+				autoClose bool
+			}{
+				{"autoClose=true", true},
+				{"autoClose=false", false},
+			}
+
+			for _, testCase := range testCases {
+				t.Run(testCase.name, func(t *testing.T) {
+					ctrl, connection, runner := createMocksWithParams(t, AccessModeWrite, testCase.autoClose)
+					runner.runPhaseHandler = runPhaseOverride
+					runner.recordsPhaseHandler = recordsPhaseOverride
+					defer ctrl.Finish()
+
+					if testCase.autoClose {
+						// we expect auto-close logic to kick-in
+						connection.EXPECT().LastBookmark()
+						connection.EXPECT().Close()
+					}
+
+					result := createResultWithConn(runner)
+					runner.pendingResults = append(runner.pendingResults, result)
+
+					recvdResult, err := runner.receive()
+
+					// returned error should be the one from handleRecordsPhase
+					assert.Equal(t, err, failure)
+					assert.Nil(t, recvdResult)
+
+					// we should mark the result complete and store the error
+					assert.True(t, result.resultCompleted)
+					assert.Equal(t, result.err, failure)
+
+					// we should remove active result from the result queue
+					assert.Len(t, runner.pendingResults, 0)
+				})
+			}
+		})
+
+		t.Run("shouldReturnResult", func(t *testing.T) {
+			runPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				result.runCompleted = true
+				return nil
+			}
+			recordsPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				result.resultCompleted = true
+				return nil
+			}
+
+			ctrl, _, runner := createMocksWithParams(t, AccessModeRead, false)
+			runner.runPhaseHandler = runPhaseOverride
+			runner.recordsPhaseHandler = recordsPhaseOverride
+			defer ctrl.Finish()
+
+			result := createResultWithConn(runner)
+			runner.pendingResults = append(runner.pendingResults, result)
+
+			recvdResult, err := runner.receive()
+
+			// we should receive the actual record and no errors
+			assert.NoError(t, err)
+			assert.Equal(t, recvdResult, result)
+
+			// we should mark the result complete and store the error
+			assert.True(t, result.runCompleted)
+			assert.True(t, result.resultCompleted)
+			assert.NoError(t, result.err)
+
+			// we should remove active result from the result queue
+			assert.Len(t, runner.pendingResults, 0)
+		})
+	})
+
+	t.Run("receiveAll", func(t *testing.T) {
+		failure := fmt.Errorf("an unexpected error")
+
+		t.Run("shouldNotReceiveIfNoPendingResults", func(t *testing.T) {
+			receiveOverride := func(runner *statementRunner) (*neoResult, error) {
+				assert.Fail(t, "receive call unexpected here")
+				return nil, nil
+			}
+
+			ctrl, _, runner := createMocksWithParams(t, AccessModeRead, false)
+			runner.receiveHandler = receiveOverride
+			defer ctrl.Finish()
+
+			assert.NoError(t, runner.receiveAll())
+		})
+
+		t.Run("shouldReceiveAllResults", func(t *testing.T) {
+			runPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				result.runCompleted = true
+				return nil
+			}
+			recordsPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				result.resultCompleted = true
+				return nil
+			}
+
+			ctrl, _, runner := createMocksWithParams(t, AccessModeRead, false)
+			runner.runPhaseHandler = runPhaseOverride
+			runner.recordsPhaseHandler = recordsPhaseOverride
+			defer ctrl.Finish()
+
+			resultsPushed := []*neoResult{}
+			for i := 0; i < 10; i++ {
+				resultsPushed = append(resultsPushed, createResultWithConn(runner))
+			}
+
+			runner.pendingResults = append(runner.pendingResults, resultsPushed...)
+
+			err := runner.receiveAll()
+
+			assert.NoError(t, err)
+			assert.Empty(t, runner.pendingResults)
+		})
+
+		t.Run("shouldReceiveAllResultsEvenSomeResultsFailInRunPhase", func(t *testing.T) {
+			runs := 0
+			runPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				runs++
+				if runs%4 == 0 {
+					return failure
+				}
+				result.runCompleted = true
+				return nil
+			}
+			recordsPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				result.resultCompleted = true
+				return nil
+			}
+
+			ctrl, _, runner := createMocksWithParams(t, AccessModeRead, false)
+			runner.runPhaseHandler = runPhaseOverride
+			runner.recordsPhaseHandler = recordsPhaseOverride
+			defer ctrl.Finish()
+
+			resultsPushed := []*neoResult{}
+			for i := 0; i < 10; i++ {
+				resultsPushed = append(resultsPushed, createResultWithConn(runner))
+			}
+
+			runner.pendingResults = append(runner.pendingResults, resultsPushed...)
+
+			err := runner.receiveAll()
+
+			assert.Equal(t, err, failure)
+			assert.Empty(t, runner.pendingResults)
+		})
+
+		t.Run("shouldReceiveAllResultsEvenSomeResultsFailInRecordsPhase", func(t *testing.T) {
+			runPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				result.runCompleted = true
+				return nil
+			}
+			records := 0
+			recordsPhaseOverride := func(runner *statementRunner, result *neoResult) error {
+				records++
+				if records%4 == 0 {
+					return failure
+				}
+				result.resultCompleted = true
+				return nil
+			}
+
+			ctrl, _, runner := createMocksWithParams(t, AccessModeRead, false)
+			runner.runPhaseHandler = runPhaseOverride
+			runner.recordsPhaseHandler = recordsPhaseOverride
+			defer ctrl.Finish()
+
+			resultsPushed := []*neoResult{}
+			for i := 0; i < 10; i++ {
+				resultsPushed = append(resultsPushed, createResultWithConn(runner))
+			}
+
+			runner.pendingResults = append(runner.pendingResults, resultsPushed...)
+
+			err := runner.receiveAll()
+
+			assert.Equal(t, err, failure)
+			assert.Empty(t, runner.pendingResults)
+		})
+	})
+}

--- a/neo4j/session_impl.go
+++ b/neo4j/session_impl.go
@@ -97,7 +97,7 @@ func ensureRunner(session *neoSession, mode AccessMode, autoClose bool) error {
 // updates bookmark before actual closure
 func closeRunner(session *neoSession) error {
 	if session.runner != nil {
-		err := session.runner.closeConnection()
+		err := session.runner.receiveAllAndClose()
 
 		session.lastBookmark = session.runner.lastSeenBookmark()
 

--- a/neo4j/test-integration/stress_test.go
+++ b/neo4j/test-integration/stress_test.go
@@ -45,8 +45,8 @@ var _ = Describe("Stress Test", func() {
 			waiter.Add(1)
 
 			go func() {
-				defer GinkgoRecover()
 				defer waiter.Done()
+				defer GinkgoRecover()
 
 				var executor func(*stress.TestContext)
 				for !ctx.ShouldStop() {


### PR DESCRIPTION
When a session is closed before consuming results of executed statements, we previously did not handle pending results and directly close the underlying connection - which contradicts with behaviour from other official drivers.

A sample code snippet demonstrating the use case is as follows;

```golang
func closeSessionWithoutFirstProcessingResults(driver *neo4j.Driver) (neo4j.Result, error) {
  if session, err = driver.Session(neo4j.AccessModeRead); err != nil {
    return nil, err
  }
  defer session.Close()

  return session.Run("UNWIND RANGE(1,100) AS N RETURN N", nil)
}
```

This PR makes session to buffer all pending results into result buffers before closing the underlying connection and makes the results available should they be used. On the contrary, in case of an explicit transaction - the transaction will eventually be rolled back if neither `Commit` or `Rollback` is called.

_**It is important to note that closing sessions before processing executed statement results is not a good practice and should be avoided - it may hide underlying errors which would be visible otherwise.**_