### PR TITLE
Improve retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,5 @@ type Logging interface {
 	Debugf(message string, args ...interface{})
 }
 ```
+
+For a customised logging target, you can implement the above interface and pass an instance of that implementation to the `Log` field.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package requires the following tools/libraries to be installed in order to 
 
 ### Compiler Toolchain
 
-Install C/C++ compiler toolchain supported by your operating system. You'll need a mingw toolchain (for instance MSYS2 from https://www.msys2.org/) for cgo support (seabolt include some instructions) on Windows.
+Install C/C++ compiler toolchain supported by your operating system. You'll need a mingw toolchain (for instance MSYS2 from https://www.msys2.org/) for cgo support (seabolt includes [instructions](https://github.com/neo4j-drivers/seabolt)) on Windows.
 
 ### Pkg-Config
 
@@ -22,15 +22,13 @@ Linux distributions provide `pkg-config` as part of their package management sys
 
 MacOS doesn't provide `pkg-config`, so have it installed through `brew install pkg-config`.
 
-Windows doesn't provide `pkg-config`, so have it installed by following [these instructions](https://stackoverflow.com/questions/1710922/how-to-install-pkg-config-in-windows?answertab=active#tab-top), make the `bin` folder available in PATH before any MSYS2 PATH entries.
+Windows doesn't provide `pkg-config`, so have it installed by following [these instructions](https://stackoverflow.com/questions/1710922/how-to-install-pkg-config-in-windows?answertab=active#tab-top), make the `bin` folder available in PATH before any MSYS2 PATH entries. *This is mandatory because `pkg-config` that ships with MSYS2 has some path handling problems*
 
 ### Seabolt
 
 #### Binaries
 
-We're now providing _**experimental**_ binaries for `Linux`, `MacOS` and `Windows` [here](https://github.com/neo4j-drivers/seabolt/releases). Please remember that `OpenSSL` is still a requirement for all of these systems. 
-
-Static linking against seabolt is only supported on **_Linux_** and **_MacOS_** at this time, and in order to get it working make sure you have static OpenSSL libraries, too.
+We're now providing _**experimental**_ binaries for `Linux`, `MacOS` and `Windows` [here](https://github.com/neo4j-drivers/seabolt/releases). Please remember that `OpenSSL` is a required dependency for `Linux` and `MacOS` - TLS on `Windows` depends on native SCHANNEL provider and doesn't require any additional third-party dependencies from version 1.7.3 onwards. 
 
 #### Source
 
@@ -54,9 +52,7 @@ Add the driver with `go get github.com/neo4j/neo4j-go-driver/neo4j`
 
 ## Static Linking
 
-We provide `seabolt_static` build tag to support static linking against seabolt and its dependencies. You can just pass `--tags seabolt_static` to your `go` toolset (like `go build --tags seabolt_static`) for your project and the output will not have any runtime dependency to `seabolt` and `openssl`.
-
-_**Static linking is currently not supported on Windows.**_
+We provide `seabolt_static` build tag to support static linking against seabolt and its dependencies. You can just pass `--tags seabolt_static` to your `go` toolset (like `go build --tags seabolt_static`) for your project and the generated binary will not have any runtime dependencies to `seabolt`.
 
 ## Setting RPATH on Linux/MacOS
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ For simplicity, we provide a predefined console logger which can be constructed 
 
 A simple code snippet that will enable console logging is as follows;
 
-```
+```go
 useConsoleLogger := func(level neo4j.LogLevel) func(config *neo4j.Config) {
 	return func(config *neo4j.Config) {
 		config.Log = neo4j.ConsoleLogger(level)
@@ -239,7 +239,7 @@ defer driver.Close()
 
 The `Log` field of the `neo4j.Config` struct is defined to be of interface `neo4j.Logging` which has the following definition.
 
-```
+```go
 type Logging interface {
 	ErrorEnabled() bool
 	WarningEnabled() bool

--- a/neo4j/retry.go
+++ b/neo4j/retry.go
@@ -21,6 +21,7 @@ package neo4j
 
 import (
 	"math/rand"
+	"strings"
 	"time"
 )
 
@@ -48,25 +49,36 @@ func computeDelayWithJitter(logic *retryLogic, delay time.Duration) time.Duratio
 	return nextDelay
 }
 
-func (logic *retryLogic) retry(work func() (interface{}, error)) (interface{}, error) {
+func (logic *retryLogic) retry(work func() (interface{}, string, error)) (interface{}, error) {
 	var result interface{}
 
+	count := 0
 	result = nil
+	id := "unknown"
 	err := error(nil)
-	startTime := time.Now()
+	suppressedErrors := make([]string, 0)
+	startTime := time.Time{}
 	nextDelay := logic.initialRetryDelay
 
 	for true {
-		result, err = work()
+		count++
+
+		result, id, err = work()
 		if err == nil {
 			return result, nil
 		}
 
 		if isRetriableError(err) {
+			suppressedErrors = append(suppressedErrors, err.Error())
+
+			if startTime.IsZero() {
+				startTime = time.Now()
+			}
+
 			elapsed := time.Since(startTime)
 			if elapsed < logic.maxRetryTime {
 				delayWithJitter := computeDelayWithJitter(logic, nextDelay)
-				warningf(logic.logging, "retriable operation failed to complete [error: %s] and will be retried in %dms", err.Error(), delayWithJitter.Nanoseconds()/int64(time.Millisecond))
+				warningf(logic.logging, "[%s]: retryable operation failed to complete [error: %s] and will be retried in %dms", id, err.Error(), delayWithJitter.Nanoseconds()/int64(time.Millisecond))
 				time.Sleep(delayWithJitter)
 				nextDelay = delayWithJitter
 				continue
@@ -76,5 +88,9 @@ func (logic *retryLogic) retry(work func() (interface{}, error)) (interface{}, e
 		break
 	}
 
-	return nil, err
+	if count == 1 {
+		return nil, err
+	}
+
+	return nil, newDriverError("[%s]: retryable operation failed to complete after %d tries, suppressed errors: [%s]", id, count, strings.Join(suppressedErrors, ", "))
 }

--- a/neo4j/retry_test.go
+++ b/neo4j/retry_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package neo4j
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryLogic(t *testing.T) {
+	type mockResult struct {
+		result interface{}
+		err    error
+	}
+
+	mockWork := func(delay time.Duration, id string, r ...mockResult) func() (interface{}, string, error) {
+		index := -1
+		return func() (interface{}, string, error) {
+			time.Sleep(delay)
+			index++
+			if index >= len(r) {
+				index = 0
+			}
+			return r[index].result, id, r[index].err
+		}
+	}
+
+	errorNotRetriable := fmt.Errorf("an un-retryable error")
+	errorRetriable := newDatabaseError("TransientError", "Neo.TransientError.Some.Error", "transient error")
+
+	t.Run("should return result from work if no errors", func(t *testing.T) {
+		retryLogic := newRetryLogic(&Config{})
+
+		result, err := retryLogic.retry(mockWork(0, "conn-1", mockResult{12, nil}))
+
+		assert.Equal(t, result, 12)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return error from work if error is not retriable", func(t *testing.T) {
+		retryLogic := newRetryLogic(&Config{})
+
+		result, err := retryLogic.retry(mockWork(0, "conn-1", mockResult{nil, errorNotRetriable}))
+
+		assert.Nil(t, result)
+		assert.Equal(t, err, errorNotRetriable)
+	})
+
+	t.Run("should not return result from work if error", func(t *testing.T) {
+		retryLogic := newRetryLogic(&Config{})
+
+		result, err := retryLogic.retry(mockWork(0, "conn-1", mockResult{12, errorNotRetriable}))
+
+		assert.Nil(t, result)
+		assert.Equal(t, err, errorNotRetriable)
+	})
+
+	t.Run("should retry on retriable error and return result upon successful completion", func(t *testing.T) {
+		retryLogic := newRetryLogic(&Config{MaxTransactionRetryTime: 5 * time.Second})
+
+		result, err := retryLogic.retry(mockWork(0, "conn-1", mockResult{nil, errorRetriable}, mockResult{12, nil}))
+
+		assert.Equal(t, result, 12)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return error on successive transient failures", func(t *testing.T) {
+		retryLogic := newRetryLogic(&Config{MaxTransactionRetryTime: 5 * time.Second})
+
+		result, err := retryLogic.retry(mockWork(2*time.Second, "conn-1", mockResult{nil, errorRetriable}))
+
+		assert.Nil(t, result)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "[conn-1]: retryable operation failed to complete after")
+		assert.Contains(t, err.Error(), fmt.Sprintf("[%s, %s", errorRetriable.Error(), errorRetriable.Error()))
+		assert.Contains(t, err.Error(), fmt.Sprintf(", %s]", errorRetriable.Error()))
+	})
+
+}

--- a/neo4j/runner.go
+++ b/neo4j/runner.go
@@ -66,6 +66,19 @@ func (runner *statementRunner) lastSeenBookmark() (string, error) {
 	return runner.lastBookmark, nil
 }
 
+func (runner *statementRunner) id() string {
+	var id = "unknown"
+	var err error
+
+	if runner.connection != nil {
+		if id, err = runner.connection.Id(); err != nil {
+			runner.driver.config.Log.Errorf("Id call on connection failed: %v", err)
+			id = "unknown[failed to get id]"
+		}
+	}
+	return id
+}
+
 func (runner *statementRunner) remoteAddress() string {
 	var remoteAddress = "unknown"
 	var err error

--- a/neo4j/test-integration/examples_test.go
+++ b/neo4j/test-integration/examples_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Examples", func() {
 			defer driver.Close()
 
 			err = createItem(driver)
-			Expect(err).To(test.BeServiceUnavailableError())
+			Expect(err).To(test.BeGenericError(ContainSubstring("retryable operation failed to complete after")))
 		})
 
 		Specify("Session", func() {

--- a/neo4j/test-integration/transaction_test.go
+++ b/neo4j/test-integration/transaction_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Transaction", func() {
 				return nil, transientError
 			})
 
-			Expect(err).To(Equal(transientError))
+			Expect(err).To(BeGenericError(And(ContainSubstring("retryable operation failed to complete after"), ContainSubstring("Neo.TransientError.Transaction.Outdated"))))
 			Expect(times).To(BeNumerically(">", 10))
 		})
 
@@ -86,7 +86,7 @@ var _ = Describe("Transaction", func() {
 				return nil, transientError
 			})
 
-			Expect(err).To(Equal(transientError))
+			Expect(err).To(BeGenericError(And(ContainSubstring("retryable operation failed to complete after"), ContainSubstring("Neo.TransientError.Transaction.Outdated"))))
 			Expect(times).To(BeNumerically(">", 10))
 		})
 	})

--- a/neo4j/test-stub/tx_test.go
+++ b/neo4j/test-stub/tx_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2018 "Neo4j,"
+ * Copyright (c) 2002-2019 "Neo4j,"
  * Neo4j Sweden AB [http://neo4j.com]
  *
  * This file is part of Neo4j.


### PR DESCRIPTION
This PR makes a couple of logging improvements on retries where now connection id is also logged and final returned error contains suppressed errors as well.

It also makes retry logic to execute the work unit at least 2 times (1 of them is the initial run) before bailing out due to maximum retry duration. 