### PR TITLE
Not allowed to use result outside of transaction

### DIFF
--- a/MIGRATIONGUIDE.md
+++ b/MIGRATIONGUIDE.md
@@ -87,3 +87,12 @@ calls were remapped to the public interface, this is now gone.
 Driver config (include logging here???)
 TODO: Trust strategies has been removed from config, relies on 4.0 URI scheme instead.
 
+Utilities
+neo4j.Collect and neo4j.Single that are used to collect a slice of records or a single record
+from a result has been changed to use the Result interface. Previous example of usage:
+    records, err := neo4j.Collect(session.ReadTransaction("MATCH (n) RETURN n", nil))
+is now discouraged and will not compile anymore
+Ssince Collect function previously could consume a result returned from a transactional function,
+which isn't allowed and doesn't work unless all records are buffered internally and that could
+cause unintential buffering of very large results.
+

--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -291,13 +291,6 @@ func (s *session) runRetriable(
 			continue
 		}
 
-		// Fetch all in last result before committing, allows for:
-		//   records, err := neo4j.Collect(session.ReadTransaction(...) { return tx.Run(...) )
-		//if res, isRes := x.(*result); isRes {
-		if tx.res != nil {
-			tx.res.fetchAll()
-		}
-
 		// Commit transaction
 		err = conn.TxCommit(txHandle)
 		if err != nil {

--- a/neo4j/test-integration/examples_test.go
+++ b/neo4j/test-integration/examples_test.go
@@ -746,9 +746,7 @@ func addPersonsAsEmployees(driver neo4j.Driver, companyName string) (int, error)
 	}
 	defer session.Close()
 
-	persons, err := neo4j.Collect(session.ReadTransaction(func(tx neo4j.Transaction) (interface{}, error) {
-		return tx.Run("MATCH (a:Person) RETURN a.name AS name", nil)
-	}))
+	persons, err := neo4j.Collect(session.Run("MATCH (a:Person) RETURN a.name AS name", nil))
 	if err != nil {
 		return 0, err
 	}

--- a/neo4j/test-stub/pass_access_mode_test.go
+++ b/neo4j/test-stub/pass_access_mode_test.go
@@ -65,13 +65,13 @@ func Test_PassingAccessMode(t *testing.T) {
 				txFunc = session.ReadTransaction
 			}
 
-			result, err := neo4j.Single(txFunc(func(tx neo4j.Transaction) (interface{}, error) {
-				return tx.Run("RETURN 1", nil)
+			record, err := neo4j.AsRecord(txFunc(func(tx neo4j.Transaction) (interface{}, error) {
+				return neo4j.Single(tx.Run("RETURN 1", nil))
 			}))
 			assertNoError(t, err)
-			assertNotNil(t, result)
+			assertNotNil(t, record)
 
-			assertInt64Eq(t, int64(1), result.Values[0].(int64))
+			assertInt64Eq(t, int64(1), record.Values[0].(int64))
 		}
 
 		t.Run("shouldPassAccessModeForReadSessionRun", func(t *testing.T) {
@@ -135,13 +135,13 @@ func Test_PassingAccessMode(t *testing.T) {
 				txFunc = session.ReadTransaction
 			}
 
-			result, err := neo4j.Single(txFunc(func(tx neo4j.Transaction) (interface{}, error) {
-				return tx.Run("RETURN 1", nil)
+			record, err := neo4j.AsRecord(txFunc(func(tx neo4j.Transaction) (interface{}, error) {
+				return neo4j.Single(tx.Run("RETURN 1", nil))
 			}))
 			assertNoError(t, err)
-			assertNotNil(t, result)
+			assertNotNil(t, record)
 
-			assertInt64Eq(t, int64(1), result.Values[0].(int64))
+			assertInt64Eq(t, int64(1), record.Values[0].(int64))
 		}
 
 		t.Run("shouldPassAccessModeForReadSessionRun", func(t *testing.T) {


### PR DESCRIPTION
The results used within transactional functions were previously
automatically fetched when transaction was closed which made it
possible to use results outside of the transaction boundary, this is by
design not allowed. Could cause a lot of fetching and allocations that
might or might not be needed.

Utility functions to collect and get a single record has been changed so
that they will not build if used directly on transaction function
returns. New utility functions has been added so that same number of
lines is needed but not breaking.