### PR TITLE
Enable neo4j scheme

### DIFF
--- a/neo4j/driver.go
+++ b/neo4j/driver.go
@@ -52,8 +52,9 @@ type Driver interface {
 // In order to connect to a single instance database, you need to pass a URI with scheme 'bolt'
 //	driver, err = NewDriver("bolt://db.server:7687", BasicAuth(username, password))
 //
-// In order to connect to a causal cluster database, you need to pass a URI with scheme 'bolt+routing' and its host
-// part set to be one of the core cluster members.
+// In order to connect to a causal cluster database, you need to pass a URI with scheme 'bolt+routing' or 'neo4j'
+// and its host part set to be one of the core cluster members. Please note that 'bolt+routing' scheme will be
+// removed with 2.0 series of drivers.
 //	driver, err = NewDriver("bolt+routing://core.db.server:7687", BasicAuth(username, password))
 //
 // You can override default configuration options by providing a configuration function(s)
@@ -66,7 +67,7 @@ func NewDriver(target string, auth AuthToken, configurers ...func(*Config)) (Dri
 		return nil, err
 	}
 
-	if parsed.Scheme != "bolt" && parsed.Scheme != "bolt+routing" {
+	if parsed.Scheme != "bolt" && parsed.Scheme != "bolt+routing" && parsed.Scheme != "neo4j" {
 		return nil, newDriverError("url scheme %s is not supported", parsed.Scheme)
 	}
 

--- a/neo4j/driver_test.go
+++ b/neo4j/driver_test.go
@@ -20,12 +20,46 @@
 package neo4j
 
 import (
+	. "github.com/neo4j/neo4j-go-driver/neo4j/utils/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Driver", func() {
+
+	Context("URI", func() {
+		It("should support bolt:// scheme", func() {
+			driver, err := NewDriver("bolt://localhost:7687", NoAuth())
+
+			Expect(err).To(BeNil())
+			Expect(driver).NotTo(BeNil())
+			Expect(driver.Target().Scheme).To(BeIdenticalTo("bolt"))
+		})
+
+		It("should support bolt+routing:// scheme", func() {
+			driver, err := NewDriver("bolt+routing://localhost:7687", NoAuth())
+
+			Expect(err).To(BeNil())
+			Expect(driver).NotTo(BeNil())
+			Expect(driver.Target().Scheme).To(BeIdenticalTo("bolt+routing"))
+		})
+
+		It("should support neo4j:// scheme", func() {
+			driver, err := NewDriver("neo4j://localhost:7687", NoAuth())
+
+			Expect(err).To(BeNil())
+			Expect(driver).NotTo(BeNil())
+			Expect(driver.Target().Scheme).To(BeIdenticalTo("neo4j"))
+		})
+
+		It("should error anotherscheme:// scheme", func() {
+			driver, err := NewDriver("anotherscheme://localhost:7687", NoAuth())
+
+			Expect(driver).To(BeNil())
+			Expect(err).To(BeGenericError(ContainSubstring("url scheme anotherscheme is not supported")))
+		})
+	})
 
 	When("constructed with bolt://localhost:7687", func() {
 		driver, err := NewDriver("bolt://localhost:7687", NoAuth())


### PR DESCRIPTION
With 2.0 driver series, `bolt+routing` URL scheme will be removed and `neo4j` will be used instead. This is the PR that introduces `neo4j` scheme within 1.7 driver, so that users can start using it.