### PR TITLE
Limited boltv3 support

### DIFF
--- a/neo4j/api/record.go
+++ b/neo4j/api/record.go
@@ -17,33 +17,15 @@
  *  limitations under the License.
  */
 
-package packstream
+package api
 
-type StructTag byte
-
-type Struct interface {
-	Tag() StructTag
-	Fields() []interface{}
-}
-
-type rawStruct struct {
-	tag    StructTag
-	fields []interface{}
-}
-
-func (s *rawStruct) Tag() StructTag {
-	return s.tag
-}
-
-func (s *rawStruct) Fields() []interface{} {
-	return s.fields
-}
-
-func (s *rawStruct) HydrateField(f interface{}) error {
-	s.fields = append(s.fields, f)
-	return nil
-}
-
-func (s *rawStruct) HydrationComplete() error {
-	return nil
+type Record interface {
+	// Keys returns the keys available
+	Keys() []string
+	// Values returns the values
+	Values() []interface{}
+	// Get returns the value (if any) corresponding to the given key
+	//Get(key string) (interface{}, bool)
+	// GetByIndex returns the value at given index
+	//GetByIndex(index int) interface{}
 }

--- a/neo4j/api/result.go
+++ b/neo4j/api/result.go
@@ -17,33 +17,20 @@
  *  limitations under the License.
  */
 
-package packstream
+package api
 
-type StructTag byte
-
-type Struct interface {
-	Tag() StructTag
-	Fields() []interface{}
-}
-
-type rawStruct struct {
-	tag    StructTag
-	fields []interface{}
-}
-
-func (s *rawStruct) Tag() StructTag {
-	return s.tag
-}
-
-func (s *rawStruct) Fields() []interface{} {
-	return s.fields
-}
-
-func (s *rawStruct) HydrateField(f interface{}) error {
-	s.fields = append(s.fields, f)
-	return nil
-}
-
-func (s *rawStruct) HydrationComplete() error {
-	return nil
+type Result interface {
+	// Keys returns the keys available on the result set.
+	//Keys() ([]string, error)
+	// Next returns true only if there is a record to be processed.
+	Next() bool
+	// Err returns the latest error that caused this Next to return false.
+	Err() error
+	// Record returns the current record.
+	Record() Record
+	// Summary returns the summary information about the statement execution.
+	Summary() (ResultSummary, error)
+	// Consume consumes the entire result and returns the summary information
+	// about the statement execution.
+	//Consume() (ResultSummary, error)
 }

--- a/neo4j/api/resultsummary.go
+++ b/neo4j/api/resultsummary.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package api
+
+type ResultSummary interface {
+	// Server returns basic information about the server where the statement is carried out.
+	Server() ServerInfo
+	// Statement returns statement that has been executed.
+	Statement() Statement
+	// StatementType returns type of statement that has been executed.
+	//StatementType() StatementType
+	// Counters returns statistics counts for the statement.
+	//Counters() Counters
+	// Plan returns statement plan for the executed statement if available, otherwise null.
+	//Plan() Plan
+	// Profile returns profiled statement plan for the executed statement if available, otherwise null.
+	//Profile() ProfiledPlan
+	// Notifications returns a slice of notifications produced while executing the statement.
+	// The list will be empty if no notifications produced while executing the statement.
+	//Notifications() []Notification
+	// ResultAvailableAfter returns the time it took for the server to make the result available for consumption.
+	//ResultAvailableAfter() time.Duration
+	// ResultConsumedAfter returns the time it took the server to consume the result.
+	//ResultConsumedAfter() time.Duration
+}
+
+type Statement interface {
+	// Text returns the statement's text.
+	Text() string
+	// Params returns the statement's parameters.
+	Params() map[string]interface{}
+}
+
+// ServerInfo contains basic information of the server.
+type ServerInfo interface {
+	// Address returns the address of the server.
+	//Address() string
+	// Version returns the version of Neo4j running at the server.
+	Version() string
+}

--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/neo4j/neo4j-go-driver/neo4j/api"
+	"github.com/neo4j/neo4j-go-driver/neo4j/internal/packstream"
+)
+
+const (
+	msgV3Reset      packstream.StructTag = 0x0f
+	msgV3Run        packstream.StructTag = 0x10
+	msgV3DiscardAll packstream.StructTag = 0x2f
+	msgV3PullAll    packstream.StructTag = 0x3f
+	msgV3Record     packstream.StructTag = 0x71
+	msgV3Success    packstream.StructTag = 0x70
+	msgV3Ignored    packstream.StructTag = 0x7e
+	msgV3Failure    packstream.StructTag = 0x7f
+	msgV3Hello      packstream.StructTag = 0x01
+	msgV3Goodbye    packstream.StructTag = 0x02
+	msgV3Begin      packstream.StructTag = 0x11
+	msgV3Commit     packstream.StructTag = 0x12
+	msgV3Rollback   packstream.StructTag = 0x13
+)
+
+const userAgent = "Go Driver/1.8"
+
+// State that belongs to a certain session. Upon reset this state is wiped.
+// All members should have a default value that gets a proper value with empty init.
+type sessionState struct {
+	//isInTx     bool
+	isMessedUp bool
+	result     *result
+	cypher     string
+	params     map[string]interface{}
+}
+
+type bolt3 struct {
+	conn          net.Conn
+	chunker       *chunker
+	connected     bool
+	packer        *packstream.Packer
+	unpacker      *packstream.Unpacker
+	state         sessionState
+	connId        string
+	serverVersion string
+}
+
+func NewBolt3(conn net.Conn) *bolt3 {
+	// Wrap connection reading/writing in chunk reader/writer
+	chunker := newChunker(conn, 4096)
+	dechunker := newDechunker(conn)
+
+	return &bolt3{
+		conn:     conn,
+		chunker:  chunker,
+		packer:   packstream.NewPacker(chunker),
+		unpacker: packstream.NewUnpacker(dechunker),
+	}
+}
+
+func (b *bolt3) appendMsg(tag packstream.StructTag, field ...interface{}) error {
+	// Each message in it's own chunk
+	b.chunker.add()
+	// Setup the message and let packstream write the packed bytes to the chunk
+	err := b.packer.PackStruct(tag, field...)
+	if err != nil {
+		// At this point we do not know the state of what has been written to the chunks.
+		// Either we should support rolling back whatever that has been written or just
+		// bail out this session.
+		b.state.isMessedUp = true
+		return err
+	}
+	return nil
+}
+
+// TODO: Error types!
+func (b *bolt3) connect() error {
+	// Server is assumed to be in CONNECTED state, send hello message with proper authentication
+	// info to the server to make it transition into READY
+	err := b.appendMsg(
+		msgV3Hello,
+		map[string]interface{}{
+			"user_agent":  userAgent,
+			"scheme":      "basic",
+			"principal":   "neo4j",
+			"credentials": "pass",
+		})
+	if err != nil {
+		return err
+	}
+	err = b.chunker.send()
+	if err != nil {
+		return err
+	}
+
+	// Read response from server
+	res, err := b.unpacker.UnpackStruct(b)
+	if err != nil {
+		return err
+	}
+	switch v := res.(type) {
+	case *successResponse:
+		b.connId, b.serverVersion, err = b.successResponseToConnectionInfo(v)
+		if err != nil {
+			return err
+		}
+		b.connected = true
+		return nil
+	case *failureResponse:
+		return errors.New("Received failure from server")
+	case *ignoredResponse:
+		return errors.New("Received ignored from server")
+	default:
+		return errors.New("Unknown response")
+	}
+}
+
+func (b *bolt3) RunAutoCommit(cypher string, params map[string]interface{} /*, timeout time.Duration, metadata map[string]interface{}*/) (api.Result, error) {
+	if !b.connected || b.state.isMessedUp {
+		return nil, errors.New("Not alive")
+	}
+
+	// TODO: Ensure no transaction open already
+
+	// If there is a pending result, ask the result to pull and discard all records before proceeding.
+	// TODO: Use DiscardAll message?
+	if b.state.result != nil {
+		b.state.result.ConsumeAll()
+		b.state.result = nil
+	}
+
+	// Send request to run query along with request to stream the result
+	// TODO: Meta data
+	err := b.appendMsg(msgV3Run,
+		cypher,
+		params,
+		map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+	err = b.appendMsg(msgV3PullAll)
+	if err != nil {
+		return nil, err
+	}
+
+	err = b.chunker.send()
+	if err != nil {
+		return nil, err
+	}
+
+	// Read Run response from server
+	res, err := b.unpacker.UnpackStruct(b)
+	if err != nil {
+		return nil, err
+	}
+	switch v := res.(type) {
+	case *successResponse:
+		b.state.result, err = b.successResponseToResult(v)
+		if err != nil {
+			b.state.isMessedUp = true
+			return nil, err
+		}
+		b.state.cypher = cypher
+		b.state.params = params
+		return b.state.result, nil
+	case *failureResponse:
+		// Returning here assumes that we don't get any response on the pull message
+		// Check code to determine if we're messed up, retry logic should be handled in session.
+		return nil, v
+	default:
+		b.state.isMessedUp = true
+		return nil, errors.New("Unexpected response")
+	}
+}
+
+// Try to create a response from a success response.
+func (b *bolt3) successResponseToResult(r *successResponse) (*result, error) {
+	m := r.Map()
+	// Should be a list of keys returned from query
+	keysx, ok := m["fields"].([]interface{})
+	if !ok {
+		return nil, errors.New("Missing fields in success response")
+	}
+	// Transform keys to proper format
+	keys := make([]string, len(keysx))
+	for i, x := range keysx {
+		keys[i], ok = x.(string)
+		if !ok {
+			return nil, errors.New("Field is not string")
+		}
+	}
+	return newResult(keys, b.readRecord), nil
+}
+
+func (b *bolt3) successResponseToConnectionInfo(r *successResponse) (string, string, error) {
+	m := r.Map()
+	id, ok := m["connection_id"].(string)
+	if !ok {
+		return "", "", errors.New("Missing connection id in success response")
+	}
+	server, ok := m["server"].(string)
+	if !ok {
+		return "", "", errors.New("Missing server in success response")
+	}
+	return id, server, nil
+}
+
+func (b *bolt3) successResponseToSummary(r *successResponse) (*summary, error) {
+	m := r.Map()
+	// Should be a bookmark
+	bm, ok := m["bookmark"].(string)
+	if !ok {
+		return nil, errors.New("Missing bookmark")
+	}
+	// Should be a statement type
+	st, ok := m["type"].(string)
+	if !ok {
+		return nil, errors.New("Missing stmnt type")
+	}
+	return &summary{
+		bookmark:      bm,
+		stmntType:     st,
+		cypher:        b.state.cypher,
+		params:        b.state.params,
+		serverVersion: b.serverVersion,
+	}, nil
+}
+
+// Reads one record from the stream.
+func (b *bolt3) readRecord() (*record, *summary, error) {
+	res, err := b.unpacker.UnpackStruct(b)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch x := res.(type) {
+	case *recordResponse:
+		rec := &record{keys: b.state.result.keys, values: x.fields[0].([]interface{})}
+		return rec, nil, nil
+	case *successResponse:
+		sum, err := b.successResponseToSummary(x)
+		if err != nil {
+			b.state.isMessedUp = true
+			return nil, nil, err
+		}
+		return nil, sum, nil
+	case *failureResponse:
+		// Returning here assumes that we don't get any response on the pull message
+		return nil, nil, x
+	default:
+		return nil, nil, errors.New("Unknown response")
+	}
+}
+
+func (b *bolt3) IsAlive() bool {
+	return b.connected && !b.state.isMessedUp
+}
+
+func (b *bolt3) Close() error {
+	// Already closed?
+	if !b.connected {
+		return nil
+	}
+
+	// TODO: Pending result?
+
+	var errs []error
+
+	// Append goodbye message to existing chunks
+	err := b.packer.PackStruct(msgV3Goodbye)
+	if err != nil {
+		// Still need to close the connection and send all pending messages that might be critical.
+		// So just remember the error and continue. Should return this error to client!
+		errs = append(errs, err)
+	}
+
+	// Send all pending messages
+	err = b.chunker.send()
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	// Close the connection
+	err = b.conn.Close()
+	b.connected = false
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return errs[0]
+	}
+	return nil
+}
+
+// Hydrator implements packstream HydratorFactory which gives this connection full control
+// over how structs are hydrated during stream unpacking.
+func (b *bolt3) Hydrator(tag packstream.StructTag, numFields int) (packstream.Hydrator, error) {
+	switch tag {
+	case msgV3Success:
+		return &successResponse{}, nil
+	case msgV3Ignored:
+		return &ignoredResponse{}, nil
+	case msgV3Failure:
+		return &failureResponse{}, nil
+	case msgV3Record:
+		return &recordResponse{}, nil
+	case 'N':
+		return &node{}, nil
+	default:
+		return nil, errors.New(fmt.Sprintf("Unknown tag: %02x", tag))
+	}
+}

--- a/neo4j/internal/bolt/bolt3_test.go
+++ b/neo4j/internal/bolt/bolt3_test.go
@@ -17,33 +17,22 @@
  *  limitations under the License.
  */
 
-package packstream
+package bolt
 
-type StructTag byte
+// bolt3.connect is tested through Connect, no need to test it herekk
 
-type Struct interface {
-	Tag() StructTag
-	Fields() []interface{}
-}
-
-type rawStruct struct {
-	tag    StructTag
-	fields []interface{}
-}
-
-func (s *rawStruct) Tag() StructTag {
-	return s.tag
-}
-
-func (s *rawStruct) Fields() []interface{} {
-	return s.fields
-}
-
-func (s *rawStruct) HydrateField(f interface{}) error {
-	s.fields = append(s.fields, f)
-	return nil
-}
-
-func (s *rawStruct) HydrationComplete() error {
-	return nil
-}
+// TODO: test RunAutoCommit
+//       happy path
+//       syntax error, RUN fails with client error
+//       locking error, RUN fails with retryable error
+//       transaction open
+//       not alive
+//       unconsumed result
+//       no response
+//       unexpected response
+// TODO: test IsAlive
+//       different error condtions that can make it not be alive
+// TODO: test Close
+//       unconsumed result
+//       already closed
+//       goodbye failure

--- a/neo4j/internal/bolt/chunker.go
+++ b/neo4j/internal/bolt/chunker.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type chunker struct {
+	wr     io.Writer
+	size   int
+	chunks [][]byte
+}
+
+func newChunker(wr io.Writer, size int) *chunker {
+	return &chunker{
+		wr:     wr,
+		size:   size + 2,
+		chunks: make([][]byte, 0, 2),
+	}
+}
+
+func (c *chunker) add() {
+	chunk := make([]byte, 0, c.size)
+	chunk = append(chunk, 0x00, 0x00)
+	c.chunks = append(c.chunks, chunk)
+}
+
+// Writes to current chunk or creates new chunks as needed.
+func (c *chunker) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	// First chunk?
+	if len(c.chunks) == 0 {
+		c.add()
+	}
+
+	written := 0
+	for len(p) > 0 {
+		index := len(c.chunks) - 1
+		chunk := c.chunks[index]
+
+		currChunkSize := len(chunk)
+		leftInChunk := c.size - currChunkSize
+
+		// There is room left in current chunk to write all
+		if len(p) <= leftInChunk {
+			c.chunks[index] = append(chunk, p...)
+			written += len(p)
+			return written, nil
+		}
+
+		c.chunks[index] = append(chunk, p[:leftInChunk]...)
+		written += leftInChunk
+		p = p[leftInChunk:]
+		c.add()
+	}
+
+	return written, nil
+}
+
+// Sends all chunks to server
+func (c *chunker) send() error {
+	// Discard chunks while writing them
+	for len(c.chunks) > 0 {
+		// Pop chunk
+		chunk := c.chunks[0]
+		c.chunks = c.chunks[1:]
+
+		// First two bytes is size of chunk, needs to be updated
+		// Last two bytes should always be zero. Size only includes
+		// user data, not size itself or trailing zeroes.
+		size := uint16(len(chunk) - 2)
+		if size == 0 {
+			// No need for empty chunks
+			continue
+		}
+		binary.BigEndian.PutUint16(chunk, size)
+		chunk = append(chunk, 0x00, 0x00)
+
+		// Write chunk to underlying writer (probably the TCP connection)
+		_, err := c.wr.Write(chunk)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Discards all chunks
+func (c *chunker) reset() {
+	// Preserve capacity
+	c.chunks = c.chunks[:0]
+}

--- a/neo4j/internal/bolt/chunker_test.go
+++ b/neo4j/internal/bolt/chunker_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+type chunkReceiver struct {
+	chunks [][]byte
+}
+
+func (r *chunkReceiver) Write(p []byte) (int, error) {
+	r.chunks = append(r.chunks, p)
+	return len(p), nil
+}
+
+func TestChunker(ot *testing.T) {
+	cases := []struct {
+		name   string
+		size   int
+		writes [][]byte
+		chunks [][]byte
+	}{
+		{
+			name:   "zero writes",
+			size:   1,
+			writes: [][]byte{},
+			chunks: [][]byte{},
+		},
+		{
+			name:   "1 write 1/2 of size",
+			size:   2,
+			writes: [][]byte{{0x01}},
+			chunks: [][]byte{{0x00, 0x01, 0x01, 0x00, 0x00}},
+		},
+		{
+			name:   "1 write 2/2 of size",
+			size:   2,
+			writes: [][]byte{{0x01, 0x02}},
+			chunks: [][]byte{{0x00, 0x02, 0x01, 0x02, 0x00, 0x00}},
+		},
+		{
+			name:   "1 write 3/2 of size",
+			size:   2,
+			writes: [][]byte{{0x01, 0x02, 0x03}},
+			chunks: [][]byte{
+				{0x00, 0x02, 0x01, 0x02, 0x00, 0x00},
+				{0x00, 0x01, 0x03, 0x00, 0x00},
+			},
+		},
+		{
+			name:   "1 write 7/2 of size",
+			size:   2,
+			writes: [][]byte{{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}},
+			chunks: [][]byte{
+				{0x00, 0x02, 0x01, 0x02, 0x00, 0x00},
+				{0x00, 0x02, 0x03, 0x04, 0x00, 0x00},
+				{0x00, 0x02, 0x05, 0x06, 0x00, 0x00},
+				{0x00, 0x01, 0x07, 0x00, 0x00},
+			},
+		},
+		{
+			name:   "multiple writes 7/2 of size",
+			size:   2,
+			writes: [][]byte{{0x01}, []byte{0x02, 0x03, 0x04}, []byte{05, 06}, []byte{0x07}},
+			chunks: [][]byte{
+				{0x00, 0x02, 0x01, 0x02, 0x00, 0x00},
+				{0x00, 0x02, 0x03, 0x04, 0x00, 0x00},
+				{0x00, 0x02, 0x05, 0x06, 0x00, 0x00},
+				{0x00, 0x01, 0x07, 0x00, 0x00},
+			},
+		},
+		{
+			name:   "multiple writes 7/3 of size",
+			size:   3,
+			writes: [][]byte{{0x01}, []byte{0x02, 0x03, 0x04}, []byte{05, 06}, []byte{0x07}},
+			chunks: [][]byte{
+				{0x00, 0x03, 0x01, 0x02, 0x03, 0x00, 0x00},
+				{0x00, 0x03, 0x04, 0x05, 0x06, 0x00, 0x00},
+				{0x00, 0x01, 0x07, 0x00, 0x00},
+			},
+		},
+	}
+	for _, c := range cases {
+		ot.Run(fmt.Sprintf("Chunking %s", c.name), func(t *testing.T) {
+			rec := &chunkReceiver{}
+			chunker := newChunker(rec, c.size)
+			chunker.add()
+			for _, p := range c.writes {
+				chunker.Write(p)
+			}
+			chunker.send()
+
+			// Check what has been received
+			if len(rec.chunks) != len(c.chunks) {
+				t.Fatalf("Wrong number of sent chunks, expected %d but was %d", len(c.chunks), len(rec.chunks))
+			}
+			for i, x := range rec.chunks {
+				if bytes.Compare(c.chunks[i], x) != 0 {
+					t.Errorf("Received chunk %d differs. Expected:\n%+v\nBut was:\n%+v", i, c.chunks[i], x)
+				}
+			}
+		})
+	}
+}

--- a/neo4j/internal/bolt/connect.go
+++ b/neo4j/internal/bolt/connect.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/neo4j/neo4j-go-driver/neo4j/internal/connection"
+)
+
+// Negotiate version of bolt protocol.
+// Closes the provided connection if any error is encountered.
+func Connect(conn net.Conn) (connection.Connection, error) {
+	// TODO: Use deadline read/write
+
+	// Perform Bolt handshake to negotiate version
+	// Send handshake to server
+	handshake := []byte{
+		0x60, 0x60, 0xb0, 0x17, // Magic: GoGoBolt
+		0x00, 0x00, 0x00, 0x03, // Versions in priority order, big endian.
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00}
+	_, err := conn.Write(handshake)
+	if err != nil {
+		return nil, err
+	}
+
+	// Receive accepted server version
+	buf := make([]byte, 4)
+	_, err = io.ReadFull(conn, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse received version and construct the correct instance
+	ver := binary.BigEndian.Uint32(buf)
+	switch ver {
+	case 3:
+		// Handover rest of connection handshaking
+		boltConn := NewBolt3(conn)
+		err = boltConn.connect()
+		if err != nil {
+			// Make sure that the connection is closed!
+			conn.Close()
+			return nil, err
+		}
+		return boltConn, nil
+	case 0:
+		return nil, errors.New("No matching version")
+	default:
+		return nil, errors.New(fmt.Sprintf("Unsupported version: %d", ver))
+	}
+}

--- a/neo4j/internal/bolt/connect_test.go
+++ b/neo4j/internal/bolt/connect_test.go
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/neo4j/neo4j-go-driver/neo4j/api"
+	"github.com/neo4j/neo4j-go-driver/neo4j/internal/connection"
+	"github.com/neo4j/neo4j-go-driver/neo4j/internal/packstream"
+)
+
+type testHydrator struct {
+}
+
+type testHydrated struct {
+	tag    packstream.StructTag
+	fields []interface{}
+}
+
+func (r *testHydrated) HydrateField(field interface{}) error {
+	r.fields = append(r.fields, field)
+	return nil
+}
+
+func (r *testHydrated) HydrationComplete() error {
+	return nil
+}
+
+func (h *testHydrator) Hydrator(tag packstream.StructTag, numFields int) (packstream.Hydrator, error) {
+	return &testHydrated{tag: tag}, nil
+}
+
+func TestConnectBolt3(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	// TODO: Test version handshake failure, connection should close
+	// TODO: Test authentication failure, connection should close (bolt3 test?)
+	// TODO: Test connect timeout
+
+	// Use a real TCP connection. Alternative is to use net.Pipe but that works a bit different
+	// in regards to buffering, chunking causes some problems with pipe since number of reads
+	// doesn''t correspond to number of writes.
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Unable to listen: %s", err)
+	}
+
+	// Simulate server with a succesful connect
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			t.Fatalf("Accept error: %s", err)
+		}
+
+		// Wait for initial handshake
+		handshake := make([]byte, 4*5)
+		_, err = io.ReadFull(conn, handshake)
+		if err != nil {
+			t.Fatalf("Server got a read error: %s", err)
+		}
+		// There should be a version 3 somewhere
+		foundV3 := false
+		for i := 0; i < 5; i++ {
+			ver := handshake[(i * 4) : (i*4)+4]
+			if ver[3] == 3 {
+				foundV3 = true
+			}
+		}
+		if !foundV3 {
+			t.Fatalf("Didn't find version 3 in handshake: %+v", handshake)
+		}
+
+		// Accept bolt version 3
+		ver3 := []byte{0x00, 0x00, 0x00, 0x03}
+		_, err = conn.Write(ver3)
+		if err != nil {
+			t.Fatalf("Failed to send version")
+		}
+
+		// Need unpacker, hydrator and a dechunker now
+		dechunker := newDechunker(conn)
+		unpacker := packstream.NewUnpacker(dechunker)
+		hyd := &testHydrator{}
+
+		// Wait for hello
+		x, err := unpacker.UnpackStruct(hyd)
+		if err != nil {
+			t.Fatalf("Server couldn't parse hello")
+		}
+		hello := x.(*testHydrated)
+		m := hello.fields[0].(map[string]interface{})
+		// Hello should contain some musts
+		_, exists := m["scheme"]
+		if !exists {
+			t.Errorf("Missing scheme")
+		}
+		_, exists = m["user_agent"]
+		if !exists {
+			t.Errorf("Missing user_agent")
+		}
+
+		// Need packer and a chunker now
+		chunker := newChunker(conn, 4096)
+		packer := packstream.NewPacker(chunker)
+
+		// Accept
+		packer.PackStruct(msgV3Success, map[string]interface{}{
+			"connection_id": "cid",
+			"server":        "fake/3.5",
+		})
+		chunker.send()
+
+		wg.Done()
+	}()
+
+	// Connect to server
+	addr := l.Addr()
+	conn, err := net.Dial(addr.Network(), addr.String())
+
+	// Pass the connection to bolt connect
+	boltconn, err := Connect(conn)
+	if err != nil {
+		t.Fatalf("Failed to connect bolt: %s", err)
+	}
+
+	boltconn.Close()
+
+	wg.Wait()
+}
+
+func dumpResult(res api.Result) error {
+	for res.Next() {
+		rec := res.Record()
+		keys := rec.Keys()
+		fmt.Println("RECORD")
+		for i, x := range rec.Values() {
+			fmt.Printf("    %s: %+v\n", keys[i], x)
+		}
+	}
+	err := res.Err()
+	if err != nil {
+		return err
+	}
+
+	sum, err := res.Summary()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Server version: %s\n", sum.Server().Version())
+
+	stmnt := sum.Statement()
+	fmt.Printf("Cypher: %s\nParams: %+v\n", stmnt.Text(), stmnt.Params())
+
+	return nil
+}
+
+func TestOnRealServer(t *testing.T) {
+	t.SkipNow()
+
+	tcpConn, err := connection.OpenTcp()
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	// Pass ownership of TCP connection to bolt upon success
+	boltConn, err := Connect(tcpConn)
+	if err != nil {
+		t.Fatalf("Failed to connect: %s", err)
+	}
+
+	// Run query
+	fmt.Println("Match")
+	res, err := boltConn.RunAutoCommit("MATCH (n) RETURN n", nil)
+	if err != nil {
+		t.Fatalf("Run failed: %s", err)
+	}
+	err = dumpResult(res)
+	if err != nil {
+		t.Errorf("Got err: %s", err)
+	}
+
+	// Run create statement
+	fmt.Println("Create")
+	params := map[string]interface{}{"rnd": rand.Int()}
+	res, err = boltConn.RunAutoCommit("CREATE (n:Random {val: $rnd})", params)
+	if err != nil {
+		t.Fatalf("Run failed: %s", err)
+	}
+	err = dumpResult(res)
+	if err != nil {
+		t.Errorf("Got err: %s", err)
+	}
+
+	err = boltConn.Close()
+	if err != nil {
+		t.Errorf("Failed to close: %s", err)
+	}
+	if boltConn.IsAlive() {
+		t.Errorf("Connection should be dead")
+	}
+
+	//t.Fail()
+}

