### PR TITLE
Correction of classification of retry error

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ The `Log` field of the `neo4j.Config` struct is defined to be of interface `neo4
 ```go
 type Logger interface {
 	Error(name string, id string, err error)
-	Errorf(name string, id string, msg string, args ...interface{})
 	Warnf(name string, id string, msg string, args ...interface{})
 	Infof(name string, id string, msg string, args ...interface{})
 	Debugf(name string, id string, msg string, args ...interface{})

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -21,10 +21,12 @@ package retry
 import (
 	"errors"
 	"io"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j/internal/pool"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j/internal/testutil"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j/log"
 )
@@ -37,6 +39,8 @@ type TStateInvocation struct {
 	expectContinued           bool
 	expectRouterInvalidated   bool
 	expectRouterInvalidatedDb string
+	expectLastErrWasRetryable bool
+	expectLastErrType         error
 }
 
 func TestState(tt *testing.T) {
@@ -53,44 +57,68 @@ func TestState(tt *testing.T) {
 
 	cases := map[string][]TStateInvocation{
 		"Retry connect": []TStateInvocation{
-			{conn: nil, err: errors.New("A connect error"), expectContinued: true},
+			{conn: nil, err: &pool.PoolTimeout{}, expectContinued: true,
+				expectLastErrWasRetryable: true, expectLastErrType: &pool.PoolTimeout{}},
 		},
 		"Retry connect timeout": []TStateInvocation{
-			{conn: nil, err: errors.New("connect error 1"), expectContinued: true, now: baseTime},
-			{conn: nil, err: errors.New("connect error 2"), expectContinued: true, now: halfTime},
-			{conn: nil, err: errors.New("connect error 3"), expectContinued: false, now: overTime},
+			{conn: nil, err: errors.New("connect error 1"), expectContinued: true, now: baseTime,
+				expectLastErrWasRetryable: true},
+			{conn: nil, err: errors.New("connect error 2"), expectContinued: true, now: halfTime,
+				expectLastErrWasRetryable: true},
+			{conn: nil, err: errors.New("connect error 3"), expectContinued: false, now: overTime,
+				expectLastErrWasRetryable: true},
 		},
 		"Retry dead connection": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error"), expectContinued: true},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error"), expectContinued: true,
+				expectLastErrWasRetryable: true},
 		},
 		"Retry dead connection timeout": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 1"), expectContinued: true, now: baseTime},
-			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 2"), expectContinued: false, now: overTime},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 1"), expectContinued: true, now: baseTime,
+				expectLastErrWasRetryable: true},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 2"), expectContinued: false, now: overTime,
+				expectLastErrWasRetryable: true},
 		},
 		"Retry dead connection max": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 1"), expectContinued: true},
-			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 2"), expectContinued: true},
-			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 3"), expectContinued: false},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 1"), expectContinued: true,
+				expectLastErrWasRetryable: true},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 2"), expectContinued: true,
+				expectLastErrWasRetryable: true},
+			{conn: &testutil.ConnFake{Alive: false}, err: errors.New("some error 3"), expectContinued: false,
+				expectLastErrWasRetryable: true},
 		},
 		"Cluster error": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: true, expectRouterInvalidated: true, expectRouterInvalidatedDb: dbName},
+			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: true,
+				expectRouterInvalidated: true, expectRouterInvalidatedDb: dbName, expectLastErrWasRetryable: true},
 		},
 		"Cluster error timeout": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: true, expectRouterInvalidated: true, expectRouterInvalidatedDb: dbName},
-			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: false, now: overTime},
+			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: true,
+				expectRouterInvalidated: true, expectRouterInvalidatedDb: dbName, expectLastErrWasRetryable: true},
+			{conn: &testutil.ConnFake{Alive: true}, err: clusterErr, expectContinued: false, now: overTime,
+				expectLastErrWasRetryable: true},
 		},
 		"Database transient error": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: true},
+			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: true,
+				expectLastErrWasRetryable: true},
 		},
 		"Database transient error timeout": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: true},
-			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: false, now: overTime},
+			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: true,
+				expectLastErrWasRetryable: true},
+			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: false, now: overTime,
+				expectLastErrWasRetryable: true},
 		},
 		"User defined error": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: true}, err: errors.New("client error"), expectContinued: false},
