### PR TITLE
Remove 4.0 Testkit feature flag

### DIFF
--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -133,10 +133,10 @@ func (b *backend) writeError(err error) {
 	if isDriverError {
 		id := b.setError(err)
 		b.writeResponse("DriverError", map[string]interface{}{
-			"id": id,
+			"id":        id,
 			"errorType": strings.Split(err.Error(), ":")[0],
-			"msg": err.Error(),
-			"code": code})
+			"msg":       err.Error(),
+			"code":      code})
 		return
 	}
 
@@ -592,7 +592,6 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 				"Feature:Auth:Bearer",
 				"Feature:Auth:Kerberos",
 				"Feature:Bolt:3.0",
-				"Feature:Bolt:4.0",
 				"Feature:Bolt:4.1",
 				"Feature:Bolt:4.2",
 				"Feature:Bolt:4.3",
@@ -691,7 +690,7 @@ func testSkips() map[string]string {
 		"stub.configuration_hints.test_connection_recv_timeout_seconds.TestRoutingConnectionRecvTimeout.*":                       "No GetRoutingTable support - too tricky to implement in Go",
 		"stub.homedb.test_homedb.TestHomeDb.test_session_should_cache_home_db_despite_new_rt":                                    "Driver does not remove servers from RT when connection breaks.",
 		"neo4j.test_authentication.TestAuthenticationBasic.test_error_on_incorrect_credentials_tx":                               "Driver retries tx on failed authentication.",
-		"stub.*.test_0_timeout":                                                                                                  "Driver omits 0 as tx timeout value",
-		"stub.*.test_negative_timeout":                                                                                           "Driver omits negative tx timeout values",
+		"stub.*.test_0_timeout":        "Driver omits 0 as tx timeout value",
+		"stub.*.test_negative_timeout": "Driver omits negative tx timeout values",
 	}
 }


### PR DESCRIPTION
4.0 is not supported in the 5.0 handshake (full or minimal)