--- a/neo4j/internal/bolt/dechunker.go
+++ b/neo4j/internal/bolt/dechunker.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type dechunker struct {
+	rd   io.Reader
+	size int // Size of current chunk or -1 if no current
+}
+
+func newDechunker(rd io.Reader) *dechunker {
+	return &dechunker{
+		rd:   rd,
+		size: -1,
+	}
+}
+
+func (d *dechunker) Read(p []byte) (n int, err error) {
+	// Read end of chunk zeroes
+	if d.size == 0 {
+		buf := []byte{0x00, 0x00}
+		_, err := io.ReadFull(d.rd, buf)
+		if err != nil {
+			return 0, err
+		}
+		d.size = -1
+	}
+
+	// Read chunk length if not in a chunk already
+	if d.size == -1 {
+		buf := []byte{0x00, 0x00}
+		_, err := io.ReadFull(d.rd, buf)
+		if err != nil {
+			return 0, err
+		}
+		d.size = int(binary.BigEndian.Uint16(buf))
+	}
+
+	// Just forward read to underlying reader and count off the bytes.
+	// BUT don't read more than what's left of the current chunk.
+	if len(p) > d.size {
+		p = p[:d.size]
+	}
+	n, err = d.rd.Read(p)
+	d.size -= n
+	return n, err
+}

