### PR TITLE
Add context.Context to function arguments

### DIFF
--- a/neo4j/directrouter.go
+++ b/neo4j/directrouter.go
@@ -19,20 +19,22 @@
 
 package neo4j
 
+import "context"
+
 // A router implementation that never routes
 type directRouter struct {
 	address string
 }
 
-func (r *directRouter) Readers(database string) ([]string, error) {
+func (r *directRouter) Readers(_ context.Context, database string) ([]string, error) {
 	return []string{r.address}, nil
 }
 
-func (r *directRouter) Writers(database string) ([]string, error) {
+func (r *directRouter) Writers(_ context.Context, database string) ([]string, error) {
 	return []string{r.address}, nil
 }
 
-func (r *directRouter) Invalidate(database string) {
+func (r *directRouter) Invalidate(_ context.Context, database string) {
 }
 
 func (r *directRouter) CleanUp() {

--- a/neo4j/driver_test.go
+++ b/neo4j/driver_test.go
@@ -20,6 +20,7 @@
 package neo4j
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -200,7 +201,7 @@ func TestNewDriverAndClose(t *testing.T) {
 	AssertNoError(t, err)
 
 	session := driver.NewSession(SessionConfig{})
-	_, err = session.Run("cypher", nil)
+	_, err = session.Run(context.TODO(), "cypher", nil)
 	if !IsUsageError(err) {
 		t.Errorf("should not allow new session after driver being closed")
 	}

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -20,6 +20,7 @@
 package retry
 
 import (
+	"context"
 	"errors"
 	"io"
 	"reflect"
@@ -144,7 +145,7 @@ func TestState(tt *testing.T) {
 				router := &testutil.RouterFake{}
 				state.Router = router
 
-				state.OnFailure(i.conn, i.err, i.isCommitting)
+				state.OnFailure(context.TODO(), i.conn, i.err, i.isCommitting)
 				continued := state.Continue()
 				if continued != i.expectContinued {
 					t.Errorf("Expected continue to return %v but returned %v", i.expectContinued, continued)

--- a/neo4j/internal/router/router.go
+++ b/neo4j/internal/router/router.go
@@ -72,7 +72,7 @@ func New(rootRouter string, getRouters func() []string, routerContext map[string
 	return r
 }
 
-func (r *Router) getTable(database string) (*db.RoutingTable, error) {
+func (r *Router) getTable(ctx context.Context, database string) (*db.RoutingTable, error) {
 	now := r.now()
 
 	r.dbRoutersMut.Lock()
@@ -92,20 +92,20 @@ func (r *Router) getTable(database string) (*db.RoutingTable, error) {
 	if dbRouter != nil && len(dbRouter.table.Routers) > 0 {
 		routers := dbRouter.table.Routers
 		r.log.Infof(log.Router, r.logId, "Reading routing table for '%s' from previously known routers: %v", database, routers)
-		table, err = readTable(context.Background(), r.pool, database, routers, r.routerContext)
+		table, err = readTable(ctx, r.pool, database, routers, r.routerContext)
 	}
 
 	// Try initial router if no routers or failed
 	if table == nil || err != nil {
 		r.log.Infof(log.Router, r.logId, "Reading routing table from initial router: %s", r.rootRouter)
-		table, err = readTable(context.Background(), r.pool, database, []string{r.rootRouter}, r.routerContext)
+		table, err = readTable(ctx, r.pool, database, []string{r.rootRouter}, r.routerContext)
 	}
 
 	// Use hook to retrieve possibly different set of routers and retry
 	if err != nil && r.getRouters != nil {
 		routers := r.getRouters()
 		r.log.Infof(log.Router, r.logId, "Reading routing table for '%s' from custom routers: %v", routers)
-		table, err = readTable(context.Background(), r.pool, database, routers, r.routerContext)
+		table, err = readTable(ctx, r.pool, database, routers, r.routerContext)
 	}
 
 	if err != nil {
@@ -130,8 +130,8 @@ func (r *Router) getTable(database string) (*db.RoutingTable, error) {
 	return table, nil
 }
 
-func (r *Router) Readers(database string) ([]string, error) {
-	table, err := r.getTable(database)
+func (r *Router) Readers(ctx context.Context, database string) ([]string, error) {
+	table, err := r.getTable(ctx, database)
 	if err != nil {
 		return nil, err
 	}
@@ -144,9 +144,9 @@ func (r *Router) Readers(database string) ([]string, error) {
 			break
 		}
 		r.log.Infof(log.Router, r.logId, "Invalidating routing table, no readers")
-		r.Invalidate(database)
+		r.Invalidate(ctx, database)
 		r.sleep(100 * time.Millisecond)
-		table, err = r.getTable(database)
+		table, err = r.getTable(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -158,8 +158,8 @@ func (r *Router) Readers(database string) ([]string, error) {
 	return table.Readers, nil
 }
 
-func (r *Router) Writers(database string) ([]string, error) {
-	table, err := r.getTable(database)
+func (r *Router) Writers(ctx context.Context, database string) ([]string, error) {
+	table, err := r.getTable(ctx, database)
 	if err != nil {
 		return nil, err
 	}
@@ -172,9 +172,9 @@ func (r *Router) Writers(database string) ([]string, error) {
 			break
 		}
 		r.log.Infof(log.Router, r.logId, "Invalidating routing table, no writers")
-		r.Invalidate(database)
+		r.Invalidate(ctx, database)
 		r.sleep(100 * time.Millisecond)
-		table, err = r.getTable(database)
+		table, err = r.getTable(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -190,7 +190,7 @@ func (r *Router) Context() map[string]string {
 	return r.routerContext
 }
 
-func (r *Router) Invalidate(database string) {
+func (r *Router) Invalidate(_ context.Context, database string) {
 	r.log.Infof(log.Router, r.logId, "Invalidating routing table for '%s'", database)
 	r.dbRoutersMut.Lock()
 	defer r.dbRoutersMut.Unlock()

--- a/neo4j/internal/router/router_test.go
+++ b/neo4j/internal/router/router_test.go
@@ -65,14 +65,14 @@ func TestMultithreading(t *testing.T) {
 	wg.Add(2)
 	consumer := func() {
 		for i := 0; i < 30; i++ {
-			readers, err := router.Readers(dbName)
+			readers, err := router.Readers(context.TODO(), dbName)
 			if len(readers) != 2 {
 				t.Error("Wrong number of readers")
 			}
 			if err != nil {
 				t.Error(err)
 			}
-			writers, err := router.Writers(dbName)
+			writers, err := router.Writers(context.TODO(), dbName)
 			if len(writers) != 1 {
 				t.Error("Wrong number of writers")
 			}
@@ -114,25 +114,25 @@ func TestRespectsTimeToLiveAndInvalidate(t *testing.T) {
 	dbName := "dbname"
 
 	// First access should trigger initial table read
-	router.Readers(dbName)
+	router.Readers(context.TODO(), dbName)
 	assertNum(t, numfetch, 1, "Should have fetched initial")
 
 	// Second access with time set to same should not trigger a read
-	router.Readers(dbName)
+	router.Readers(context.TODO(), dbName)
 	assertNum(t, numfetch, 1, "Should not have have fetched")
 
 	// Third access with time passed table due should trigger fetch
 	n = n.Add(2 * time.Second)
-	router.Readers(dbName)
+	router.Readers(context.TODO(), dbName)
 	assertNum(t, numfetch, 2, "Should have have fetched")
 
 	// Just another one to make sure we're cached
-	router.Readers(dbName)
+	router.Readers(context.TODO(), dbName)
 	assertNum(t, numfetch, 2, "Should not have have fetched")
 
 	// Invalidate should force fetching
-	router.Invalidate(dbName)
-	router.Readers(dbName)
+	router.Invalidate(context.TODO(), dbName)
+	router.Readers(context.TODO(), dbName)
 	assertNum(t, numfetch, 3, "Should have have fetched")
 }
 
@@ -160,13 +160,13 @@ func TestUsesRootRouterWhenPreviousRoutersFails(t *testing.T) {
 	dbName := "dbname"
 
 	// First access should trigger initial table read from root router
-	router.Readers(dbName)
+	router.Readers(context.TODO(), dbName)
 	if borrows[0][0] != "rootRouter" {
 		t.Errorf("Should have connected to root upon first router request")
 	}
 	// Next access should go to otherRouter
 	n = n.Add(2 * time.Second)
-	router.Readers(dbName)
+	router.Readers(context.TODO(), dbName)
 	if borrows[1][0] != "otherRouter" {
 		t.Errorf("Should have queried other router")
 	}
@@ -191,7 +191,7 @@ func TestUsesRootRouterWhenPreviousRoutersFails(t *testing.T) {
 		return &testutil.ConnFake{Table: &db.RoutingTable{TimeToLive: 1, Readers: []string{"aReader"}}}, nil
 	}
 	n = n.Add(2 * time.Second)
-	readers, err := router.Readers(dbName)
+	readers, err := router.Readers(context.TODO(), dbName)
 	if err != nil {
 		t.Error(err)
 	}
@@ -219,7 +219,7 @@ func TestUseGetRoutersHookWhenInitialRouterFails(t *testing.T) {
 	dbName := "dbname"
 
 	// Trigger read of routing table
-	router.Readers(dbName)
+	router.Readers(context.TODO(), dbName)
 
 	expected := []string{rootRouter}
 	expected = append(expected, backupRouters...)
@@ -247,7 +247,7 @@ func TestWritersFailAfterNRetries(t *testing.T) {
 	dbName := "dbname"
 
 	// Should trigger a lot of retries to get a writer until it finally fails
-	writers, err := router.Writers(dbName)
+	writers, err := router.Writers(context.TODO(), dbName)
 	if err == nil {
 		t.Error("Should have failed")
 	}
@@ -285,7 +285,7 @@ func TestWritersRetriesWhenNoWriters(t *testing.T) {
 
 	// Should trigger initial table read that contains no writers and a second table read
 	// that gets the writers
-	writers, err := router.Writers(dbName)
+	writers, err := router.Writers(context.TODO(), dbName)
 	if err != nil {
 		t.Errorf("Got error: %s", err)
 	}
@@ -323,7 +323,7 @@ func TestReadersRetriesWhenNoReaders(t *testing.T) {
 
 	// Should trigger initial table read that contains no readers and a second table read
 	// that gets the readers
-	readers, err := router.Readers(dbName)
+	readers, err := router.Readers(context.TODO(), dbName)
 	if err != nil {
 		t.Errorf("Got error: %s", err)
 	}
@@ -349,8 +349,8 @@ func TestCleanUp(t *testing.T) {
 	router := New("router", func() []string { return []string{} }, nil, pool, logger, "routerid")
 	router.now = func() time.Time { return now }
 
-	router.Readers("db1")
-	router.Readers("db2")
+	router.Readers(context.TODO(), "db1")
+	router.Readers(context.TODO(), "db2")
 
 	// Should be a router for each requested database
 	if len(router.dbRouters) != 2 {

--- a/neo4j/internal/testutil/routerfake.go
+++ b/neo4j/internal/testutil/routerfake.go
@@ -19,6 +19,8 @@
 
 package testutil
 
+import "context"
+
 type RouterFake struct {
 	Invalidated   bool
 	InvalidatedDb string
@@ -28,16 +30,16 @@ type RouterFake struct {
 	CleanUpHook   func()
 }
 
-func (r *RouterFake) Invalidate(database string) {
+func (r *RouterFake) Invalidate(_ context.Context, database string) {
 	r.InvalidatedDb = database
 	r.Invalidated = true
 }
 
-func (r *RouterFake) Readers(database string) ([]string, error) {
+func (r *RouterFake) Readers(_ context.Context, database string) ([]string, error) {
 	return r.ReadersRet, r.Err
 }
 
-func (r *RouterFake) Writers(database string) ([]string, error) {
+func (r *RouterFake) Writers(_ context.Context, database string) ([]string, error) {
 	return r.WritersRet, r.Err
 }
 

--- a/neo4j/test-integration/auth_test.go
+++ b/neo4j/test-integration/auth_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -44,7 +45,7 @@ func TestAuthentication(tt *testing.T) {
 		defer driver.Close()
 		defer session.Close()
 
-		_, err := session.Run("RETURN 1", nil)
+		_, err := session.Run(context.TODO(),"RETURN 1", nil)
 		if err == nil {
 			t.Fatal("Should NOT be able to connect")
 		}

--- a/neo4j/test-integration/bookmark_test.go
+++ b/neo4j/test-integration/bookmark_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"errors"
 
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -33,11 +34,11 @@ var _ = Describe("Bookmark", func() {
 	server := dbserver.GetDbServer()
 
 	createNodeInTx := func(driver neo4j.Driver) string {
-		session, err := driver.Session(neo4j.AccessModeWrite)
+		session, err := driver.Session(context.TODO(), neo4j.AccessModeWrite)
 		Expect(err).To(BeNil())
 		defer session.Close()
 
-		_, err = session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+		_, err = session.WriteTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 			result, err := tx.Run("CREATE ()", nil)
 			Expect(err).To(BeNil())
 
@@ -64,7 +65,7 @@ var _ = Describe("Bookmark", func() {
 
 		BeforeEach(func() {
 			driver = server.Driver()
-			session, err = driver.Session(neo4j.AccessModeWrite)
+			session, err = driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).To(BeNil())
 		})
 
@@ -79,7 +80,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("when a node is created in auto-commit mode, last bookmark should not be empty", func() {
-			result, err = session.Run("CREATE (p:Person { name: 'Test'})", nil)
+			result, err = session.Run(context.TODO(), "CREATE (p:Person { name: 'Test'})", nil)
 			Expect(err).To(BeNil())
 
 			summary, err = result.Consume()
@@ -89,7 +90,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("when a node is created in explicit transaction and committed, last bookmark should not be empty", func() {
-			tx, err := session.BeginTransaction()
+			tx, err := session.BeginTransaction(context.TODO(), )
 			Expect(err).To(BeNil())
 
 			result, err = tx.Run("CREATE (p:Person { name: 'Test'})", nil)
@@ -105,7 +106,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("when a node is created in explicit transaction and rolled back, last bookmark should be empty", func() {
-			tx, err := session.BeginTransaction()
+			tx, err := session.BeginTransaction(context.TODO(), )
 			Expect(err).To(BeNil())
 
 			result, err = tx.Run("CREATE (p:Person { name: 'Test'})", nil)
@@ -121,7 +122,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("when a node is created in transaction function, last bookmark should not be empty", func() {
-			result, err := session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+			result, err := session.WriteTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 				result, err := tx.Run("CREATE (p:Person { name: 'Test'})", nil)
 				Expect(err).To(BeNil())
 
@@ -138,7 +139,7 @@ var _ = Describe("Bookmark", func() {
 
 		Specify("when a node is created in transaction function and rolled back, last bookmark should be empty", func() {
 			failWith := errors.New("some error")
-			result, err := session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+			result, err := session.WriteTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 				result, err := tx.Run("CREATE (p:Person { name: 'Test'})", nil)
 				Expect(err).To(BeNil())
 
@@ -154,7 +155,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("when a node is queried in transaction function, last bookmark should not be empty", func() {
-			result, err := session.ReadTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+			result, err := session.ReadTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 				result, err := tx.Run("MATCH (p:Person) RETURN count(p)", nil)
 				Expect(err).To(BeNil())
 
@@ -174,7 +175,7 @@ var _ = Describe("Bookmark", func() {
 
 		Specify("when a node is created in transaction function and rolled back, last bookmark should be empty", func() {
 			failWith := errors.New("some error")
-			result, err := session.ReadTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+			result, err := session.ReadTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 				result, err := tx.Run("MATCH (p:Person) RETURN count(p)", nil)
 				Expect(err).To(BeNil())
 
@@ -206,7 +207,7 @@ var _ = Describe("Bookmark", func() {
 
 			bookmark = createNodeInTx(driver)
 
-			session, err = driver.Session(neo4j.AccessModeWrite, bookmark)
+			session, err = driver.Session(context.TODO(), neo4j.AccessModeWrite, bookmark)
 			Expect(err).To(BeNil())
 		})
 
@@ -221,7 +222,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("given bookmark should be reported back by the server after BEGIN", func() {
-			tx, err := session.BeginTransaction()
+			tx, err := session.BeginTransaction(context.TODO())
 			Expect(err).To(BeNil())
 			defer tx.Close()
 
@@ -229,7 +230,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("given bookmark should be accessible after ROLLBACK", func() {
-			tx, err := session.BeginTransaction()
+			tx, err := session.BeginTransaction(context.TODO())
 			Expect(err).To(BeNil())
 			defer tx.Close()
 
@@ -243,7 +244,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("given bookmark should be accessible when transaction fails", func() {
-			tx, err := session.BeginTransaction()
+			tx, err := session.BeginTransaction(context.TODO())
 			Expect(err).To(BeNil())
 			defer tx.Close()
 
@@ -256,7 +257,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("given bookmark should be accessible after run", func() {
-			result, err := session.Run("RETURN 1", nil)
+			result, err := session.Run(context.TODO(), "RETURN 1", nil)
 			Expect(err).To(BeNil())
 
 			_, err = result.Consume()
@@ -266,7 +267,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("given bookmark should be accessible after failed run", func() {
-			_, err := session.Run("RETURN", nil)
+			_, err := session.Run(context.TODO(), "RETURN", nil)
 			Expect(err).To(Not(BeNil()))
 
 			Expect(session.LastBookmark()).To(Equal(bookmark))
@@ -290,7 +291,7 @@ var _ = Describe("Bookmark", func() {
 			bookmark2 = createNodeInTx(driver)
 			Expect(bookmark1).NotTo(Equal(bookmark2))
 
-			session, err = driver.Session(neo4j.AccessModeWrite, bookmark1, bookmark2)
+			session, err = driver.Session(context.TODO(), neo4j.AccessModeWrite, bookmark1, bookmark2)
 			Expect(err).To(BeNil())
 		})
 
@@ -305,7 +306,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("highest bookmark should be reported back by the server after BEGIN", func() {
-			tx, err := session.BeginTransaction()
+			tx, err := session.BeginTransaction(context.TODO())
 			Expect(err).To(BeNil())
 			defer tx.Close()
 
@@ -313,7 +314,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("new bookmark should be reported back by the server after committing", func() {
-			tx, err := session.BeginTransaction()
+			tx, err := session.BeginTransaction(context.TODO())
 			Expect(err).To(BeNil())
 			defer tx.Close()
 
@@ -346,7 +347,7 @@ var _ = Describe("Bookmark", func() {
 
 			bookmark = createNodeInTx(driver)
 
-			session, err = driver.Session(neo4j.AccessModeWrite, bookmark+"0")
+			session, err = driver.Session(context.TODO(), neo4j.AccessModeWrite, bookmark+"0")
 			Expect(err).To(BeNil())
 		})
 
@@ -361,7 +362,7 @@ var _ = Describe("Bookmark", func() {
 		})
 
 		Specify("the request should fail", func() {
-			tx, err := session.BeginTransaction()
+			tx, err := session.BeginTransaction(context.TODO())
 
 			Expect(tx).To(BeNil())
 			neo4jErr := err.(*neo4j.Neo4jError)

--- a/neo4j/test-integration/dbserver/dbserver.go
+++ b/neo4j/test-integration/dbserver/dbserver.go
@@ -21,6 +21,7 @@
 package dbserver
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -100,7 +101,7 @@ func (s DbServer) deleteData() {
 	defer session.Close()
 
 	for {
-		result, err := session.Run("MATCH (n) WITH n LIMIT 10000 DETACH DELETE n RETURN count(n)", nil)
+		result, err := session.Run(context.TODO(), "MATCH (n) WITH n LIMIT 10000 DETACH DELETE n RETURN count(n)", nil)
 		if err != nil {
 			panic(err)
 		}

--- a/neo4j/test-integration/dbserver/version.go
+++ b/neo4j/test-integration/dbserver/version.go
@@ -20,6 +20,7 @@
 package dbserver
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -38,7 +39,7 @@ func versionOfDriver(driver neo4j.Driver) Version {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 
-	result, err := session.Run("RETURN 1", nil)
+	result, err := session.Run(context.TODO(), "RETURN 1", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/neo4j/test-integration/driver_test.go
+++ b/neo4j/test-integration/driver_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -37,7 +38,7 @@ var _ = Describe("Driver", func() {
 		It("should return nil upon good connection", func() {
 			driver := server.Driver()
 			defer driver.Close()
-			err := driver.VerifyConnectivity()
+			err := driver.VerifyConnectivity(context.TODO())
 			Expect(err).To(BeNil())
 		})
 
@@ -46,7 +47,7 @@ var _ = Describe("Driver", func() {
 			driver, err := neo4j.NewDriver(server.BoltURI(), auth, server.ConfigFunc())
 			Expect(err).To(BeNil())
 			defer driver.Close()
-			err = driver.VerifyConnectivity()
+			err = driver.VerifyConnectivity(context.TODO())
 			Expect(err).ToNot(BeNil())
 		})
 	})
@@ -62,7 +63,7 @@ var _ = Describe("Driver", func() {
 		BeforeEach(func() {
 			driver = server.Driver()
 
-			session, err = driver.Session(neo4j.AccessModeWrite)
+			session, err = driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).To(BeNil())
 		})
 
@@ -77,7 +78,7 @@ var _ = Describe("Driver", func() {
 		})
 
 		It("it should not allow work on existing sessions, after driver is closed", func() {
-			result, err = session.Run("RETURN 1", nil)
+			result, err = session.Run(context.TODO(), "RETURN 1", nil)
 			Expect(err).To(BeNil())
 
 			if result.Next() {
@@ -89,12 +90,12 @@ var _ = Describe("Driver", func() {
 			err := driver.Close()
 			Expect(err).To(BeNil())
 
-			_, err = session.Run("RETURN 1", nil)
+			_, err = session.Run(context.TODO(), "RETURN 1", nil)
 			Expect(err).NotTo(BeNil())
 		})
 
 		It("it should not allow new sessions, after driver is closed", func() {
-			result, err = session.Run("RETURN 1", nil)
+			result, err = session.Run(context.TODO(), "RETURN 1", nil)
 			Expect(err).To(BeNil())
 
 			if result.Next() {
@@ -106,7 +107,7 @@ var _ = Describe("Driver", func() {
 			err := driver.Close()
 			Expect(err).To(BeNil())
 
-			_, err = driver.Session(neo4j.AccessModeWrite)
+			_, err = driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).NotTo(BeNil())
 		})
 
@@ -134,24 +135,24 @@ var _ = Describe("Driver", func() {
 
 		It("should return error when pool is full", func() {
 			// Open connection 1
-			session1, err := driver.Session(neo4j.AccessModeWrite)
+			session1, err := driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).To(BeNil())
 
-			_, err = session1.Run("UNWIND RANGE(1, 100) AS N RETURN N", nil)
+			_, err = session1.Run(context.TODO(), "UNWIND RANGE(1, 100) AS N RETURN N", nil)
 			Expect(err).To(BeNil())
 
 			// Open connection 2
-			session2, err := driver.Session(neo4j.AccessModeWrite)
+			session2, err := driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).To(BeNil())
 
-			_, err = session2.Run("UNWIND RANGE(1, 100) AS N RETURN N", nil)
+			_, err = session2.Run(context.TODO(), "UNWIND RANGE(1, 100) AS N RETURN N", nil)
 			Expect(err).To(BeNil())
 
 			// Try opening connection 3
-			session3, err := driver.Session(neo4j.AccessModeWrite)
+			session3, err := driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).To(BeNil())
 
-			_, err = session3.Run("UNWIND RANGE(1, 100) AS N RETURN N", nil)
+			_, err = session3.Run(context.TODO(), "UNWIND RANGE(1, 100) AS N RETURN N", nil)
 			Expect(neo4j.IsConnectivityError(err)).To(BeTrue())
 			//Expect(err).To(BeConnectorErrorWithCode(0x600))
 		})
@@ -179,25 +180,25 @@ var _ = Describe("Driver", func() {
 
 		It("should return error when pool is full", func() {
 			// Open connection 1
-			session1, err := driver.Session(neo4j.AccessModeWrite)
+			session1, err := driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).To(BeNil())
 
-			_, err = session1.Run("UNWIND RANGE(1, 100) AS N RETURN N", nil)
+			_, err = session1.Run(context.TODO(), "UNWIND RANGE(1, 100) AS N RETURN N", nil)
 			Expect(err).To(BeNil())
 
 			// Open connection 2
-			session2, err := driver.Session(neo4j.AccessModeWrite)
+			session2, err := driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).To(BeNil())
 
-			_, err = session2.Run("UNWIND RANGE(1, 100) AS N RETURN N", nil)
+			_, err = session2.Run(context.TODO(), "UNWIND RANGE(1, 100) AS N RETURN N", nil)
 			Expect(err).To(BeNil())
 
 			// Try opening connection 3
-			session3, err := driver.Session(neo4j.AccessModeWrite)
+			session3, err := driver.Session(context.TODO(), neo4j.AccessModeWrite)
 			Expect(err).To(BeNil())
 
 			start := time.Now()
-			_, err = session3.Run("UNWIND RANGE(1, 100) AS N RETURN N", nil)
+			_, err = session3.Run(context.TODO(), "UNWIND RANGE(1, 100) AS N RETURN N", nil)
 			elapsed := time.Since(start)
 			Expect(neo4j.IsConnectivityError(err)).To(BeTrue())
 			//Expect(err).To(BeConnectorErrorWithCode(0x601))

--- a/neo4j/test-integration/examples_test.go
+++ b/neo4j/test-integration/examples_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -258,7 +259,7 @@ func helloWorld(uri, username, password string) (string, error) {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	greeting, err := session.WriteTransaction(func(transaction neo4j.Transaction) (interface{}, error) {
+	greeting, err := session.WriteTransaction(context.TODO(), func(transaction neo4j.Transaction) (interface{}, error) {
 		result, err := transaction.Run(
 			"CREATE (a:Greeting) SET a.message = $message RETURN a.message + ', from node ' + id(a)",
 			map[string]interface{}{"message": "hello, world"})
@@ -361,7 +362,7 @@ func addPerson(name string) error {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	result, err := session.Run("CREATE (n:Person { name: $name})", map[string]interface{}{"name": name})
+	result, err := session.Run(context.TODO(),"CREATE (n:Person { name: $name})", map[string]interface{}{"name": name})
 	if err != nil {
 		return err
 	}
@@ -411,7 +412,7 @@ func createItem(driver neo4j.Driver) error {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	_, err := session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+	_, err := session.WriteTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 		result, err := tx.Run("CREATE (a:Item)", nil)
 		if err != nil {
 			return nil, err
@@ -429,7 +430,7 @@ func countNodes(driver neo4j.Driver, label string, property string, value string
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 
-	result, err := session.Run(fmt.Sprintf("MATCH (a:%s {%s: $value}) RETURN count(a)", label, property), map[string]interface{}{"value": value})
+	result, err := session.Run(context.TODO(), fmt.Sprintf("MATCH (a:%s {%s: $value}) RETURN count(a)", label, property), map[string]interface{}{"value": value})
 	if err != nil {
 		return -1, err
 	}
@@ -446,7 +447,7 @@ func addPersonInSession(driver neo4j.Driver, name string) error {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	result, err := session.Run("CREATE (a:Person {name: $name})", map[string]interface{}{"name": name})
+	result, err := session.Run(context.TODO(),"CREATE (a:Person {name: $name})", map[string]interface{}{"name": name})
 	if err != nil {
 		return err
 	}
@@ -465,7 +466,7 @@ func addPersonInAutoCommitTx(driver neo4j.Driver, name string) error {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	result, err := session.Run("CREATE (a:Person {name: $name})", map[string]interface{}{"name": name})
+	result, err := session.Run(context.TODO(),"CREATE (a:Person {name: $name})", map[string]interface{}{"name": name})
 	if err != nil {
 		return err
 	}
@@ -484,7 +485,7 @@ func addPersonInTxFunc(driver neo4j.Driver, name string) error {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	_, err := session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+	_, err := session.WriteTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 		result, err := tx.Run("CREATE (a:Person {name: $name})", map[string]interface{}{"name": name})
 		if err != nil {
 			return nil, err
@@ -548,13 +549,13 @@ func addAndEmploy(driver neo4j.Driver, person string, company string) (string, e
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	if _, err := session.WriteTransaction(addCompanyTxFunc(company)); err != nil {
+	if _, err := session.WriteTransaction(context.TODO(), addCompanyTxFunc(company)); err != nil {
 		return "", err
 	}
-	if _, err := session.WriteTransaction(addPersonTxFunc(person)); err != nil {
+	if _, err := session.WriteTransaction(context.TODO(), addPersonTxFunc(person)); err != nil {
 		return "", err
 	}
-	if _, err := session.WriteTransaction(employTxFunc(person, company)); err != nil {
+	if _, err := session.WriteTransaction(context.TODO(), employTxFunc(person, company)); err != nil {
 		return "", err
 	}
 
@@ -565,7 +566,7 @@ func makeFriend(driver neo4j.Driver, person1 string, person2 string, bookmarks .
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite, Bookmarks: bookmarks})
 	defer session.Close()
 
-	if _, err := session.WriteTransaction(makeFriendTxFunc(person1, person2)); err != nil {
+	if _, err := session.WriteTransaction(context.TODO(), makeFriendTxFunc(person1, person2)); err != nil {
 		return "", err
 	}
 
@@ -591,7 +592,7 @@ func addEmployAndMakeFriends(driver neo4j.Driver) error {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead, Bookmarks: []string{bookmark1, bookmark2, bookmark3}})
 	defer session.Close()
 
-	if _, err = session.ReadTransaction(printFriendsTxFunc()); err != nil {
+	if _, err = session.ReadTransaction(context.TODO(), printFriendsTxFunc()); err != nil {
 		return err
 	}
 
@@ -631,13 +632,13 @@ func addPersonNode(driver neo4j.Driver, name string) (int64, error) {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	if _, err := session.WriteTransaction(addPersonNodeTxFunc(name)); err != nil {
+	if _, err := session.WriteTransaction(context.TODO(), addPersonNodeTxFunc(name)); err != nil {
 		return -1, err
 	}
 
 	var id interface{}
 	var err error
-	if id, err = session.ReadTransaction(matchPersonNodeTxFunc(name)); err != nil {
+	if id, err = session.ReadTransaction(context.TODO(), matchPersonNodeTxFunc(name)); err != nil {
 		return -1, err
 	}
 
@@ -660,7 +661,7 @@ func getPeople(driver neo4j.Driver) ([]string, error) {
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	defer session.Close()
 
-	people, err := session.ReadTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+	people, err := session.ReadTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 		var list []string
 
 		result, err := tx.Run("MATCH (a:Person) RETURN a.name ORDER BY a.name", nil)
@@ -692,14 +693,14 @@ func addPersonsAsEmployees(driver neo4j.Driver, companyName string) (int, error)
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
 
-	persons, err := neo4j.Collect(session.Run("MATCH (a:Person) RETURN a.name AS name", nil))
+	persons, err := neo4j.Collect(session.Run(context.TODO(),"MATCH (a:Person) RETURN a.name AS name", nil))
 	if err != nil {
 		return 0, err
 	}
 
 	employees := 0
 	for _, person := range persons {
-		_, err = session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+		_, err = session.WriteTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 			return tx.Run("MATCH (emp:Person {name: $person_name}) "+
 				"MERGE (com:Company {name: $company_name}) "+
 				"MERGE (emp)-[:WORKS_FOR]->(com)", map[string]interface{}{"person_name": person.Values[0], "company_name": companyName})

--- a/neo4j/test-integration/multidatabase_test.go
+++ b/neo4j/test-integration/multidatabase_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -45,9 +46,9 @@ func TestMultidatabase(ot *testing.T) {
 	func() {
 		sysSess := driver.NewSession(neo4j.SessionConfig{DatabaseName: "system"})
 		defer sysSess.Close()
-		_, err := sysSess.Run("DROP DATABASE testdb IF EXISTS", nil)
+		_, err := sysSess.Run(context.TODO(),"DROP DATABASE testdb IF EXISTS", nil)
 		assertNoError(ot, err)
-		_, err = sysSess.Run("CREATE DATABASE testdb", nil)
+		_, err = sysSess.Run(context.TODO(),"CREATE DATABASE testdb", nil)
 		assertNoError(ot, err)
 	}()
 

--- a/neo4j/test-integration/no_test.go
+++ b/neo4j/test-integration/no_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"crypto/rand"
 	"math"
 	"math/big"
@@ -72,7 +73,7 @@ func randomInt() int64 {
 }
 
 func createRandomNode(t *testing.T, sess neo4j.Session) int64 {
-	nodex, err := sess.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+	nodex, err := sess.WriteTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 		res, err := tx.Run("CREATE (n:RandomNode{val: $r}) RETURN n", map[string]interface{}{"r": randomInt()})
 		if err != nil {
 			return nil, err
@@ -88,7 +89,7 @@ func createRandomNode(t *testing.T, sess neo4j.Session) int64 {
 }
 
 func findRandomNode(t *testing.T, sess neo4j.Session, randomId int64) *neo4j.Node {
-	nodex, err := sess.ReadTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+	nodex, err := sess.ReadTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 		res, err := tx.Run("MATCH (n:RandomNode{val: $r}) RETURN n", map[string]interface{}{"r": randomId})
 		if err != nil {
 			return nil, err
@@ -127,7 +128,7 @@ func single(t *testing.T, driver neo4j.Driver, cypher string, params map[string]
 	t.Helper()
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close()
-	result, err := session.Run(cypher, params)
+	result, err := session.Run(context.TODO(), cypher, params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/neo4j/test-integration/routing_test.go
+++ b/neo4j/test-integration/routing_test.go
@@ -20,6 +20,8 @@
 package test_integration
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -52,11 +54,11 @@ var _ = Describe("Routing", func() {
 		Expect(err).To(BeNil())
 		defer driver.Close()
 
-		session, err = driver.Session(neo4j.AccessModeRead)
+		session, err = driver.Session(context.TODO(), neo4j.AccessModeRead)
 		Expect(err).To(BeNil())
 		defer session.Close()
 
-		result, err = session.Run("RETURN 1", nil)
+		result, err = session.Run(context.TODO(), "RETURN 1", nil)
 		Expect(err).To(BeNil())
 
 		summary, err = result.Consume()
@@ -73,10 +75,10 @@ var _ = Describe("Routing", func() {
 		driver := getDriver(server.URI())
 		Expect(err).To(BeNil())
 
-		session, err = driver.Session(neo4j.AccessModeWrite)
+		session, err = driver.Session(context.TODO(), neo4j.AccessModeWrite)
 		Expect(err).To(BeNil())
 
-		writeCount, err = session.WriteTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+		writeCount, err = session.WriteTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 			writeResult, err := tx.Run("MERGE (n:Person {name: 'John'}) RETURN 1", nil)
 			if err != nil {
 				return nil, err
@@ -95,7 +97,7 @@ var _ = Describe("Routing", func() {
 		Expect(err).To(BeNil())
 		Expect(writeCount).To(BeNumerically("==", 1))
 
-		readCount, err = session.ReadTransaction(func(tx neo4j.Transaction) (interface{}, error) {
+		readCount, err = session.ReadTransaction(context.TODO(), func(tx neo4j.Transaction) (interface{}, error) {
 			readResult, err := tx.Run("MATCH (n:Person {name: 'John'}) RETURN COUNT(*) AS count", nil)
 			if err != nil {
 				return nil, err

--- a/neo4j/test-integration/temporaltypes_test.go
+++ b/neo4j/test-integration/temporaltypes_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"time"
@@ -52,7 +53,7 @@ var _ = Describe("Temporal Types", func() {
 			Skip("temporal types are only available after neo4j 3.4.0 release")
 		}
 
-		session, err = driver.Session(neo4j.AccessModeWrite)
+		session, err = driver.Session(context.TODO(), neo4j.AccessModeWrite)
 		Expect(err).To(BeNil())
 		Expect(session).NotTo(BeNil())
 	})
@@ -177,7 +178,7 @@ var _ = Describe("Temporal Types", func() {
 	}
 
 	testSendAndReceive := func(query string, data interface{}, expected []interface{}) {
-		result, err = session.Run(query, map[string]interface{}{"x": data})
+		result, err = session.Run(context.TODO(), query, map[string]interface{}{"x": data})
 		Expect(err).To(BeNil())
 
 		if result.Next() {
@@ -190,7 +191,7 @@ var _ = Describe("Temporal Types", func() {
 	}
 
 	testSendAndReceiveValue := func(value interface{}) {
-		result, err = session.Run("CREATE (n:Node {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n:Node {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		if result.Next() {
@@ -203,7 +204,7 @@ var _ = Describe("Temporal Types", func() {
 	}
 
 	testSendAndReceiveValueComp := func(value interface{}, comp func(x, y interface{}) bool) {
-		result, err = session.Run("CREATE (n:Node {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n:Node {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		if result.Next() {
@@ -428,7 +429,7 @@ var _ = Describe("Temporal Types", func() {
 
 	DescribeTable("should be able to send and receive nil pointer property",
 		func(value interface{}) {
-			result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+			result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 			Expect(err).To(BeNil())
 
 			if result.Next() {

--- a/neo4j/test-integration/timeout_test.go
+++ b/neo4j/test-integration/timeout_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -48,12 +49,12 @@ var _ = Describe("Timeout and Lifetime", func() {
 		session1, _ = newSessionAndTx(driver, neo4j.AccessModeRead)
 		defer session1.Close()
 
-		session2, err = driver.Session(neo4j.AccessModeRead)
+		session2, err = driver.Session(context.TODO(), neo4j.AccessModeRead)
 		Expect(err).To(BeNil())
 		Expect(session2).NotTo(BeNil())
 		defer session2.Close()
 
-		_, err = session2.Run("RETURN 1", nil)
+		_, err = session2.Run(context.TODO(), "RETURN 1", nil)
 		Expect(err).ToNot(BeNil())
 		//Expect(err).To(test.BeConnectorErrorWithCode(0x601))
 	})
@@ -100,7 +101,7 @@ var _ = Describe("Timeout and Lifetime", func() {
 		session = newSession(driver, neo4j.AccessModeRead)
 		defer session.Close()
 
-		_, err = session.BeginTransaction()
+		_, err = session.BeginTransaction(context.TODO())
 		Expect(err).ToNot(BeNil())
 		//Expect(err).To(test.BeConnectorErrorWithCode(6))
 	})

--- a/neo4j/test-integration/types_test.go
+++ b/neo4j/test-integration/types_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"math/rand"
 	"reflect"
 
@@ -40,7 +41,7 @@ var _ = Describe("Types", func() {
 	BeforeEach(func() {
 		driver = server.Driver()
 
-		session, err = driver.Session(neo4j.AccessModeWrite)
+		session, err = driver.Session(context.TODO(), neo4j.AccessModeWrite)
 		Expect(err).To(BeNil())
 		Expect(session).NotTo(BeNil())
 	})
@@ -57,7 +58,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive boolean property", func() {
 		value := true
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -68,7 +69,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive byte property", func() {
 		value := byte(1)
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -80,7 +81,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive int8 property", func() {
 		value := int8(2)
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -92,7 +93,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive int16 property", func() {
 		value := int16(3)
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -104,7 +105,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive int property", func() {
 		value := int(4)
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -116,7 +117,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive int32 property", func() {
 		value := int32(5)
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -128,7 +129,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive int64 property", func() {
 		value := int64(6)
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -140,7 +141,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive float32 property", func() {
 		value := float32(7.1)
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -152,7 +153,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive float64 property", func() {
 		value := float64(81.9224)
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -164,7 +165,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive string property", func() {
 		value := "a string"
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -176,7 +177,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive byte array property", func() {
 		value := []byte{1, 2, 3, 4, 5}
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -188,7 +189,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive boolean array property", func() {
 		value := []bool{true, false, false, true}
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -200,7 +201,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive int array property", func() {
 		value := []int{1, 2, 3, 4, 5}
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -212,7 +213,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive float64 array property", func() {
 		value := []float64{1.11, 2.22, 3.33, 4.44, 5.55}
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -224,7 +225,7 @@ var _ = Describe("Types", func() {
 
 	It("should be able to send and receive string array property", func() {
 		value := []string{"a", "b", "c", "d", "e"}
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -247,7 +248,7 @@ var _ = Describe("Types", func() {
 
 		value := randSeq(20 * 1024)
 
-		result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+		result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -258,7 +259,7 @@ var _ = Describe("Types", func() {
 	})
 
 	It("should be able to receive a node with properties", func() {
-		result, err = session.Run("CREATE (n:Person:Manager {id: 1, name: 'a name'}) RETURN n", nil)
+		result, err = session.Run(context.TODO(), "CREATE (n:Person:Manager {id: 1, name: 'a name'}) RETURN n", nil)
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -277,7 +278,7 @@ var _ = Describe("Types", func() {
 	})
 
 	It("should be able to receive a relationship with properties", func() {
-		result, err = session.Run("CREATE (e:Person:Employee {id: 1, name: 'employee 1'})-[w:WORKS_FOR { from: '2017-01-01' }]->(m:Person:Manager {id: 2, name: 'manager 1'}) RETURN e, w, m", nil)
+		result, err = session.Run(context.TODO(), "CREATE (e:Person:Employee {id: 1, name: 'employee 1'})-[w:WORKS_FOR { from: '2017-01-01' }]->(m:Person:Manager {id: 2, name: 'manager 1'}) RETURN e, w, m", nil)
 		Expect(err).To(BeNil())
 
 		Expect(result.Next()).To(BeTrue())
@@ -315,7 +316,7 @@ var _ = Describe("Types", func() {
 	})
 
 	It("should be able to receive a path with two nodes and one relationship", func() {
-		result, err = session.Run("CREATE p=(e:Person:Employee {id: 1, name: 'employee 1'})-[w:WORKS_FOR { from: '2017-01-01' }]->(m:Person:Manager {id: 2, name: 'manager 1'}) RETURN p, e, w, m", nil)
+		result, err = session.Run(context.TODO(), "CREATE p=(e:Person:Employee {id: 1, name: 'employee 1'})-[w:WORKS_FOR { from: '2017-01-01' }]->(m:Person:Manager {id: 2, name: 'manager 1'}) RETURN p, e, w, m", nil)
 		Expect(err).To(BeNil())
 		Expect(result.Next()).To(BeTrue())
 		path := result.Record().Values[0].(neo4j.Path)
@@ -334,7 +335,7 @@ var _ = Describe("Types", func() {
 	})
 
 	It("should be able to receive a path with three nodes and two relationship", func() {
-		result, err = session.Run(`CREATE (e1:Person:Employee $employee) 
+		result, err = session.Run(context.TODO(), `CREATE (e1:Person:Employee $employee) 
 				CREATE (l1:Person:Lead $lead) 
 				CREATE (m1:Person:Manager $manager) 
 				CREATE p = (e1)-[r1:LED_BY { from: '2017-01-01' }]->(l1)-[r2:REPORTS_TO { from: '2017-01-01' }]->(m1)
@@ -376,7 +377,7 @@ var _ = Describe("Types", func() {
 
 	DescribeTable("should be able to send and receive nil pointer property",
 		func(value interface{}) {
-			result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+			result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 			Expect(err).To(BeNil())
 
 			Expect(result.Next()).To(BeTrue())
@@ -422,14 +423,14 @@ var _ = Describe("Types", func() {
 
 		Context("Session.Run", func() {
 			It("should fail when sending as parameter", func() {
-				result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": unsupportedType{}})
+				result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": unsupportedType{}})
 				Expect(err).ToNot(BeNil())
 				//Expect(err).To(BeGenericError(ContainSubstring("unable to convert parameter \"value\" to connector value for run message")))
 				Expect(result).To(BeNil())
 			})
 
 			It("should fail when sending as tx metadata", func() {
-				result, err = session.Run("CREATE (n)", nil, neo4j.WithTxMetadata(map[string]interface{}{"m1": unsupportedType{}}))
+				result, err = session.Run(context.TODO(), "CREATE (n)", nil, neo4j.WithTxMetadata(map[string]interface{}{"m1": unsupportedType{}}))
 				Expect(err).ToNot(BeNil())
 				//Expect(err).To(BeGenericError(ContainSubstring("unable to convert tx metadata to connector value for run message")))
 				Expect(result).To(BeNil())
@@ -486,7 +487,7 @@ var _ = Describe("Types", func() {
 			var tx neo4j.Transaction
 
 			It("should fail when sending as tx metadata", func() {
-				tx, err = session.BeginTransaction()
+				tx, err = session.BeginTransaction(context.TODO())
 				Expect(err).To(BeNil())
 				Expect(tx).NotTo(BeNil())
 
@@ -552,7 +553,7 @@ var _ = Describe("Types", func() {
 
 		DescribeTable("should be able to send and receive nil pointers",
 			func(value interface{}) {
-				result, err = session.Run("CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
+				result, err = session.Run(context.TODO(), "CREATE (n {value: $value}) RETURN n.value", map[string]interface{}{"value": value})
 				Expect(err).To(BeNil())
 
 				Expect(result.Next()).To(BeTrue())
@@ -625,7 +626,7 @@ var _ = Describe("Types", func() {
 					}
 				}
 
-				result, err = session.Run("CREATE (n {value1: $value1, value2: $value2}) RETURN n.value1, n.value2", map[string]interface{}{"value1": value, "value2": &value})
+				result, err = session.Run(context.TODO(), "CREATE (n {value1: $value1, value2: $value2}) RETURN n.value1, n.value2", map[string]interface{}{"value1": value, "value2": &value})
 				Expect(err).To(BeNil())
 
 				Expect(result.Next()).To(BeTrue())

--- a/neo4j/test-integration/utils_test.go
+++ b/neo4j/test-integration/utils_test.go
@@ -20,6 +20,7 @@
 package test_integration
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -53,21 +54,21 @@ func transactionWithIntWork(tx neo4j.Transaction, work neo4j.TransactionWork) in
 }
 
 func readTransactionWithIntWork(session neo4j.Session, work neo4j.TransactionWork, configurers ...func(*neo4j.TransactionConfig)) int64 {
-	result, err := session.ReadTransaction(work, configurers...)
+	result, err := session.ReadTransaction(context.TODO(), work, configurers...)
 	Expect(err).To(BeNil())
 
 	return result.(int64)
 }
 
 func writeTransactionWithIntWork(session neo4j.Session, work neo4j.TransactionWork, configurers ...func(*neo4j.TransactionConfig)) int64 {
-	result, err := session.WriteTransaction(work, configurers...)
+	result, err := session.WriteTransaction(context.TODO(), work, configurers...)
 	Expect(err).To(BeNil())
 
 	return result.(int64)
 }
 
 func newSession(driver neo4j.Driver, mode neo4j.AccessMode) neo4j.Session {
-	session, err := driver.Session(mode)
+	session, err := driver.Session(context.TODO(), mode)
 	Expect(err).To(BeNil())
 	return session
 }
@@ -75,7 +76,7 @@ func newSession(driver neo4j.Driver, mode neo4j.AccessMode) neo4j.Session {
 func newSessionAndTx(driver neo4j.Driver, mode neo4j.AccessMode, configurers ...func(*neo4j.TransactionConfig)) (neo4j.Session, neo4j.Transaction) {
 	session := newSession(driver, mode)
 
-	tx, err := session.BeginTransaction(configurers...)
+	tx, err := session.BeginTransaction(context.TODO(), configurers...)
 	Expect(err).To(BeNil())
 
 	return session, tx
@@ -89,9 +90,9 @@ func createNode(session neo4j.Session, label string, props map[string]interface{
 	)
 
 	if len(props) > 0 {
-		result, err = session.Run(fmt.Sprintf("CREATE (n:%s) SET n = $props", label), map[string]interface{}{"props": props})
+		result, err = session.Run(context.TODO(), fmt.Sprintf("CREATE (n:%s) SET n = $props", label), map[string]interface{}{"props": props})
 	} else {
-		result, err = session.Run(fmt.Sprintf("CREATE (n:%s)", label), nil)
+		result, err = session.Run(context.TODO(), fmt.Sprintf("CREATE (n:%s)", label), nil)
 	}
 	Expect(err).To(BeNil())
 
@@ -152,7 +153,7 @@ func updateNode(session neo4j.Session, label string, newProps map[string]interfa
 		ginkgo.Fail("newProps is empty")
 	}
 
-	result, err = session.Run(fmt.Sprintf("MATCH (n:%s) SET n = $props", label), map[string]interface{}{"props": newProps})
+	result, err = session.Run(context.TODO(), fmt.Sprintf("MATCH (n:%s) SET n = $props", label), map[string]interface{}{"props": newProps})
 	Expect(err).To(BeNil())
 
 	summary, err = result.Consume()

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -268,9 +269,9 @@ func (b *backend) handleTransactionFunc(isRead bool, data map[string]interface{}
 	}
 	var err error
 	if isRead {
-		_, err = sessionState.session.ReadTransaction(blockingRetry, b.toTransactionConfigApply(data))
+		_, err = sessionState.session.ReadTransaction(context.Background(), blockingRetry, b.toTransactionConfigApply(data))
 	} else {
-		_, err = sessionState.session.WriteTransaction(blockingRetry, b.toTransactionConfigApply(data))
+		_, err = sessionState.session.WriteTransaction(context.Background(), blockingRetry, b.toTransactionConfigApply(data))
 	}
 
 	if err != nil {
@@ -377,7 +378,7 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 	case "SessionRun":
 		sessionState := b.sessionStates[data["sessionId"].(string)]
 		cypher, params := b.toCypherAndParams(data)
-		result, err := sessionState.session.Run(cypher, params, b.toTransactionConfigApply(data))
+		result, err := sessionState.session.Run(context.Background(), cypher, params, b.toTransactionConfigApply(data))
 		if err != nil {
 			b.writeError(err)
 			return
@@ -388,7 +389,7 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 
 	case "SessionBeginTransaction":
 		sessionState := b.sessionStates[data["sessionId"].(string)]
-		tx, err := sessionState.session.BeginTransaction(b.toTransactionConfigApply(data))
+		tx, err := sessionState.session.BeginTransaction(context.Background(), b.toTransactionConfigApply(data))
 		if err != nil {
 			b.writeError(err)
 			return


### PR DESCRIPTION
Adding `context.Context` to each function. This is a proposal to follow a practice  to use context as function parameter. 

I know this breaks the API but I don't know how important to keep the API unchanged.

**Potential pros:**

* Enable tracing of driver. In our project we use OpenTelemetry and this would greatly simplify the integration.
* Allow to control the operation timeout or cancel.

If the HTTP server has a request timeout and under heavy load the request all waiting for the pool to return a Connection but it takes more time than the timeout, there is no way not to cancel the operation. This could allow but there are still a lot to do until. 

I intend to solve the #190 problem that makes the system non response under high load. 