### PR TITLE
testkit: Porting tests to testkit

### DIFF
--- a/neo4j/session_test.go
+++ b/neo4j/session_test.go
@@ -131,7 +131,7 @@ func TestSession(st *testing.T) {
 	})
 
 	st.Run("Bookmarking", func(bt *testing.T) {
-		bt.Run("Last initial bookmark is used for LastBookmark", func(t *testing.T) {
+		bt.Run("Initial bookmark is used for LastBookmark", func(t *testing.T) {
 			_, _, sess := createSessionWithBookmarks([]string{"b1", "b2"})
 			AssertStringEqual(t, sess.LastBookmark(), "b2")
 		})
@@ -158,6 +158,11 @@ func TestSession(st *testing.T) {
 					t.Errorf("Using unclean or no bookmarks: %+v", rtx)
 				}
 			}
+		})
+
+		bt.Run("LastBookmark is empty when no initial bookmark", func(t *testing.T) {
+			_, _, sess := createSession()
+			AssertStringEqual(t, sess.LastBookmark(), "")
 		})
 	})
 

--- a/neo4j/test-integration/auth_test.go
+++ b/neo4j/test-integration/auth_test.go
@@ -38,34 +38,6 @@ func TestAuthentication(tt *testing.T) {
 		return driver, driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	}
 
-	assertConnect := func(t *testing.T, token neo4j.AuthToken) {
-		driver, session := getDriverAndSession(token)
-		defer driver.Close()
-		defer session.Close()
-
-		_, err := session.Run("RETURN 1", nil)
-		if err != nil {
-			t.Errorf("Failed to run query when connect should succeed: %s", err)
-		}
-	}
-
-	tt.Run("when credentials are provided as a basic token with realm", func(t *testing.T) {
-		token := neo4j.BasicAuth(server.Username, server.Password, "native")
-		assertConnect(t, token)
-	})
-
-	tt.Run("when credentials are provided as a custom token", func(t *testing.T) {
-		token := neo4j.CustomAuth("basic", server.Username, server.Password, "native", nil)
-		assertConnect(t, token)
-	})
-
-	tt.Run("when credentials are provided as a custom token with parameters", func(t *testing.T) {
-		token := neo4j.CustomAuth("basic", server.Username, server.Password, "native", map[string]interface{}{
-			"otp": "12345",
-		})
-		assertConnect(t, token)
-	})
-
 	tt.Run("when wrong credentials are provided, it should fail with authentication error", func(t *testing.T) {
 		token := neo4j.BasicAuth("wrong", "wrong", "")
 		driver, session := getDriverAndSession(token)

--- a/neo4j/test-integration/bookmark_test.go
+++ b/neo4j/test-integration/bookmark_test.go
@@ -78,29 +78,7 @@ var _ = Describe("Bookmark", func() {
 			}
 		})
 
-		Specify("session should not have any bookmark", func() {
-			Expect(session.LastBookmark()).To(BeEmpty())
-		})
-
-		Specify("when a node is created in auto-commit mode, last bookmark should be empty", func() {
-			if server.Version.GreaterThanOrEqual(V350) {
-				Skip("this test is targeted for server version less than neo4j 3.5.0")
-			}
-
-			result, err = session.Run("CREATE (p:Person { name: 'Test'})", nil)
-			Expect(err).To(BeNil())
-
-			summary, err = result.Consume()
-			Expect(err).To(BeNil())
-
-			Expect(session.LastBookmark()).To(BeEmpty())
-		})
-
 		Specify("when a node is created in auto-commit mode, last bookmark should not be empty", func() {
-			if server.Version.GreaterThanOrEqual(V350) {
-				Skip("this test is targeted for server version after neo4j 3.5.0")
-			}
-
 			result, err = session.Run("CREATE (p:Person { name: 'Test'})", nil)
 			Expect(err).To(BeNil())
 

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -399,7 +399,11 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 	case "SessionLastBookmarks":
 		sessionState := b.sessionStates[data["sessionId"].(string)]
 		bookmark := sessionState.session.LastBookmark()
-		b.writeResponse("Bookmarks", map[string]interface{}{"bookmarks": []string{bookmark}})
+		bookmarks := []string{}
+		if bookmark != "" {
+			bookmarks = append(bookmarks, bookmark)
+		}
+		b.writeResponse("Bookmarks", map[string]interface{}{"bookmarks": bookmarks})
 
 	case "TransactionRun":
 		tx := b.transactions[data["txId"].(string)]
@@ -466,6 +470,15 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 			}
 			b.writeResponse("NullRecord", nil)
 		}
+	case "ResultConsume":
+		result := b.results[data["resultId"].(string)]
+		_, err := result.Consume()
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		b.writeResponse("Summary", nil)
+
 	default:
 		b.writeError(errors.New("Unknown request: " + name))
 	}


### PR DESCRIPTION
Added support for Consume in testkit backend and cleaned up among
integration tests (moved some to unit tests and removed some tests
covered by testkit tests)