--- a/neo4j/internal/bolt/dechunker_test.go
+++ b/neo4j/internal/bolt/dechunker_test.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestDechunker(ot *testing.T) {
+	cases := []struct {
+		name     string
+		stream   []byte
+		reads    []int
+		expected []byte
+	}{
+		{
+			name: "one byte",
+			stream: []byte{
+				0x00, 0x02, 0x66, 0x77, 0x00, 0x00, // Chunk of size 2
+			},
+			reads:    []int{1},
+			expected: []byte{0x66},
+		},
+		{
+			name: "all bytes in chunk, two reads",
+			stream: []byte{
+				0x00, 0x02, 0x66, 0x77, 0x00, 0x00, // Chunk of size 2
+			},
+			reads:    []int{1, 1},
+			expected: []byte{0x66, 0x77},
+		},
+		{
+			name: "all bytes in two chunks, one read",
+			stream: []byte{
+				0x00, 0x02, 0x66, 0x77, 0x00, 0x00, // Chunk of size 2
+				0x00, 0x02, 0x88, 0x99, 0x00, 0x00, // Chunk of size 2
+			},
+			reads:    []int{4},
+			expected: []byte{0x66, 0x77, 0x88, 0x99},
+		},
+		{
+			name: "all bytes in two chunks, evil reads",
+			stream: []byte{
+				0x00, 0x03, 0x11, 0x22, 0x33, 0x00, 0x00, // Chunk of size 3
+				0x00, 0x07, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0x00, 0x00, // Chunk of size 7
+			},
+			reads:    []int{1, 4, 2, 3},
+			expected: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa},
+		},
+	}
+
+	for _, c := range cases {
+		ot.Run(fmt.Sprintf("Dechunk %s", c.name), func(t *testing.T) {
+			// Initialize underlying reader, typically corresponds to reading from network.
+			urd := bytes.NewBuffer(c.stream)
+
+			dec := newDechunker(urd)
+
+			// Perform the reads as specified in test case
+			res := make([]byte, 0)
+			for i, r := range c.reads {
+				// Make an output buffer same size as current read operation.
+				// The result in this buffer should be same size as in the test case.
+				buf := make([]byte, r)
+				// Use io.ReadFull to emulate how a real consumer would use the reader in
+				// a correct way (probably by also using io.ReadFull). Since it is up to the Read
+				// implementation how many actual reads that are needed we shouldn't test the
+				// exact behaviour of the dechunker but that it behaves correctly.
+				n, err := io.ReadFull(dec, buf)
+				if err != nil {
+					t.Fatalf("Unexpected read %d error: %s", i, err)
+				}
+				if n != r {
+					t.Fatalf("Length of read %d differs, expected %d but was %d", i, r, n)
+				}
+				res = append(res, buf...)
+			}
+			if !bytes.Equal(res, c.expected) {
+				t.Errorf("Buffer differs, expected %+v but was %+v", c.expected, res)
+			}
+		})
+	}
+}

