### PR TITLE
Handle general network errors as connectivity errors

### DIFF
--- a/neo4j/error.go
+++ b/neo4j/error.go
@@ -141,11 +141,8 @@ func wrapError(err error) error {
 		return &ConnectivityError{inner: err}
 	case *retry.CommitFailedDeadError:
 		return &ConnectivityError{inner: err}
-	case *net.OpError:
-		if e.Timeout() && e.Op == "read" {
-			// most likely due to read timeout configuration hint being applied
-			return &ConnectivityError{inner: err}
-		}
+	case net.Error:
+		return &ConnectivityError{inner: err}
 	case *db.Neo4jError:
 		if e.Code == "Neo.ClientError.Security.TokenExpired" {
 			return &TokenExpiredError{Code: e.Code, Message: e.Msg}


### PR DESCRIPTION
This helps with some testkit tests where the error is sometimes
io.EOF or a TCP read error.

See stub test test_connection_pool_maxes_out_at_100_by_default e.g.