### PR TITLE
Remove "Temporary:ConnectionAcquisitionTimeout" TestKit flag

### DIFF
--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -685,7 +685,6 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 				"Optimization:ConnectionReuse",
 				"Optimization:ImplicitDefaultArguments",
 				"Optimization:PullPipelining",
-				"Temporary:ConnectionAcquisitionTimeout",
 				"Temporary:CypherPathAndRelationship",
 				"Temporary:DriverFetchSize",
 				"Temporary:DriverMaxConnectionPoolSize",


### PR DESCRIPTION
The this temporary feature flag will be removed from TestKit.

Tests that were guarded by it, will now be guarded by `Feature:API:ConnectionAcquisitionTimeout`
See also: https://github.com/neo4j-drivers/testkit/pull/417