### PR TITLE
Rename query in result summary to match other drivers

### DIFF
--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -44,7 +44,7 @@ const (
 type ResultSummary interface {
 	// Server returns basic information about the server where the statement is carried out.
 	Server() ServerInfo
-	// Deprecated: Use Query instead
+	// Deprecated: since 4.4, will be removed in 5.0. Use Query instead
 	Statement() Statement
 	// Query returns the query that has been executed.
 	Query() Query
@@ -104,7 +104,7 @@ type Statement interface {
 type Query interface {
 	// Text returns the statement's text.
 	Text() string
-	// Deprecated: Use Parameters instead
+	// Deprecated: since 4.4, will be removed in 5.0. Use Parameters instead
 	Params() map[string]interface{}
 	// Parameters returns the statement's parameters.
 	Parameters() map[string]interface{}

--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -44,8 +44,10 @@ const (
 type ResultSummary interface {
 	// Server returns basic information about the server where the statement is carried out.
 	Server() ServerInfo
-	// Statement returns statement that has been executed.
+	// Deprecated: Use Query instead
 	Statement() Statement
+	// Query returns the query that has been executed.
+	Query() Query
 	// StatementType returns type of statement that has been executed.
 	StatementType() StatementType
 	// Counters returns statistics counts for the statement.
@@ -96,10 +98,16 @@ type Counters interface {
 }
 
 type Statement interface {
+	Query
+}
+
+type Query interface {
 	// Text returns the statement's text.
 	Text() string
-	// Params returns the statement's parameters.
+	// Deprecated: Use Parameters instead
 	Params() map[string]interface{}
+	// Parameters returns the statement's parameters.
+	Parameters() map[string]interface{}
 }
 
 // ServerInfo contains basic information of the server.
@@ -219,6 +227,10 @@ func (s *resultSummary) Statement() Statement {
 	return s
 }
 
+func (s *resultSummary) Query() Query {
+	return s
+}
+
 func (s *resultSummary) StatementType() StatementType {
 	return StatementType(s.sum.StmntType)
 }
@@ -228,6 +240,10 @@ func (s *resultSummary) Text() string {
 }
 
 func (s *resultSummary) Params() map[string]interface{} {
+	return s.Parameters()
+}
+
+func (s *resultSummary) Parameters() map[string]interface{} {
 	return s.params
 }
 

--- a/neo4j/test-integration/session_test.go
+++ b/neo4j/test-integration/session_test.go
@@ -78,8 +78,8 @@ var _ = Describe("Session", func() {
 			Expect(result.Next()).To(BeFalse())
 			Expect(result.Err()).To(BeNil())
 
-			Expect(summary.Statement().Text()).To(BeIdenticalTo(stmt))
-			Expect(summary.Statement().Params()).To(BeNil())
+			Expect(summary.Query().Text()).To(BeIdenticalTo(stmt))
+			Expect(summary.Query().Parameters()).To(BeNil())
 		})
 
 		Specify("when a query is executed, it should run and return summary with correct statement and params", func() {
@@ -96,8 +96,8 @@ var _ = Describe("Session", func() {
 			Expect(result.Next()).To(BeFalse())
 			Expect(result.Err()).To(BeNil())
 
-			Expect(summary.Statement().Text()).To(Equal(stmt))
-			Expect(summary.Statement().Params()).To(Equal(params))
+			Expect(summary.Query().Text()).To(Equal(stmt))
+			Expect(summary.Query().Parameters()).To(Equal(params))
 		})
 
 		Specify("when a query is executed, it should run and return summary when consumed", func() {


### PR DESCRIPTION
Deprecate ResultSummary.Statement() -> .Query()
Rename Statement interface -> Query
Deprecate Query.Params() -> .Parameters()