### PR TITLE
testkit-backend: treat 'Invalid transaction handle' as driver error

### DIFF
--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -112,7 +112,8 @@ func (b *backend) writeError(err error) {
 	isDriverError := neo4j.IsNeo4jError(err) ||
 		neo4j.IsUsageError(err) ||
 		neo4j.IsConnectivityError(err) ||
-		neo4j.IsTransactionExecutionLimit(err)
+		neo4j.IsTransactionExecutionLimit(err) ||
+		err.Error() == "Invalid transaction handle"
 
 	if isDriverError {
 		id := b.setError(err)


### PR DESCRIPTION
This kind of errors were being wrongly considered backend errors, It could make difficult to assert situations of wrong driver usage like commit in a already commited transaction and checks if the driver thorws an error.