### PR TITLE
Fix ownership issue of byte slice used as a buffer

### DIFF
--- a/neo4j/internal/bolt/incoming.go
+++ b/neo4j/internal/bolt/incoming.go
@@ -33,8 +33,9 @@ func (i *incoming) next(rd io.Reader) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Reuse buffer for next dechunk
-	i.buf = buf
+	// Create a new buffer for the incoming stream so the hydrator can own the
+	// current byte slice.
+	i.buf = make([]byte, 4096)
 
 	return i.hyd.hydrate(buf)
 }


### PR DESCRIPTION
This change should fix #183. It appears that when we read a bolt message into the buffer, accounting for dechunking, a reference to that byte slice is then passed to the hydrator. However, since it's a reference to the same underlying buffer using by the "incoming" struct for processing bolt messages on the stream, it's possible data corruption can occur.

This might not be the best approach as it won't preserve any highwater-mark behavior that the driver currently has (because the dechunker reallocates the byte slice if the message size grows large enough). Maybe it's worth allocating a slice that's the same size as the old buffer to prevent future allocations?

> Note: it's not possible to just zero the existing `i.buf` because it's a shared reference with the `buf` passed to `i.hyd.hydrate()`