### PR TITLE
Support 32-bit archs like ARM7

### DIFF
--- a/neo4j/internal/packstream/packer.go
+++ b/neo4j/internal/packstream/packer.go
@@ -127,7 +127,7 @@ func (p *Packer) writeListHeader(l int, shortOffset, longOffset byte) error {
 			hdr = hdr[:1+2]
 			hdr[0] = longOffset + 1
 			binary.BigEndian.PutUint16(hdr[1:], uint16(l))
-		case l < math.MaxUint32:
+		case uint32(l) < uint32(math.MaxUint32):
 			hdr = hdr[:1+4]
 			hdr[0] = longOffset + 2
 			binary.BigEndian.PutUint32(hdr[1:], uint32(l))
@@ -164,7 +164,7 @@ func (p *Packer) writeBytes(b []byte) error {
 		hdr = hdr[:1+2]
 		hdr[0] = 0xcd
 		binary.BigEndian.PutUint16(hdr[1:], uint16(l))
-	case l < 0x100000000:
+	case uint32(l) <= uint32(0xffffffff):
 		hdr = hdr[:1+4]
 		hdr[0] = 0xce
 		binary.BigEndian.PutUint32(hdr[1:], uint32(l))

--- a/neo4j/internal/packstream/packer.go
+++ b/neo4j/internal/packstream/packer.go
@@ -127,7 +127,7 @@ func (p *Packer) writeListHeader(l int, shortOffset, longOffset byte) error {
 			hdr = hdr[:1+2]
 			hdr[0] = longOffset + 1
 			binary.BigEndian.PutUint16(hdr[1:], uint16(l))
-		case uint32(l) < uint32(math.MaxUint32):
+		case uint64(l) < uint64(math.MaxUint32):
 			hdr = hdr[:1+4]
 			hdr[0] = longOffset + 2
 			binary.BigEndian.PutUint32(hdr[1:], uint32(l))
@@ -164,7 +164,7 @@ func (p *Packer) writeBytes(b []byte) error {
 		hdr = hdr[:1+2]
 		hdr[0] = 0xcd
 		binary.BigEndian.PutUint16(hdr[1:], uint16(l))
-	case uint32(l) <= uint32(0xffffffff):
+	case uint64(l) <= uint64(0x100000000):
 		hdr = hdr[:1+4]
 		hdr[0] = 0xce
 		binary.BigEndian.PutUint32(hdr[1:], uint32(l))


### PR DESCRIPTION
Before this change, builds of [v1.8.0](https://github.com/neo4j/neo4j-go-driver/releases/tag/v1.8.0) failed:
```shell
$ GOARCH=arm GOARM=7 go build ./...
# github.com/neo4j/neo4j-go-driver/neo4j/internal/packstream
neo4j/internal/packstream/packer.go:130:10: constant 4294967295 overflows int
neo4j/internal/packstream/packer.go:167:9: constant 4294967296 overflows int
```
This PR fixes that