### PR TITLE
Do not raise error when closing a session with a pending tx

### DIFF
--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -458,9 +458,7 @@ func (s *session) Close() error {
 	var err error
 
 	if s.txExplicit != nil {
-		s.txExplicit.Close()
-		err = &UsageError{Message: "Closing session with a pending transaction"}
-		s.log.Warnf(log.Session, s.logId, err.Error())
+		err = s.txExplicit.Close()
 	}
 
 	if s.txAuto != nil {


### PR DESCRIPTION
This aligns with the behavior of the other official drivers.