--- a/neo4j/internal/bolt/node.go
+++ b/neo4j/internal/bolt/node.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"errors"
+)
+
+type node struct {
+	state int
+	id    int64
+	tags  []string
+	props map[string]interface{}
+}
+
+func (n *node) Id() int64 {
+	return n.id
+}
+
+func (n *node) Labels() []string {
+	return n.tags
+}
+
+func (n *node) Props() map[string]interface{} {
+	return n.props
+}
+
+func (n *node) HydrateField(field interface{}) error {
+	switch n.state {
+	case 0:
+		id, ok := field.(int64)
+		if !ok {
+			return errors.New("Expected id of type int64")
+		}
+		n.id = id
+	case 1:
+		tagsx, ok := field.([]interface{})
+		if !ok {
+			return errors.New("Expected list of tags")
+		}
+		n.tags = make([]string, len(tagsx))
+		for i, x := range tagsx {
+			tag, ok := x.(string)
+			if !ok {
+				return errors.New("Tag is not string")
+			}
+			n.tags[i] = tag
+		}
+	case 2:
+		props, ok := field.(map[string]interface{})
+		if !ok {
+			return errors.New("Expected map of props")
+		}
+		n.props = props
+	default:
+		return errors.New("Got more than expected")
+	}
+
+	n.state += 1
+	return nil
+}
+
+func (n *node) HydrationComplete() error {
+	if n.state != 3 {
+		return errors.New("Missing fields")
+	}
+	return nil
+}

