### PR TITLE
Fix testkit test test_discards_on_session_close

### DIFF
--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -429,7 +429,11 @@ func (b *bolt4) discardStream() {
 			// already sent a discard.
 			discarded = true
 			stream.fetchSize = -1
-			b.out.appendDiscardNQid(stream.fetchSize, stream.qid)
+			if b.state == bolt4_streamingtx {
+				b.out.appendDiscardNQid(stream.fetchSize, stream.qid)
+			} else {
+				b.out.appendDiscardN(stream.fetchSize)
+			}
 			b.out.send(b.conn)
 		} else if sum != nil || b.err != nil {
 			// Stream is detached in receiveNext

--- a/neo4j/internal/bolt/bolt4_test.go
+++ b/neo4j/internal/bolt/bolt4_test.go
@@ -302,7 +302,7 @@ func TestBolt4(ot *testing.T) {
 			// ... and the batch summary
 			srv.send(msgSuccess, map[string]interface{}{"has_more": true})
 			// Wait for the discard message
-			srv.waitForDiscardN(-1, int(qid))
+			srv.waitForDiscardNAndQid(-1, int(qid))
 			// Respond to discard with has more to indicate that there are more records
 			srv.send(msgSuccess, map[string]interface{}{"has_more": true})
 			// Wait for the commit
@@ -730,7 +730,7 @@ func TestBolt4(ot *testing.T) {
 			srv.send(msgRecord, []interface{}{"2"})
 			srv.send(msgRecord, []interface{}{"3"})
 			srv.send(msgSuccess, map[string]interface{}{"has_more": true, "qid": int64(qid)})
-			srv.waitForDiscardN(-1, qid)
+			srv.waitForDiscardN(-1)
 			srv.send(msgSuccess, map[string]interface{}{"bookmark": bookmark, "type": "r"})
 		})
 		defer cleanup()

--- a/neo4j/internal/bolt/bolt4server_test.go
+++ b/neo4j/internal/bolt/bolt4server_test.go
@@ -163,7 +163,8 @@ func (s *bolt4server) waitForPullNandQid(n, qid int) {
 		panic(fmt.Sprintf("Expected PULL qid:%d but got PULL %d", qid, sentQid))
 	}
 }
-func (s *bolt4server) waitForDiscardN(n, qid int) {
+
+func (s *bolt4server) waitForDiscardNAndQid(n, qid int) {
 	msg := s.receiveMsg()
 	s.assertStructType(msg, msgDiscardN)
 	extra := msg.fields[0].(map[string]interface{})
@@ -174,6 +175,20 @@ func (s *bolt4server) waitForDiscardN(n, qid int) {
 	sentQid := int(extra["qid"].(int64))
 	if sentQid != qid {
 		panic(fmt.Sprintf("Expected DISCARD qid:%d but got DISCARD %d", qid, sentQid))
+	}
+}
+
+func (s *bolt4server) waitForDiscardN(n int) {
+	msg := s.receiveMsg()
+	s.assertStructType(msg, msgDiscardN)
+	extra := msg.fields[0].(map[string]interface{})
+	sentN := int(extra["n"].(int64))
+	if sentN != n {
+		panic(fmt.Sprintf("Expected DISCARD n:%d but got DISCARD %d", n, sentN))
+	}
+	_, hasQid := extra["qid"]
+	if hasQid {
+		panic("Expected DISCARD without qid")
 	}
 }
 

--- a/neo4j/internal/bolt/outgoing.go
+++ b/neo4j/internal/bolt/outgoing.go
@@ -127,6 +127,18 @@ func (o *outgoing) appendPullNQid(n int, qid int64) {
 	o.end()
 }
 
+func (o *outgoing) appendDiscardN(n int) {
+	if o.boltLogger != nil {
+		o.boltLogger.LogClientMessage(o.logId, "DISCARD %s", loggableDictionary{"n": n})
+	}
+	o.begin()
+	o.packer.StructHeader(byte(msgDiscardN), 1)
+	o.packer.MapHeader(1)
+	o.packer.String("n")
+	o.packer.Int(n)
+	o.end()
+}
+
 func (o *outgoing) appendDiscardNQid(n int, qid int64) {
 	if o.boltLogger != nil {
 		o.boltLogger.LogClientMessage(o.logId, "DISCARD %s", loggableDictionary{"n": n, "qid": qid})


### PR DESCRIPTION
Do not include qid in DISCARD when it is -1

Signed-off-by: Rouven Bauer <rouven.bauer@neo4j.com>