### PR TITLE
Fix profile child computation

### DIFF
--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -20,6 +20,7 @@
 package neo4j
 
 import (
+	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j/db"
 	"time"
 )
@@ -355,6 +356,10 @@ type profile struct {
 	profile *db.ProfiledPlan
 }
 
+func (p *profile) String() string {
+	return fmt.Sprintf("%v", *p.profile)
+}
+
 func (p *profile) Operator() string {
 	return p.profile.Operator
 }
@@ -378,7 +383,8 @@ func (p *profile) Records() int64 {
 func (p *profile) Children() []ProfiledPlan {
 	children := make([]ProfiledPlan, len(p.profile.Children))
 	for i, c := range p.profile.Children {
-		children[i] = &profile{profile: &c}
+		child := c
+		children[i] = &profile{profile: &child}
 	}
 	return children
 }

--- a/neo4j/resultsummary_test.go
+++ b/neo4j/resultsummary_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package neo4j
+
+import (
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j/db"
+	"reflect"
+	"testing"
+)
+
+func TestProfiledPlan(st *testing.T) {
+	leaf1 := db.ProfiledPlan{Operator: "bar"}
+	leaf2 := db.ProfiledPlan{Operator: "fighters"}
+	root := &profile{profile: &db.ProfiledPlan{Operator: "foo", Children: []db.ProfiledPlan{leaf1, leaf2}}}
+
+	st.Run("Child plans are correctly populated", func(t *testing.T) {
+		expected := []ProfiledPlan{
+			&profile{profile: &leaf1},
+			&profile{profile: &leaf2},
+		}
+
+		children := root.Children()
+
+		if !reflect.DeepEqual(children, expected) {
+			t.Errorf("Expected %v to equal %v", children, expected)
+		}
+	})
+}


### PR DESCRIPTION
A range variable "lives" at the same virtual address during the
whole for scope. Without this fix, this means the plan children
slice will be made of n times the same profile plan instance (i.e.
the last one).