### PR TITLE
Simplified error handling in packsteam PackStruct

### DIFF
--- a/neo4j/internal/bolt/hydratedehydrate_test.go
+++ b/neo4j/internal/bolt/hydratedehydrate_test.go
@@ -195,7 +195,9 @@ func TestDehydrateHydrate(ot *testing.T) {
 		buf := []byte{}
 		packer := packstream.Packer{}
 		var err error
-		buf, err = packer.Pack(buf, dehydrate, xi)
+		s, err := dehydrate(xi)
+		AssertNoError(t, err)
+		buf, err = packer.PackStruct(buf, dehydrate, s.Tag, s.Fields...)
 		AssertNoError(t, err)
 		unpacker := &packstream.Unpacker{}
 		xo, err := unpacker.UnpackStruct(buf, hydrate)

--- a/neo4j/internal/packstream/packstream_test.go
+++ b/neo4j/internal/packstream/packstream_test.go
@@ -511,9 +511,9 @@ func TestPackStream(ot *testing.T) {
 		ot.Run(fmt.Sprintf("Packing of %s", c.name), func(t *testing.T) {
 			buf := []byte{}
 			p := Packer{buf: buf, dehydrate: c.dehydrate}
-			err := p.pack(c.value)
-			if err != nil {
-				t.Fatalf("Unable to pack: %s", err)
+			p.pack(c.value)
+			if p.err != nil {
+				t.Fatalf("Unable to pack: %s", p.err)
 			}
 			buf = p.buf
 			if len(c.expectPacked) != len(buf) {
@@ -582,9 +582,9 @@ func TestPackStream(ot *testing.T) {
 		p := Packer{buf: buf, dehydrate: func(x interface{}) (*Struct, error) {
 			return nil, &UnsupportedTypeError{t: reflect.TypeOf(x)}
 		}}
-		err := p.pack(m)
-		if err != nil {
-			ot.Fatalf("Unable to pack: %s", err)
+		p.pack(m)
+		if p.err != nil {
+			ot.Fatalf("Unable to pack: %s", p.err)
 		}
 		buf = p.buf
 
@@ -666,12 +666,12 @@ func TestPackStream(ot *testing.T) {
 			if c.valueFunc != nil {
 				v = c.valueFunc()
 			}
-			err := p.pack(v)
-			if err == nil {
+			p.pack(v)
+			if p.err == nil {
 				t.Fatal("Should have gotten an error!")
 			}
-			if reflect.TypeOf(err) != reflect.TypeOf(c.expectedErr) {
-				t.Errorf("Wrong type of error, expected %T but was %T", c.expectedErr, err)
+			if reflect.TypeOf(p.err) != reflect.TypeOf(c.expectedErr) {
+				t.Errorf("Wrong type of error, expected %T but was %T", c.expectedErr, p.err)
 			}
 		})
 	}


### PR DESCRIPTION
Use sticky error in Packer to reduce amount of explicit error checking
with the side effect that an error could cause more writes even after an
error.