### PR TITLE
Extracted retry logic into own package

### DIFF
--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package retry
+
+import (
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j/log"
+)
+
+type Router interface {
+	Invalidate(database string)
+}
+
+type State struct {
+	IsRetryable             bool
+	Err                     error
+	MaxTransactionRetryTime time.Duration
+	Log                     log.Logger
+	LogName                 string
+	LogId                   string
+	Now                     func() time.Time
+	Sleep                   func(time.Duration)
+	Throttle                Throttler
+	MaxDeadConnections      int
+	Router                  Router
+	DatabaseName            string
+
+	start      time.Time
+	cause      string
+	deadErrors int
+	skipSleep  bool
+}
+
+func (s *State) OnFailure(conn db.Connection, err error, isCommitting bool) {
+	s.Err = err
+	s.IsRetryable = false
+	s.cause = ""
+	s.skipSleep = false
+
+	// Check timeout
+	if s.start.IsZero() {
+		s.start = s.Now()
+	}
+	if s.Now().Sub(s.start) > s.MaxTransactionRetryTime {
+		s.cause = "Timeout"
+		return
+	}
+
+	// Failed to connect
+	if conn == nil {
+		s.IsRetryable = true
+		s.cause = "No available connection"
+		return
+	}
+
+	// Check if the connection died, if it died during commit it is not safe to retry.
+	if !conn.IsAlive() {
+		if isCommitting {
+			s.cause = "Connection lost during commit"
+			return
+		}
+
+		s.deadErrors += 1
+		s.IsRetryable = s.deadErrors <= s.MaxDeadConnections
+		s.cause = "Connection lost"
+		s.skipSleep = true
+		return
+	}
+
+	if dbErr, isDbErr := err.(*db.DatabaseError); isDbErr {
+		if dbErr.IsRetriableCluster() {
+			// Force routing tables to be updated before trying again
+			s.Router.Invalidate(s.DatabaseName)
+			s.cause = "Cluster error"
+			s.IsRetryable = true
+			return
+		}
+
+		if dbErr.IsRetriableTransient() {
+			s.cause = "Transient error"
+			s.IsRetryable = true
+			return
+		}
+	}
+}
+
+func (s *State) Continue() bool {
+	if s.Err == nil {
+		return true
+	}
+
+	if !s.IsRetryable {
+		// When there is a cause we failed due to a reason we should be able to handle, therefore
+		// log it as an error. The transaction could fail due to many other reasons, not sure if
+		// these are errors that the driver should log.
+		if s.cause != "" {
+			s.Log.Errorf(s.LogName, s.LogId, "Transaction failed (%s): %s", s.cause, s.Err)
+		}
+		return false
+	}
+
+	if s.skipSleep {
+		s.Log.Debugf(s.LogName, s.LogId, "Retrying transaction (%s): %s", s.cause, s.Err)
+	} else {
+		s.Throttle = s.Throttle.next()
+		sleepTime := s.Throttle.delay()
+		s.Log.Debugf(s.LogName, s.LogId, "Retrying transaction (%s): %s [after %s]", s.cause, s.Err, sleepTime)
+		s.Sleep(sleepTime)
+	}
+
+	// Reset
+	s.Err = nil
+	s.IsRetryable = false
+	return true
+}

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package retry
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j/internal/testutil"
+)
+
+type TStateInvocation struct {
+	conn                      db.Connection
+	err                       error
+	isCommitting              bool
+	now                       time.Time
+	expectContinued           bool
+	expectRouterInvalidated   bool
+	expectRouterInvalidatedDb string
+}
+
+func TestState(tt *testing.T) {
+	var (
+		baseTime       = time.Now()
+		maxRetryTime   = time.Second * 10
+		overTime       = baseTime.Add(maxRetryTime).Add(1 * time.Second)
+		halfTime       = baseTime.Add(maxRetryTime / 2)
+		maxDead        = 2
+		dbName         = "thedb"
+		clusterErr     = &db.DatabaseError{Code: "Neo.ClientError.Cluster.NotALeader"}
+		dbTransientErr = &db.DatabaseError{Code: "Neo.TransientError.Some.Some"}
+	)
+
+	cases := map[string][]TStateInvocation{
+		"Retry connect": []TStateInvocation{
+			{conn: nil, err: errors.New("A connect error"), expectContinued: true},
+		},
+		"Retry connect timeout": []TStateInvocation{
+			{conn: nil, err: errors.New("connect error 1"), expectContinued: true, now: baseTime},
+			{conn: nil, err: errors.New("connect error 2"), expectContinued: true, now: halfTime},
+			{conn: nil, err: errors.New("connect error 3"), expectContinued: false, now: overTime},
+		},
+		"Retry dead connection": []TStateInvocation{
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error"), expectContinued: true},
+		},
+		"Retry dead connection timeout": []TStateInvocation{
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 1"), expectContinued: true, now: baseTime},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 2"), expectContinued: false, now: overTime},
+		},
+		"Retry dead connection max": []TStateInvocation{
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 1"), expectContinued: true},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 2"), expectContinued: true},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 3"), expectContinued: false},
+		},
+		"Cluster error": []TStateInvocation{
+			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: true, expectRouterInvalidated: true, expectRouterInvalidatedDb: dbName},
+		},
+		"Cluster error timeout": []TStateInvocation{
+			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: true, expectRouterInvalidated: true, expectRouterInvalidatedDb: dbName},
+			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: false, now: overTime},
+		},
+		"Database transient error": []TStateInvocation{
+			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: true},
+		},
+		"Database transient error timeout": []TStateInvocation{
+			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: true},
+			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: false, now: overTime},
+		},
+	}
+
+	for n, c := range cases {
+		tt.Run(n, func(t *testing.T) {
+			now := baseTime
+			state := State{
+				Now:                     func() time.Time { return now },
+				Log:                     &testutil.ConsoleLogger{Errors: true, Debugs: true},
+				LogName:                 "TEST",
+				LogId:                   "State",
+				Sleep:                   func(time.Duration) {},
+				MaxTransactionRetryTime: maxRetryTime,
+				MaxDeadConnections:      maxDead,
+				DatabaseName:            dbName,
+			}
+			for _, i := range c {
+				// Update now if a value has been provided
+				if !i.now.IsZero() {
+					now = i.now
+				}
+				router := &testutil.RouterFake{}
+				state.Router = router
+
+				state.OnFailure(i.conn, i.err, i.isCommitting)
+				continued := state.Continue()
+				if continued != i.expectContinued {
+					t.Errorf("Expected continue to return %v but returned %v", i.expectContinued, continued)
+				}
+				if i.expectRouterInvalidated != router.Invalidated ||
+					i.expectRouterInvalidatedDb != router.InvalidatedDb {
+					t.Errorf("Expected router invalidated: (%v/%s) vs (%v/%s)",
+						i.expectRouterInvalidated, i.expectRouterInvalidatedDb,
+						router.Invalidated, router.InvalidatedDb)
+				}
+			}
+		})
+	}
+}

