### PR TITLE
Better error message on 3.5 vs 4.0 TLS change

### DIFF
--- a/neo4j/connector.go
+++ b/neo4j/connector.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sync/atomic"
 	"time"
@@ -139,6 +140,9 @@ func (c *connector) wrapInTls(target string, rawConn net.Conn) (net.Conn, error)
 	tlsConn := tls.Client(rawConn, &conf)
 	err = tlsConn.Handshake()
 	if err != nil {
+		if err == io.EOF {
+			err = errors.New("Remote end closed the connection, check that TLS is enabled on the server")
+		}
 		rawConn.Close()
 		return nil, err
 	}


### PR DESCRIPTION
Neo4j server 3.5 generated certificates automatically, 4.0 does not and
has therefore TLS disabled by default. This causes confusion upon
upgrade and this improves that error message.