### PR TITLE
Makes it possible to run tests against a 4.0 database

### DIFF
--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -546,7 +546,12 @@ func (b *bolt3) Next(shandle db.Handle) (*db.Record, *db.Summary, error) {
 		return nil, sum, nil
 	case *db.DatabaseError:
 		b.state = bolt3_failed
-		b.log.Error(b.logId, x)
+		if x.IsClient() {
+			// These could include potentially large cypher statement, only log to debug
+			b.log.Debugf(b.logId, "%s", x)
+		} else {
+			b.log.Error(b.logId, x)
+		}
 		return nil, nil, x
 	default:
 		b.state = bolt3_dead

--- a/neo4j/test-integration/auth_test.go
+++ b/neo4j/test-integration/auth_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Authentication", func() {
 
 	verifyConnect := func(token neo4j.AuthToken) func() {
 		return func() {
-			driver, err := neo4j.NewDriver(server.BoltURI(), token)
+			driver, err := neo4j.NewDriver(server.BoltURI(), token, server.Config())
 			Expect(err).To(BeNil())
 			defer driver.Close()
 

--- a/neo4j/test-integration/bookmark_test.go
+++ b/neo4j/test-integration/bookmark_test.go
@@ -403,9 +403,8 @@ var _ = Describe("Bookmark", func() {
 
 			Expect(tx).To(BeNil())
 			Expect(neo4j.IsTransientError(err)).To(BeTrue())
-			//Expect(err).To(ContainMessage("Database not up to the requested version"))
 			errDesc := err.Error()
-			Expect(errDesc).To(ContainSubstring("Database not up to the requested version"))
+			Expect(errDesc).To(ContainSubstring("not up to the requested version"))
 		})
 	})
 

--- a/neo4j/test-integration/control/causal-cluster.go
+++ b/neo4j/test-integration/control/causal-cluster.go
@@ -156,6 +156,7 @@ func newCluster(path string) (*Cluster, error) {
 
 	authToken := neo4j.BasicAuth(username, password, "")
 	config := func(config *neo4j.Config) {
+		config.Encrypted = useEncryption()
 		config.Log = neo4j.ConsoleLogger(logLevel())
 	}
 

--- a/neo4j/test-integration/control/constants.go
+++ b/neo4j/test-integration/control/constants.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	communityEdition  = "community"
 	enterpriseEdition = "enterprise"
 
 	defaultVersionAndEdition = "-e 3.5"

--- a/neo4j/test-integration/control/single-instance.go
+++ b/neo4j/test-integration/control/single-instance.go
@@ -99,6 +99,7 @@ func newSingleInstance(path string) (*SingleInstance, error) {
 
 	authToken := neo4j.BasicAuth(username, password, "")
 	config := func(config *neo4j.Config) {
+		config.Encrypted = useEncryption()
 		config.Log = neo4j.ConsoleLogger(logLevel())
 	}
 

--- a/neo4j/test-integration/control/utils.go
+++ b/neo4j/test-integration/control/utils.go
@@ -68,6 +68,20 @@ func logLevel() neo4j.LogLevel {
 	return defaultLogLevel
 }
 
+func useEncryption() bool {
+	// We will be able infer this by the URI scheme later on
+	switch os.Getenv("NEOENCRYPTION") {
+	case "False", "FALSE", "false":
+		return false
+	default:
+		return true
+	}
+}
+
+func IsTlsEnabled() bool {
+	return useEncryption()
+}
+
 func resolveServerPath(isCluster bool) string {
 	var serverPath = os.TempDir()
 

--- a/neo4j/test-integration/spatialtypes_test.go
+++ b/neo4j/test-integration/spatialtypes_test.go
@@ -134,11 +134,15 @@ var _ = Describe("Spatial Types", func() {
 			return float64(rand.Intn(360)-180) + rand.Float64()
 		}
 
+		randomDoubleY := func() float64 {
+			return float64(rand.Intn(180)-90) + rand.Float64()
+		}
+
 		switch sequence % 4 {
 		case 0:
-			return neo4j.NewPoint2D(WGS84SrID, randomDouble(), randomDouble())
+			return neo4j.NewPoint2D(WGS84SrID, randomDouble(), randomDoubleY())
 		case 1:
-			return neo4j.NewPoint3D(WGS843DSrID, randomDouble(), randomDouble(), randomDouble())
+			return neo4j.NewPoint3D(WGS843DSrID, randomDouble(), randomDoubleY(), randomDouble())
 		case 2:
 			return neo4j.NewPoint2D(CartesianSrID, randomDouble(), randomDouble())
 		case 3:
@@ -244,7 +248,7 @@ var _ = Describe("Spatial Types", func() {
 
 	It("should send and receive point", func() {
 		testSendAndReceive(neo4j.NewPoint2D(WGS84SrID, 51.24923585, 0.92723724))
-		testSendAndReceive(neo4j.NewPoint3D(WGS843DSrID, 22.86211019, 171.61820439, 0.1230987))
+		testSendAndReceive(neo4j.NewPoint3D(WGS843DSrID, 22.86211019, 71.61820439, 0.1230987))
 		testSendAndReceive(neo4j.NewPoint2D(CartesianSrID, 39.111748, -76.775635))
 		testSendAndReceive(neo4j.NewPoint3D(Cartesian3DSrID, 39.111748, -76.775635, 19.2937302840))
 	})

--- a/neo4j/test-integration/tls_test.go
+++ b/neo4j/test-integration/tls_test.go
@@ -30,6 +30,13 @@ var _ = Describe("Trust", func() {
 	var err error
 	var server *control.SingleInstance
 
+	// If the server isn't configured for TLS we cannot test this.
+	if !control.IsTlsEnabled() {
+		// Unable to skip here...
+		//Skip("Can not test TLS trust on server with TLS disabled")
+		return
+	}
+
 	BeforeEach(func() {
 		server, err = control.EnsureSingleInstance()
 		Expect(err).To(BeNil())
@@ -45,6 +52,7 @@ var _ = Describe("Trust", func() {
 
 		driver, err = neo4j.NewDriver(uri, server.AuthToken(), server.Config(), func(config *neo4j.Config) {
 			config.TrustStrategy = strategy
+			config.Encrypted = true
 		})
 		Expect(err).To(BeNil())
 		Expect(driver).NotTo(BeNil())
@@ -71,6 +79,7 @@ var _ = Describe("Trust", func() {
 
 		driver, err = neo4j.NewDriver(uri, server.AuthToken(), server.Config(), func(config *neo4j.Config) {
 			config.TrustStrategy = strategy
+			config.Encrypted = true
 		})
 		Expect(err).To(BeNil())
 		Expect(driver).NotTo(BeNil())


### PR DESCRIPTION
Added environment variable to specify if encryption should be used or
not when connecting to test database. 3.5 databases has encryption on by
default, 4.0 defaults to off.

Range of spatial y values changed, fix random range.

Downgraded an error print to debug to avoid flooding the log (especially
during tests).