--- a/neo4j/internal/bolt/node_test.go
+++ b/neo4j/internal/bolt/node_test.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestNodeHydration(ot *testing.T) {
+	cases := []struct {
+		name          string
+		fields        []interface{}
+		fieldErrors   []error
+		completeError error
+		node          *node
+	}{
+		{
+			name: "happy",
+			fields: []interface{}{
+				int64(1),
+				[]interface{}{"Person"},
+				map[string]interface{}{"age": 29},
+			},
+			node: &node{
+				id:    1,
+				tags:  []string{"Person"},
+				props: map[string]interface{}{"age": 29},
+			},
+		},
+		{
+			name:          "no fields",
+			completeError: errors.New("something"),
+		},
+		{
+			name:        "id wrong type",
+			fields:      []interface{}{"1"},
+			fieldErrors: []error{errors.New("1")},
+		},
+		{
+			name:        "labels wrong type",
+			fields:      []interface{}{int64(1), "Person"},
+			fieldErrors: []error{nil, errors.New("Label")},
+		},
+		{
+			name:        "props wrong type",
+			fields:      []interface{}{int64(1), []interface{}{"Person"}, "props"},
+			fieldErrors: []error{nil, nil, errors.New("Label")},
+		},
+	}
+
+	for _, c := range cases {
+		ot.Run(c.name, func(t *testing.T) {
+			n := &node{}
+			var err error
+			for i, f := range c.fields {
+				// Hydrate field
+				err = n.HydrateField(f)
+				// Check against expected error
+				var expectErr error
+				if i < len(c.fieldErrors) {
+					expectErr = c.fieldErrors[i]
+				}
+				// Compare existance of error, not actual error (yet)
+				if (err == nil) != (expectErr == nil) {
+					t.Fatalf("Failed error expectation on field %d, got '%s' but expected '%s'", i, err, expectErr)
+				}
+			}
+
+			if err != nil {
+				return
+			}
+
+			// Mark hydration as complete
+			err = n.HydrationComplete()
+			if (err == nil) != (c.completeError == nil) {
+				t.Fatalf("Failed error expectation on completion, got %s but expected %s", err, c.completeError)
+			}
+
+			fmt.Printf("The err: %+v", err)
+			if err == nil {
+				// Compare nodes manually to avoid comparing internal state with reflect.DeepEqual
+				ok := c.node.id == n.id && reflect.DeepEqual(c.node.tags, n.tags) && reflect.DeepEqual(c.node.props, n.props)
+				if !ok {
+					t.Errorf("Nodes differ")
+				}
+			}
+		})
+	}
+}