+			{conn: &testutil.ConnFake{Alive: true}, err: errors.New("client error"), expectContinued: false,
+				expectLastErrWasRetryable: false},
 		},
 		"Fail during commit": []TStateInvocation{
-			{conn: &testutil.ConnFake{Alive: false}, err: io.EOF, isCommitting: true, expectContinued: false},
+			{conn: &testutil.ConnFake{Alive: false}, err: io.EOF, isCommitting: true, expectContinued: false,
+				expectLastErrWasRetryable: false, expectLastErrType: &CommitFailedDeadError{}},
+		},
+		"Fail during commit after retry": []TStateInvocation{
+			{conn: &testutil.ConnFake{Alive: true}, err: dbTransientErr, expectContinued: true,
+				expectLastErrWasRetryable: true},
+			{conn: &testutil.ConnFake{Alive: false}, err: io.EOF, isCommitting: true, expectContinued: false,
+				expectLastErrWasRetryable: false, expectLastErrType: &CommitFailedDeadError{}},
 		},
 	}
 
@@ -125,6 +153,19 @@ func TestState(tt *testing.T) {
 					t.Errorf("Expected router invalidated: (%v/%s) vs (%v/%s)",
 						i.expectRouterInvalidated, i.expectRouterInvalidatedDb,
 						router.Invalidated, router.InvalidatedDb)
+				}
+				if state.LastErr == nil {
+					t.Errorf("LastErr should be set")
+				}
+				if state.LastErrWasRetryable != i.expectLastErrWasRetryable {
+					t.Errorf("LastErrWasRetryable mismatch")
+				}
+				if i.expectLastErrType != nil {
+					t1 := reflect.TypeOf(state.LastErr)
+					t2 := reflect.TypeOf(i.expectLastErrType)
+					if t1 != t2 {
+						t.Errorf("LastErr type mismatch: %s vs %s", t1, t2)
+					}
 				}
 			}
 		})

--- a/neo4j/internal/testutil/asserts.go
+++ b/neo4j/internal/testutil/asserts.go
@@ -173,3 +173,12 @@ func AssertIntEqual(t *testing.T, ai, ei int) {
 		t.Errorf("Differs %+v vs %+v", ai, ei)
 	}
 }
+
+func AssertSameType(t *testing.T, x, y interface{}) {
+	t.Helper()
+	t1 := reflect.TypeOf(x)
+	t2 := reflect.TypeOf(y)
+	if t1 != t2 {
+		t.Errorf("Expected types of %s and %s to be same but was %s and %s", x, y, t1, t2)
+	}
+}

--- a/neo4j/log/console.go
+++ b/neo4j/log/console.go
@@ -44,14 +44,6 @@ func (l *Console) Error(name, id string, err error) {
 	fmt.Fprintf(os.Stderr, "%s  ERROR  [%s %s] %s\n", now.Format(timeFormat), name, id, err.Error())
 }
 
