### PR TITLE
Allow access to DatabaseError code

### DIFF
--- a/neo4j/error.go
+++ b/neo4j/error.go
@@ -94,3 +94,13 @@ func IsServiceUnavailable(err error) bool {
 	_, is = err.(*pool.PoolFull)
 	return is
 }
+
+// GetDatabaseErrorCode is a utility method to check if the provided error is DatabaseError and if so
+// it gets the error code.
+func GetDatabaseErrorCode(err error) string {
+	dbErr, is := err.(*db.DatabaseError)
+	if !is {
+		return ""
+	}
+	return dbErr.Code
+}


### PR DESCRIPTION
When I try to implement the error handling I find it hard to know what kind of error the Driver returns. As  #142 also suggested some improvement I think this simply allows to know what kind of error my code should deal with. 

For instance the code could be `Neo.ClientError.Schema.ConstraintValidationFailed` but through the `error` interface I can access only the string message `Server error: [Neo.ClientError.Schema.ConstraintValidationFailed] Node(6) already exists with label `. I think accessing the Code directly rather than parsing the string improves the usability of the library. 

The error types are internal which makes the error handling impossible so I agree with the need to improve it some way. These utility methods could be one way I agree some types of error messages could be internal because the Client application don't need to be concerned but when it's related to the consequences of Cypher and the Parameters so the client app shell handle it _(Like Constraint or Security)_ the error could expose more than just a string message.