--- a/neo4j/internal/bolt/record.go
+++ b/neo4j/internal/bolt/record.go
@@ -17,33 +17,17 @@
  *  limitations under the License.
  */
 
-package packstream
+package bolt
 
-type StructTag byte
-
-type Struct interface {
-	Tag() StructTag
-	Fields() []interface{}
+type record struct {
+	values []interface{}
+	keys   []string
 }
 
-type rawStruct struct {
-	tag    StructTag
-	fields []interface{}
+func (r *record) Keys() []string {
+	return r.keys
 }
 
-func (s *rawStruct) Tag() StructTag {
-	return s.tag
-}
-
-func (s *rawStruct) Fields() []interface{} {
-	return s.fields
-}
-
-func (s *rawStruct) HydrateField(f interface{}) error {
-	s.fields = append(s.fields, f)
-	return nil
-}
-
-func (s *rawStruct) HydrationComplete() error {
-	return nil
+func (r *record) Values() []interface{} {
+	return r.values
 }

--- a/neo4j/internal/bolt/responses.go
+++ b/neo4j/internal/bolt/responses.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"fmt"
+)
+
+// Ignored response from server
+type ignoredResponse struct {
+	fields []interface{}
+}
+
+func (r *ignoredResponse) HydrateField(field interface{}) error {
+	r.fields = append(r.fields, field)
+	return nil
+}
+
+func (r *ignoredResponse) HydrationComplete() error {
+	return nil
+}
+
+func (r *ignoredResponse) Error() string {
+	return "ignored"
+}
+
+// Failure response from server
+type failureResponse struct {
+	fields []interface{}
+}
+
+func (r *failureResponse) HydrateField(field interface{}) error {
+	r.fields = append(r.fields, field)
+	return nil
+}
+
+func (r *failureResponse) HydrationComplete() error {
+	return nil
+}
+
+func (r *failureResponse) Error() string {
+	return fmt.Sprintf("failed: %+v", r.fields)
+}
+
+// Record response from server
+type recordResponse struct {
+	fields []interface{}
+}
+
+func (r *recordResponse) HydrateField(field interface{}) error {
+	r.fields = append(r.fields, field)
+	return nil
+}
+
+func (r *recordResponse) HydrationComplete() error {
+	return nil
+}

--- a/neo4j/internal/bolt/result.go
+++ b/neo4j/internal/bolt/result.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"container/list"
+
+	"github.com/neo4j/neo4j-go-driver/neo4j/api"
+)
+
+type fetch func() (*record, *summary, error)
+
+type result struct {
+	keys        []string
+	err         error
+	fetch       fetch
+	allReceived bool
+	unconsumed  list.List
+	record      *record
+	summary     *summary
+}
+
+func newResult(keys []string, fetch fetch) *result {
+	return &result{
+		keys:  keys,
+		fetch: fetch,
+	}
+}
+
+// Receive another record.
+func (r *result) doFetch() *record {
+	var rec *record
+	var sum *summary
+	rec, sum, r.err = r.fetch()
+	r.allReceived = r.err != nil || rec == nil
+	r.summary = sum
+	return rec
+}
+
+func (r *result) Next() bool {
+	e := r.unconsumed.Front()
+	if e == nil {
+		// All has been received and consumed
+		if r.allReceived {
+			r.record = nil
+			return false
+		}
+
+		// Receive another record
+		r.record = r.doFetch()
+		return r.record != nil
+	}
+
+	// Remove the record from list of unconsumed and return it
+	r.unconsumed.Remove(e)
+	r.record = e.Value.(*record)
+	return true
+}
+
+func (r *result) Record() api.Record {
+	// Unbox for better client experience
+	if r.record == nil {
+		return nil
+	}
+	return r.record
+}
+
+func (r *result) Err() error {
+	return r.err
+}
+
+func (r *result) Summary() (api.ResultSummary, error) {
+	r.FetchAll()
+	// Unbox for better client experience
+	if r.summary == nil {
+		return nil, r.err
+	}
+	return r.summary, r.err
+}
+
+// Used internally to fetch all records from stream and put them in unconsumed list.
+func (r *result) FetchAll() {
+	for !r.allReceived {
+		rec := r.doFetch()
+		if rec != nil {
+			r.unconsumed.PushBack(rec)
+		}
+	}
+}
+
+// Used internally to drain all records from stream.
+func (r *result) ConsumeAll() {
+	for !r.allReceived {
+		r.doFetch()
+	}
+}

--- a/neo4j/internal/bolt/result_test.go
+++ b/neo4j/internal/bolt/result_test.go
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/neo4j/neo4j-go-driver/neo4j/api"
+)
+
+type iter struct {
+	expectNext   bool
+	expectRec    api.Record
+	expectSum    api.ResultSummary
+	expectSumErr error
+	expectErr    error
+	fetchAll     bool
+	consumeAll   bool
+	summary      bool
+	panicOnFetch bool
+}
+
+type fetchRet struct {
+	rec *record
+	sum *summary
+	err error
+}
+
+type testFetcher struct {
+	rets         []fetchRet
+	panicOnFetch bool
+}
+
+func (f *testFetcher) fetch() (*record, *summary, error) {
+	if len(f.rets) == 0 || f.panicOnFetch {
+		// If signalling is made correctly in test case this shouldn't happen and if it does
+		// it is an error in test setup.
+		panic("boom")
+	}
+	ret := f.rets[0]
+	f.rets = f.rets[1:]
+	return ret.rec, ret.sum, ret.err
+}
+
+func TestResult(ot *testing.T) {
+	keys := []string{"key1", "key2"}
+	recs := []*record{
+		&record{},
+		&record{},
+		&record{},
+	}
+	sums := []*summary{
+		&summary{},
+	}
+	errs := []error{
+		errors.New("Whatever"),
+	}
+
+	// Initialization
+	ot.Run("Initialization", func(t *testing.T) {
+		fetcher := &testFetcher{}
+		res := newResult(keys, fetcher.fetch)
+		rec := res.Record()
+		if rec != nil {
+			t.Errorf("Should be no record")
+		}
+		err := res.Err()
+		if err != nil {
+			t.Errorf("Should be no error")
+		}
+		if err != nil {
+			t.Errorf("Shouldn't be an error to call summary too early")
+		}
+	})
+
+	// Iterate without any unconsumed (no push from connection)
+	iterCases := []struct {
+		name   string
+		stream []fetchRet
+		iters  []iter
+		sum    api.ResultSummary
+	}{
+		{
+			name: "happy",
+			stream: []fetchRet{
+				fetchRet{rec: recs[0]},
+				fetchRet{rec: recs[1]},
+				fetchRet{sum: sums[0]},
+			},
+			iters: []iter{
+				iter{expectNext: true, expectRec: recs[0]},
+				iter{expectNext: true, expectRec: recs[1]},
+				iter{expectNext: false},
+				iter{expectNext: false, summary: true, expectSum: sums[0]},
+			},
+		},
+		{
+			name: "error after one record",
+			stream: []fetchRet{
+				fetchRet{rec: recs[0]},
+				fetchRet{err: errs[0]},
+			},
+			iters: []iter{
+				iter{expectNext: true, expectRec: recs[0]},
+				iter{expectNext: false, expectErr: errs[0]},
+				iter{expectNext: false, expectErr: errs[0], summary: true, expectSumErr: errs[0]},
+			},
+		},
+		{
+			name: "proceed after error",
+			stream: []fetchRet{
+				fetchRet{rec: recs[0]},
+				fetchRet{err: errs[0]},
+			},
+			iters: []iter{
+				iter{expectNext: true, expectRec: recs[0]},
+				iter{expectNext: false, expectErr: errs[0]},
+				iter{expectNext: false, expectErr: errs[0]},
+			},
+		},
+		{
+			name: "summary",
+			stream: []fetchRet{
+				fetchRet{rec: recs[0]},
+				fetchRet{rec: recs[1]},
+				fetchRet{rec: recs[2]},
+				fetchRet{sum: sums[0]},
+			},
+			iters: []iter{
+				iter{expectNext: true, expectRec: recs[0]},
+				iter{summary: true, expectNext: true, expectRec: recs[1], expectSum: sums[0]},
+				iter{panicOnFetch: true, summary: true, expectNext: true, expectRec: recs[2], expectSum: sums[0]},
+			},
+		},
+		{
+			name: "fetch all",
+			stream: []fetchRet{
+				fetchRet{rec: recs[0]},
+				fetchRet{rec: recs[1]},
+				fetchRet{rec: recs[2]},
+				fetchRet{sum: sums[0]},
+			},
+			iters: []iter{
+				iter{expectNext: true, expectRec: recs[0]},
+				iter{fetchAll: true, expectNext: true, expectRec: recs[1]},
+				iter{panicOnFetch: true, summary: true, expectNext: true, expectRec: recs[2], expectSum: sums[0]},
+			},
+		},
+		{
+			name: "consume all",
+			stream: []fetchRet{
+				fetchRet{rec: recs[0]},
+				fetchRet{rec: recs[1]},
+				fetchRet{sum: sums[0]},
+			},
+			iters: []iter{
+				iter{expectNext: true, expectRec: recs[0]},
+				iter{consumeAll: true, expectNext: false},
+				iter{panicOnFetch: true, expectNext: false},
+			},
+		},
+	}
+	for _, c := range iterCases {
+		ot.Run(fmt.Sprintf("Iteration-%s", c.name), func(t *testing.T) {
+			fetcher := &testFetcher{rets: c.stream}
+			res := newResult(keys, fetcher.fetch)
+			for i, call := range c.iters {
+				fetcher.panicOnFetch = call.panicOnFetch
+				if call.fetchAll {
+					res.FetchAll()
+					if len(fetcher.rets) > 0 {
+						t.Fatalf("FetchAll should have emptied stream")
+					}
+				}
+				if call.consumeAll {
+					res.ConsumeAll()
+					if len(fetcher.rets) > 0 {
+						t.Fatalf("ConsumeAll should have emptied stream")
+					}
+				}
+				if call.summary {
+					gotSum, gotSumErr := res.Summary()
+					if (gotSum == nil) != (call.expectSum == nil) {
+						if gotSum == nil {
+							t.Fatalf("Expected to get summary but didn't at iter %d", i)
+						} else {
+							t.Fatalf("Expected to NOT get summary but did at iter %d", i)
+						}
+					}
+					if (gotSumErr == nil) != (call.expectSumErr == nil) {
+						if gotSumErr == nil {
+							t.Fatalf("Expected to get a summary error but didn't at iter %d", i)
+						} else {
+							t.Fatalf("Expected to NOT get a summary error but did at iter %d", i)
+						}
+					}
+				}
+				gotNext := res.Next()
+				if gotNext != call.expectNext {
+					t.Fatalf("Next at iter %d returned %t but expected to return %t", i, gotNext, call.expectNext)
+				}
+				gotRec := res.Record()
+				if (gotRec == nil) != (call.expectRec == nil) {
+					if gotRec == nil {
+						t.Fatalf("Expected to get record but didn't at iter %d", i)
+					} else {
+						t.Fatalf("Expected to NOT get a record but did at iter %d", i)
+					}
+				}
+				gotErr := res.Err()
+				if (gotErr == nil) != (call.expectErr == nil) {
+					if gotErr == nil {
+						t.Fatalf("Expected to get an error but didn't at iter %d", i)
+					} else {
+						t.Fatalf("Expected to NOT get an error but did at iter %d", i)
+					}
+				}
+			}
+		})
+	}
+}

