### PR TITLE
Introduce workers in gobolt

### DIFF
--- a/neo4j/gobolt_driver_test.go
+++ b/neo4j/gobolt_driver_test.go
@@ -20,11 +20,12 @@
 package neo4j
 
 import (
+	"net/url"
+
 	. "github.com/neo4j/neo4j-go-driver/neo4j/utils/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"net/url"
 
 	"github.com/neo4j-drivers/gobolt"
 )
@@ -45,7 +46,7 @@ var _ = Describe("Driver", func() {
 				}
 
 				driver, err := newGoboltDriver(driverUrl, token, nil)
-				Expect(err).To(BeGenericError(ContainSubstring("unable to convert authentication token to connector value")))
+				Expect(err).To(BeGenericError(ContainSubstring("unable to convert authentication token:")))
 				Expect(driver).To(BeNil())
 			})
 		})

--- a/neo4j/mock_connection_test.go
+++ b/neo4j/mock_connection_test.go
@@ -56,10 +56,11 @@ func (m *MockConnection) EXPECT() *MockConnectionMockRecorder {
 }
 
 // Id connector-mocks base method
-func (m *MockConnection) Id() string {
+func (m *MockConnection) Id() (string, error) {
 	ret := m.ctrl.Call(m, "Id")
 	ret0, _ := ret[0].(string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Id indicates an expected call of Id
@@ -68,10 +69,11 @@ func (mr *MockConnectionMockRecorder) Id() *gomock.Call {
 }
 
 // RemoteAddress connector-mocks base method
-func (m *MockConnection) RemoteAddress() string {
+func (m *MockConnection) RemoteAddress() (string, error) {
 	ret := m.ctrl.Call(m, "RemoteAddress")
 	ret0, _ := ret[0].(string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RemoteAddress indicates an expected call of RemoteAddress
@@ -80,10 +82,11 @@ func (mr *MockConnectionMockRecorder) RemoteAddress() *gomock.Call {
 }
 
 // Server connector-mocks base method
-func (m *MockConnection) Server() string {
+func (m *MockConnection) Server() (string, error) {
 	ret := m.ctrl.Call(m, "Server")
 	ret0, _ := ret[0].(string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Server indicates an expected call of Server
@@ -194,10 +197,11 @@ func (mr *MockConnectionMockRecorder) Flush() *gomock.Call {
 }
 
 // LastBookmark connector-mocks base method
-func (m *MockConnection) LastBookmark() string {
+func (m *MockConnection) LastBookmark() (string, error) {
 	ret := m.ctrl.Call(m, "LastBookmark")
 	ret0, _ := ret[0].(string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // LastBookmark indicates an expected call of LastBookmark

--- a/neo4j/runner_test.go
+++ b/neo4j/runner_test.go
@@ -38,8 +38,8 @@ func TestRunner(t *testing.T) {
 		driver := newGoboltWithConnector("bolt://localhost", connector)
 		runner := newRunner(driver, mode, autoClose)
 
-		connection.EXPECT().RemoteAddress().Return("localhost:7687").AnyTimes()
-		connection.EXPECT().Server().Return("neo4j/3.5.0").AnyTimes()
+		connection.EXPECT().RemoteAddress().Return("localhost:7687", nil).AnyTimes()
+		connection.EXPECT().Server().Return("neo4j/3.5.0", nil).AnyTimes()
 
 		return ctrl, connection, runner
 	}
@@ -140,7 +140,7 @@ func TestRunner(t *testing.T) {
 		_ = runner.ensureConnection()
 
 		gomock.InOrder(
-			connection.EXPECT().LastBookmark().Return("a bookmark"),
+			connection.EXPECT().LastBookmark().Return("a bookmark", nil),
 			connection.EXPECT().Close(),
 		)
 
@@ -157,8 +157,9 @@ func TestRunner(t *testing.T) {
 		ctrl, _, runner := createMocks(t)
 		defer ctrl.Finish()
 
-		bookmark := runner.lastSeenBookmark()
+		bookmark, err := runner.lastSeenBookmark()
 
+		assert.NoError(t, err)
 		assert.Empty(t, bookmark)
 	})
 
@@ -168,8 +169,9 @@ func TestRunner(t *testing.T) {
 
 		runner.lastBookmark = "a bookmark"
 
-		bookmark := runner.lastSeenBookmark()
+		bookmark, err := runner.lastSeenBookmark()
 
+		assert.NoError(t, err)
 		assert.Equal(t, bookmark, "a bookmark")
 	})
 
@@ -180,10 +182,11 @@ func TestRunner(t *testing.T) {
 		_ = runner.ensureConnection()
 
 		runner.lastBookmark = "a bookmark 1"
-		connection.EXPECT().LastBookmark().Return("a bookmark 2")
+		connection.EXPECT().LastBookmark().Return("a bookmark 2", nil)
 
-		bookmark := runner.lastSeenBookmark()
+		bookmark, err := runner.lastSeenBookmark()
 
+		assert.NoError(t, err)
 		assert.Equal(t, bookmark, "a bookmark 2")
 	})
 

--- a/neo4j/session_impl.go
+++ b/neo4j/session_impl.go
@@ -97,9 +97,14 @@ func ensureRunner(session *neoSession, mode AccessMode, autoClose bool) error {
 // updates bookmark before actual closure
 func closeRunner(session *neoSession) error {
 	if session.runner != nil {
-		err := session.runner.receiveAllAndClose()
+		var err error
+		var bookmark string
 
-		session.lastBookmark = session.runner.lastSeenBookmark()
+		err = session.runner.receiveAllAndClose()
+
+		if bookmark, err = session.runner.lastSeenBookmark(); err == nil {
+			session.lastBookmark = bookmark
+		}
 
 		session.runner = nil
 		return err
@@ -110,7 +115,12 @@ func closeRunner(session *neoSession) error {
 
 func (session *neoSession) LastBookmark() string {
 	if session.runner != nil {
-		return session.runner.lastSeenBookmark()
+		var err error
+		var bookmark string
+
+		if bookmark, err = session.runner.lastSeenBookmark(); err == nil {
+			return bookmark
+		}
 	}
 
 	return session.lastBookmark


### PR DESCRIPTION
This PR introduces stability improvements for (very) large number of concurrent goroutines executing neo4j queries;

`gobolt` now has two different connection implementations - `workerConnection`s or the original `seaboltConnection`s. Original connections call seabolt functions directly on the executing goroutine, whereas worker connections are schedules calls in dedicated workers which are the only goroutines that call seabolt functions (and limiting the number of goroutines that are tied to native threads).

The **default** connection implementation is changed to be **worker connections** and this behaviour can be changed through `BOLTWORKERS` environment variable (`0` to revert to original mode, `1` (default) to enable worker connections). Worker pool sizing can be controlled through the following environment variables;

`BOLTWORKERS` (default: `1`): Whether to enable worker pool or use original implementation.
`BOLTWORKERSMIN` (default: `0`): Number of workers to pre-start on construction.
`BOLTWORKERSMAX` (default: `MaxPoolSize*1.2`): Number of workers to create at most. Requests will be blocked until a worker finishes its execution.
`BOLTWORKERSKEEPALIVE` (default: `5m`): When a worker has been idle this many amount of time, it will be terminated.

_Expect an overhead in execution times due to seabolt calls' being scheduled on a worker and blocking the executing goroutine until worker completes the scheduled job. **However, stability and throughput will improve when there are too many goroutines executing concurrent neo4j requests.**_