### PR TITLE
Close connections on cluster retryable errors

### DIFF
--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -109,6 +109,7 @@ func (s *State) OnFailure(conn db.Connection, err error, isCommitting bool) {
 	if dbErr, isDbErr := err.(*db.Neo4jError); isDbErr {
 		if dbErr.IsRetriableCluster() {
 			// Force routing tables to be updated before trying again
+			conn.Close()
 			s.Router.Invalidate(s.DatabaseName)
 			s.cause = "Cluster error"
 			s.LastErrWasRetryable = true


### PR DESCRIPTION
 so that a new TCP connection is used to fetch new routing table

When server side routing is used with a load balancer using the same TCP connection will get you to the same back end. Even if the intervening load balancer has detected a problem it will not necessarily kill open tcp connections

closing the tcp connection and getting a new one after a cluster-retriable error ensures that you get a connection to a server that any intervening components think is healthy