-func (l *Console) Errorf(name, id string, msg string, args ...interface{}) {
-	if !l.Infos {
-		return
-	}
-	now := time.Now()
-	fmt.Fprintf(os.Stdout, "%s  ERROR  [%s %s] %s\n", now.Format(timeFormat), name, id, fmt.Sprintf(msg, args...))
-}
-
 func (l *Console) Infof(name, id string, msg string, args ...interface{}) {
 	if !l.Infos {
 		return

--- a/neo4j/log/logger.go
+++ b/neo4j/log/logger.go
@@ -36,10 +36,14 @@ import (
 //
 // Database connections takes to form of "bolt3" and "bolt-123@192.168.0.1:7687"
 // where "bolt3" is the name of the protocol handler in use, "bolt-123" is the
-// databatases identity of the connection on server "192.168.0.1:7687".
+// databases identity of the connection on server "192.168.0.1:7687".
 type Logger interface {
+	// Error is called whenever the driver encounters an error that might
+	// or might not cause a retry operation which means that all logged
+	// errors are not critical. Type of err might or might not be a publicly
+	// exported type. The same root cause of an error might be reported
+	// more than once by different components using same or different err types.
 	Error(name string, id string, err error)
-	Errorf(name string, id string, msg string, args ...interface{})
 	Warnf(name string, id string, msg string, args ...interface{})
 	Infof(name string, id string, msg string, args ...interface{})
 	Debugf(name string, id string, msg string, args ...interface{})

--- a/neo4j/log/void.go
+++ b/neo4j/log/void.go
@@ -19,12 +19,10 @@
 
 package log
 
+// Logger implementation that throws away all log events.
 type Void struct{}
 
 func (l Void) Error(name, id string, err error) {
-}
-
-func (l Void) Errorf(name, id string, msg string, args ...interface{}) {
 }
 
 func (l Void) Infof(name, id string, msg string, args ...interface{}) {

--- a/neo4j/result.go
+++ b/neo4j/result.go
@@ -86,7 +86,7 @@ func (r *result) Record() *Record {
 }
 
 func (r *result) Err() error {
-	return wrapBoltError(r.err)
+	return wrapError(r.err)
 }
 
 func (r *result) Collect() ([]*Record, error) {
@@ -98,7 +98,7 @@ func (r *result) Collect() ([]*Record, error) {
 		}
 	}
 	if r.err != nil {
-		return nil, wrapBoltError(r.err)
+		return nil, wrapError(r.err)
 	}
 	return recs, nil
 }
@@ -111,7 +111,7 @@ func (r *result) Single() (*Record, error) {
 	// Try retrieving the single record
 	r.record, r.summary, r.err = r.conn.Next(r.streamHandle)
 	if r.err != nil {
-		return nil, wrapBoltError(r.err)
+		return nil, wrapError(r.err)
 	}
 	if r.summary != nil {
 		r.err = &UsageError{Message: "Result contains no more records"}
@@ -134,7 +134,7 @@ func (r *result) Single() (*Record, error) {
 	if r.err != nil {
 		// Might be more records or not, anyway something is bad.
 		// Both r.record and r.summary are nil at this point which is good.
-		return nil, wrapBoltError(r.err)
+		return nil, wrapError(r.err)
 	}
 	// We got the expected summary
 	// r.record contains the single record and r.summary the summary.
@@ -155,13 +155,13 @@ func (r *result) Consume() (ResultSummary, error) {
 	// set by Single to indicate some kind of usage error that "destroyed"
 	// the result.
 	if r.err != nil {
-		return nil, wrapBoltError(r.err)
+		return nil, wrapError(r.err)
 	}
 
 	r.record = nil
 	r.summary, r.err = r.conn.Consume(r.streamHandle)
 	if r.err != nil {
-		return nil, wrapBoltError(r.err)
+		return nil, wrapError(r.err)
 	}
 	return r.toResultSummary(), nil
 }

--- a/neo4j/transaction.go
+++ b/neo4j/transaction.go
@@ -49,7 +49,7 @@ type transaction struct {
 func (tx *transaction) Run(cypher string, params map[string]interface{}) (Result, error) {
 	stream, err := tx.conn.RunTx(tx.txHandle, db.Command{Cypher: cypher, Params: params, FetchSize: tx.fetchSize})
 	if err != nil {
-		return nil, wrapBoltError(err)
+		return nil, wrapError(err)
 	}
 	return newResult(tx.conn, stream, cypher, params), nil
 }
@@ -61,7 +61,7 @@ func (tx *transaction) Commit() error {
 	tx.err = tx.conn.TxCommit(tx.txHandle)
 	tx.done = true
 	tx.onClosed()
-	return wrapBoltError(tx.err)
+	return wrapError(tx.err)
 }
 
 func (tx *transaction) Rollback() error {
@@ -71,7 +71,7 @@ func (tx *transaction) Rollback() error {
 	tx.err = tx.conn.TxRollback(tx.txHandle)
 	tx.done = true
 	tx.onClosed()
-	return wrapBoltError(tx.err)
+	return wrapError(tx.err)
 }
 
 func (tx *transaction) Close() error {
@@ -88,7 +88,7 @@ type retryableTransaction struct {
 func (tx *retryableTransaction) Run(cypher string, params map[string]interface{}) (Result, error) {
 	stream, err := tx.conn.RunTx(tx.txHandle, db.Command{Cypher: cypher, Params: params, FetchSize: tx.fetchSize})
 	if err != nil {
-		return nil, wrapBoltError(err)
+		return nil, wrapError(err)
 	}
 	return newResult(tx.conn, stream, cypher, params), nil
 }

--- a/testkit-backend/streamlogger.go
+++ b/testkit-backend/streamlogger.go
@@ -29,9 +29,6 @@ type streamLog struct {
 func (l *streamLog) Error(name string, id string, err error) {
 	l.writeLine(fmt.Sprintf("[%s %s] %s", name, id, err))
 }
-func (l *streamLog) Errorf(name string, id string, msg string, args ...interface{}) {
-	l.writeLine(fmt.Sprintf("[%s %s] %s", name, id, fmt.Sprintf(msg, args...)))
-}
 func (l *streamLog) Warnf(name string, id string, msg string, args ...interface{}) {
 	l.writeLine(fmt.Sprintf("[%s %s] %s", name, id, fmt.Sprintf(msg, args...)))
 }


### PR DESCRIPTION
If there are retries but the last error is a client error or another non
retriable error the final error should not be TransactionExecutionLimit
error.

Also cleans up error logging by only having one function to log errors.

Also separates the hopefully odd case of losing connection during
commit, should be clearly visible in logs and now classified as
ConnectivityError.