--- a/neo4j/internal/bolt/successresponse.go
+++ b/neo4j/internal/bolt/successresponse.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"errors"
+)
+
+// Success response from server
+type successResponse struct {
+	m map[string]interface{}
+
+	// RUN with autocommit
+	//   map[string] interface{}:
+	//     "fields":  []string -- Names of returned fields
+	//     "t_first": int64
+	//
+	// PULL ALL no (more) matching records
+	//   map[string] interface{}
+	//     "bookmark": string
+	//     "t_last":   int64
+	//     "type":     string  "r"
+	//
+	//fields []interface{}
+}
+
+// Invoked by packstream
+func (r *successResponse) HydrateField(field interface{}) error {
+	if r.m != nil {
+		return errors.New("Didn't expect more fields")
+	}
+
+	m, ok := field.(map[string]interface{})
+	if !ok {
+		return errors.New("Unexpected type")
+	}
+	r.m = m
+	return nil
+}
+
+// Invoked by packstream
+func (r *successResponse) HydrationComplete() error {
+	if r.m == nil {
+		return errors.New("No map")
+	}
+	return nil
+}
+
+func (r *successResponse) Map() map[string]interface{} {
+	if r.m == nil {
+		return map[string]interface{}{}
+	}
+	return r.m
+}

--- a/neo4j/internal/bolt/summary.go
+++ b/neo4j/internal/bolt/summary.go
@@ -17,33 +17,34 @@
  *  limitations under the License.
  */
 
