### PR TITLE
Implement connection read timeout hint

### DIFF
--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -96,6 +96,8 @@ func NewBolt3(serverName string, conn net.Conn, log log.Logger, boltLog log.Bolt
 			hyd: hydrator{
 				boltLogger: boltLog,
 			},
+			connReadTimeout: -1,
+			logger: log,
 		},
 		birthDate: time.Now(),
 		log:       log,
@@ -195,6 +197,7 @@ func (b *bolt3) connect(minor int, auth map[string]interface{}, userAgent string
 	b.connId = succ.connectionId
 	connectionLogId := fmt.Sprintf("%s@%s", b.connId, b.serverName)
 	b.logId = connectionLogId
+	b.in.logId = connectionLogId
 	b.in.hyd.logId = connectionLogId
 	b.out.logId = connectionLogId
 	b.serverVersion = succ.server

--- a/neo4j/internal/bolt/bolt3server_test.go
+++ b/neo4j/internal/bolt/bolt3server_test.go
@@ -91,7 +91,7 @@ func (s *bolt3server) waitForHello() {
 }
 
 func (s *bolt3server) receiveMsg() *testStruct {
-	_, buf, err := dechunkMessage(s.conn, []byte{})
+	_, buf, err := dechunkMessage(s.conn, []byte{}, -1, nil, "")
 	if err != nil {
 		panic(err)
 	}

--- a/neo4j/internal/bolt/bolt4server_test.go
+++ b/neo4j/internal/bolt/bolt4server_test.go
@@ -94,7 +94,7 @@ func (s *bolt4server) waitForHello() map[string]interface{} {
 }
 
 func (s *bolt4server) receiveMsg() *testStruct {
-	_, buf, err := dechunkMessage(s.conn, []byte{})
+	_, buf, err := dechunkMessage(s.conn, []byte{}, -1, nil, "")
 	if err != nil {
 		panic(err)
 	}
@@ -229,6 +229,14 @@ func (s *bolt4server) acceptHello() {
 	s.send(msgSuccess, map[string]interface{}{
 		"connection_id": "cid",
 		"server":        "fake/4.5",
+	})
+}
+
+func (s *bolt4server) acceptHelloWithHints(hints map[string]interface{}) {
+	s.send(msgSuccess, map[string]interface{}{
+		"connection_id": "cid",
+		"server":        "fake/4.5",
+		"hints":         hints,
 	})
 }
 

--- a/neo4j/internal/bolt/dechunker.go
+++ b/neo4j/internal/bolt/dechunker.go
@@ -21,18 +21,23 @@ package bolt
 
 import (
 	"encoding/binary"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j/log"
 	"io"
+	"net"
+	"time"
 )
 
 // dechunkMessage takes a buffer to be reused and returns the reusable buffer
 // (might have been reallocated to handle growth), the message buffer and
 // error.
-func dechunkMessage(rd io.Reader, msgBuf []byte) ([]byte, []byte, error) {
+// If a non-default connection read timeout configuration hint is passed, the dechunker resets the connection read
+// deadline as well after successfully reading a chunk (NOOP messages included)
+func dechunkMessage(conn net.Conn, msgBuf []byte, readTimeout time.Duration, logger log.Logger, logId string) ([]byte, []byte, error) {
 	sizeBuf := []byte{0x00, 0x00}
 	off := 0
 
 	for {
-		_, err := io.ReadFull(rd, sizeBuf)
+		_, err := io.ReadFull(conn, sizeBuf)
 		if err != nil {
 			return msgBuf, nil, err
 		}
@@ -42,6 +47,7 @@ func dechunkMessage(rd io.Reader, msgBuf []byte) ([]byte, []byte, error) {
 				return msgBuf, msgBuf[:off], nil
 			}
 			// Got a nop chunk
+			resetConnectionReadDeadline(conn, readTimeout, logger, logId)
 			continue
 		}
 
@@ -52,10 +58,20 @@ func dechunkMessage(rd io.Reader, msgBuf []byte) ([]byte, []byte, error) {
 			msgBuf = newMsgBuf
 		}
 		// Read the chunk into buffer
-		_, err = io.ReadFull(rd, msgBuf[off:(off+chunkSize)])
+		_, err = io.ReadFull(conn, msgBuf[off:(off+chunkSize)])
 		if err != nil {
 			return msgBuf, nil, err
 		}
 		off += chunkSize
+		resetConnectionReadDeadline(conn, readTimeout, logger, logId)
+	}
+}
+
+func resetConnectionReadDeadline(conn net.Conn, readTimeout time.Duration, logger log.Logger, logId string) {
+	if readTimeout < 0 {
+		return
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
+		logger.Error(log.Bolt4, logId, err)
 	}
 }

--- a/neo4j/internal/bolt/hydratedehydrate_test.go
+++ b/neo4j/internal/bolt/hydratedehydrate_test.go
@@ -20,7 +20,7 @@
 package bolt
 
 import (
-	"bytes"
+	"net"
 	"testing"
 	"time"
 
@@ -30,24 +30,33 @@ import (
 )
 
 func TestDehydrateHydrate(ot *testing.T) {
-	out := &outgoing{
-		chunker: newChunker(),
-		packer:  packstream.Packer{},
-		onErr: func(err error) {
-			ot.Fatalf("Should be no dehydration errors in this test: %s", err)
-		},
-	}
 	hydrator := hydrator{}
 
 	// A bit of white box testing, uses "internal" APIs to shortcut
 	// hydration/dehydration circuit.
 	dehydrateAndHydrate := func(t *testing.T, xi interface{}) interface{} {
-		// Put the stuff in a record to avoid getting too violent with the hydrator
-		out.appendX(byte(msgRecord), []interface{}{xi})
-		buf := &bytes.Buffer{}
-		out.send(buf)
-
-		_, byts, err := dechunkMessage(buf, []byte{})
+		out := &outgoing{
+			chunker: newChunker(),
+			packer:  packstream.Packer{},
+			onErr: func(err error) {
+				ot.Fatalf("Should be no dehydration errors in this test: %s", err)
+			},
+		}
+		serv, cli := net.Pipe()
+		defer func() {
+			if err := cli.Close(); err != nil {
+				ot.Errorf("failed to close client connection %v", err)
+			}
+			if err := serv.Close(); err != nil {
+				ot.Errorf("failed to close server connection %v", err)
+			}
+		}()
+		// format data in a record to avoid confusing the hydrator
+		out.appendX(msgRecord, []interface{}{xi})
+		go func() {
+			out.send(cli)
+		}()
+		_, byts, err := dechunkMessage(serv, []byte{}, -1, nil, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -56,7 +65,6 @@ func TestDehydrateHydrate(ot *testing.T) {
 		if err != nil {
 			ot.Fatalf("Should be no hydration errors in this test: %s", err)
 		}
-
 		rec := recx.(*db.Record)
 		return rec.Values[0]
 	}

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -49,7 +49,8 @@ type success struct {
 	profile       *db.ProfiledPlan
 	notifications []db.Notification
 	routingTable  *db.RoutingTable
-	num           uint32
+	num                uint32
+	configurationHints map[string]interface{}
 }
 
 func (s *success) String() string {
@@ -241,6 +242,9 @@ func (h *hydrator) success(n uint32) *success {
 			succ.notifications = parseNotifications(l)
 		case "rt":
 			succ.routingTable = h.routingTable()
+		case "hints":
+			hints := h.amap()
+			succ.configurationHints = hints
 		default:
 			// Unknown key, waste it
 			h.trash()

--- a/neo4j/internal/bolt/incoming.go
+++ b/neo4j/internal/bolt/incoming.go
@@ -19,19 +19,24 @@
 package bolt
 
 import (
-	"io"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j/log"
+	"net"
+	"time"
 )
 
 type incoming struct {
-	buf []byte // Reused buffer
-	hyd hydrator
+	buf             []byte // Reused buffer
+	hyd             hydrator
+	connReadTimeout time.Duration
+	logger          log.Logger
+	logId           string
 }
 
-func (i *incoming) next(rd io.Reader) (interface{}, error) {
+func (i *incoming) next(rd net.Conn) (interface{}, error) {
 	// Get next message from transport layer
 	var err error
 	var msg []byte
-	i.buf, msg, err = dechunkMessage(rd, i.buf)
+	i.buf, msg, err = dechunkMessage(rd, i.buf, i.connReadTimeout, i.logger, i.logId)
 	if err != nil {
 		return nil, err
 	}

--- a/neo4j/internal/testutil/asserts.go
+++ b/neo4j/internal/testutil/asserts.go
@@ -21,6 +21,7 @@
 package testutil
 
 import (
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -65,6 +66,12 @@ func AssertNextOnlyError(t *testing.T, rec *db.Record, sum *db.Summary, err erro
 	if err == nil {
 		t.Errorf("Expected error")
 	}
+}
+
+func AssertWriteSucceeds(t *testing.T, w io.Writer, b []byte) {
+	t.Helper()
+	_, err := w.Write(b)
+	AssertNoError(t, err)
 }
 
 func AssertNoError(t *testing.T, err error) {

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -24,13 +24,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j/db"
 	"io"
 	"net/url"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
-
-	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 )
 
 // Handles a testkit backend session.
@@ -396,6 +397,7 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 	case "NewSession":
 		driver := b.drivers[data["driverId"].(string)]
 		sessionConfig := neo4j.SessionConfig{}
+		sessionConfig.BoltLogger = neo4j.ConsoleBoltLogger()
 		switch data["accessMode"].(string) {
 		case "r":
 			sessionConfig.AccessMode = neo4j.AccessModeRead
@@ -499,6 +501,17 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 		}
 		b.writeResponse("Transaction", map[string]interface{}{"id": txId})
 
+	case "TransactionClose":
+		txId := data["txId"].(string)
+		tx := b.transactions[txId]
+		delete(b.transactions, txId)
+		err := tx.Close()
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		b.writeResponse("TransactionClose", map[string]interface{}{"id": txId})
+
 	case "SessionReadTransaction":
 		b.handleTransactionFunc(true, data)
 
@@ -549,12 +562,15 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 		})
 
 	case "GetFeatures":
-		b.writeResponse("FeatureList", nil)
+		b.writeResponse("FeatureList", map[string]interface{}{
+			"features": []string{
+				"ConfHint:connection.recv_timeout_seconds",
+			},
+		})
 
 	case "StartTest":
 		testName := data["testName"].(string)
-		skippedTests := testSkips()
-		if reason, ok := skippedTests[testName]; ok {
+		if reason, ok := mustSkip(testName); ok {
 			b.writeResponse("SkipTest", map[string]interface{}{"reason": reason})
 			return
 		}
@@ -565,14 +581,43 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 	}
 }
 
+func mustSkip(testName string) (string, bool) {
+	skippedTests := testSkips()
+	for testPattern, exclusionReason := range skippedTests {
+		if matches(testPattern, testName) {
+			return exclusionReason, true
+		}
+	}
+	return "", false
+}
+
+func matches(pattern, testName string) bool {
+	if pattern == testName {
+		return true
+	}
+	if !strings.Contains(pattern, "*") {
+		return false
+	}
+	regex := asRegex(pattern)
+	return regex.MatchString(testName)
+}
+
+func asRegex(rawPattern string) *regexp.Regexp {
+	pattern := regexp.QuoteMeta(rawPattern)
+	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
+	return regexp.MustCompile(pattern)
+}
+
+// you can use '*' as wildcards anywhere in the qualified test name (useful to exclude a whole class e.g.)
 func testSkips() map[string]string {
 	return map[string]string{
-		"stub.disconnects.test_disconnects.TestDisconnects.test_fail_on_reset": "It is not resetting driver when put back to pool",
-		"stub.routing.test_routing_v3.RoutingV3.test_should_use_resolver_during_rediscovery_when_existing_routers_fail": "It needs investigation - custom resolver does not seem to be called",
-		"stub.routing.test_routing_v4x1.RoutingV4x1.test_should_use_resolver_during_rediscovery_when_existing_routers_fail": "It needs investigation - custom resolver does not seem to be called",
-		"stub.routing.test_routing_v4x3.RoutingV4x3.test_should_use_resolver_during_rediscovery_when_existing_routers_fail": "It needs investigation - custom resolver does not seem to be called",
-		"stub.routing.test_routing_v3.RoutingV3.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors": "It needs investigation - custom resolver does not seem to be called",
+		"stub.disconnects.test_disconnects.TestDisconnects.test_fail_on_reset":                                                   "It is not resetting driver when put back to pool",
+		"stub.routing.test_routing_v3.RoutingV3.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":          "It needs investigation - custom resolver does not seem to be called",
+		"stub.routing.test_routing_v4x1.RoutingV4x1.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":      "It needs investigation - custom resolver does not seem to be called",
+		"stub.routing.test_routing_v4x3.RoutingV4x3.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":      "It needs investigation - custom resolver does not seem to be called",
+		"stub.routing.test_routing_v3.RoutingV3.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":     "It needs investigation - custom resolver does not seem to be called",
 		"stub.routing.test_routing_v4x1.RoutingV4x1.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors": "It needs investigation - custom resolver does not seem to be called",
 		"stub.routing.test_routing_v4x3.RoutingV4x3.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors": "It needs investigation - custom resolver does not seem to be called",
+		"stub.configuration_hints.test_connection_recv_timeout_seconds.TestRoutingConnectionRecvTimeout.*":                       "No GetRoutingTable support - too tricky to implement in Go",
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/neo4j-drivers/testkit/pull/234

Reset connection read deadline after every message reception,
including NOOPs.

Exclude routing-aware configuration hint testkit tests, as
`GetRoutingTable` is too complicated/fragile to implement in Go