--- a/neo4j/internal/retry/throttler.go
+++ b/neo4j/internal/retry/throttler.go
@@ -17,22 +17,22 @@
  * limitations under the License.
  */
 
-package neo4j
+package retry
 
 import (
 	"math/rand"
 	"time"
 )
 
-type throttler time.Duration
+type Throttler time.Duration
 
-func (t throttler) next() throttler {
+func (t Throttler) next() Throttler {
 	delay := time.Duration(t)
 	const delayJitter = 0.2
 	jitter := float64(delay) * delayJitter
-	return throttler(delay - time.Duration(jitter) + time.Duration(2*jitter*rand.Float64()))
+	return Throttler(delay - time.Duration(jitter) + time.Duration(2*jitter*rand.Float64()))
 }
 
-func (t throttler) delay() time.Duration {
+func (t Throttler) delay() time.Duration {
 	return time.Duration(t)
 }

--- a/neo4j/internal/retry/throttler_test.go
+++ b/neo4j/internal/retry/throttler_test.go
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package neo4j
+package retry
 
 import (
 	"testing"
@@ -32,7 +32,7 @@ func TestThrottler(t *testing.T) {
 		}
 	}
 
-	thr := throttler(1 * time.Second)
+	thr := Throttler(1 * time.Second)
 	d1 := thr.delay()
 	var d2 time.Duration
 	for i := 0; i < 10; i++ {

--- a/neo4j/internal/testutil/consolelogger.go
+++ b/neo4j/internal/testutil/consolelogger.go
@@ -28,6 +28,7 @@ type ConsoleLogger struct {
 	Errors bool
 	Infos  bool
 	Warns  bool
+	Debugs bool
 }
 
 const timeFormat = "2006-01-02 15:04:05.000"
@@ -41,7 +42,7 @@ func (l *ConsoleLogger) Error(name, id string, err error) {
 }
 
 func (l *ConsoleLogger) Errorf(name, id string, msg string, args ...interface{}) {
-	if !l.Infos {
+	if !l.Errors {
 		return
 	}
 	now := time.Now()
@@ -65,7 +66,7 @@ func (l *ConsoleLogger) Warnf(name, id string, msg string, args ...interface{}) 
 }
 
 func (l *ConsoleLogger) Debugf(name, id string, msg string, args ...interface{}) {
-	if !l.Warns {
+	if !l.Debugs {
 		return
 	}
 	now := time.Now()

--- a/neo4j/internal/testutil/routerfake.go
+++ b/neo4j/internal/testutil/routerfake.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package testutil
+
+type RouterFake struct {
+	Invalidated   bool
+	InvalidatedDb string
+}
+
+func (r *RouterFake) Invalidate(database string) {
+	r.InvalidatedDb = database
+	r.Invalidated = true
+}


### PR DESCRIPTION
Makes it possible to use retry for building cbindings.
Improves test coverage on retry logic.
Reduces complexity of session implementation.