-package packstream
+package bolt
 
-type StructTag byte
+import "github.com/neo4j/neo4j-go-driver/neo4j/api"
 
-type Struct interface {
-	Tag() StructTag
-	Fields() []interface{}
+type summary struct {
+	bookmark      string
+	stmntType     string
+	cypher        string
+	params        map[string]interface{}
+	serverVersion string
 }
 
-type rawStruct struct {
-	tag    StructTag
-	fields []interface{}
+func (s *summary) Server() api.ServerInfo {
+	return s
 }
 
-func (s *rawStruct) Tag() StructTag {
-	return s.tag
+func (s *summary) Statement() api.Statement {
+	return s
 }
 
-func (s *rawStruct) Fields() []interface{} {
-	return s.fields
+func (s *summary) Text() string {
+	return s.cypher
 }
 
-func (s *rawStruct) HydrateField(f interface{}) error {
-	s.fields = append(s.fields, f)
-	return nil
+func (s *summary) Params() map[string]interface{} {
+	return s.params
 }
 
-func (s *rawStruct) HydrationComplete() error {
-	return nil
+func (i *summary) Version() string {
+	return i.serverVersion
 }

--- a/neo4j/internal/connection/connection.go
+++ b/neo4j/internal/connection/connection.go
@@ -17,33 +17,31 @@
  *  limitations under the License.
  */
 
-package packstream
+package connection
 
-type StructTag byte
+import (
+	"net"
 
-type Struct interface {
-	Tag() StructTag
-	Fields() []interface{}
+	"github.com/neo4j/neo4j-go-driver/neo4j/api"
+)
+
+type Connection interface {
+	RunAutoCommit(cypher string, params map[string]interface{} /*, timeout time.Duration, metadata map[string]interface{}*/) (api.Result, error)
+	IsAlive() bool
+	Close() error
+	// BeginTx
+	// CommitTx
+	// RollbackTx
+	// GetResult
+	// Run
 }
 
-type rawStruct struct {
-	tag    StructTag
-	fields []interface{}
+type Routable interface {
+	// GetRoutingTabe
 }
 
-func (s *rawStruct) Tag() StructTag {
-	return s.tag
-}
-
-func (s *rawStruct) Fields() []interface{} {
-	return s.fields
-}
-
-func (s *rawStruct) HydrateField(f interface{}) error {
-	s.fields = append(s.fields, f)
-	return nil
-}
-
-func (s *rawStruct) HydrationComplete() error {
-	return nil
+// Handles TLS handshake rules according to config
+func OpenTcp() (net.Conn, error) {
+	return net.Dial("tcp", "localhost:7687")
+	// TODO: DialTimeout ???
 }

--- a/neo4j/internal/packstream/hydrator.go
+++ b/neo4j/internal/packstream/hydrator.go
@@ -27,5 +27,10 @@ type HydratorFactory interface {
 }
 
 type Hydrator interface {
-	AddUnpackedField(field interface{}) error
+	// Called by unpacker to let receiver check and store the unpacked field in custom object.
+	// If the hydrator considers this field wrong it should return an error, this
+	// error will make the unpacker stop unpacking and return this error to the unpack caller.
+	HydrateField(field interface{}) error
+	// Called by unpacker when all fields has been unpacked. Same error rules apply as above.
+	HydrationComplete() error
 }


### PR DESCRIPTION
Implements connection handshake and running a Cypher query with
auto-commit. The query returns a result with a very limited support for
data types. Only simple data types like string, int64 etc plus show
casing more complex data type in the form of a node.

The 1.7 API will be preserved. Interface definitions will be in
neo4j/api package and exported from neo4j. This is to make it possible
to use the interfaces from the internal packages without any circular
dependencies (the neo4j package will use the internal packages).