### PR TITLE
Unify transaction behavior with other drivers

### DIFF
--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -742,7 +742,7 @@ func (b *bolt3) GetRoutingTable(ctx context.Context,
 		Cypher: "CALL dbms.cluster.routing.getRoutingTable($context)",
 		Params: map[string]interface{}{"context": routingContext},
 	}
-	txConfig := idb.TxConfig{Mode: idb.ReadMode}
+	txConfig := idb.TxConfig{Mode: idb.ReadMode, Timeout: idb.DefaultTxConfigTimeout}
 	streamHandle, err := b.Run(ctx, runCommand, txConfig)
 	if err != nil {
 		// Give a better error

--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -64,7 +64,7 @@ func (i *internalTx4) toMeta() map[string]interface{} {
 		meta["bookmarks"] = i.bookmarks
 	}
 	ms := int(i.timeout.Nanoseconds() / 1e6)
-	if ms > 0 {
+	if ms >= 0 {
 		meta["tx_timeout"] = ms
 	}
 	if len(i.txMeta) > 0 {
@@ -279,8 +279,7 @@ func (b *bolt4) checkImpersonationAndVersion(impersonatedUser string) error {
 	return nil
 }
 
-func (b *bolt4) TxBegin(ctx context.Context, txConfig idb.TxConfig) (idb.
-	TxHandle, error) {
+func (b *bolt4) TxBegin(ctx context.Context, txConfig idb.TxConfig) (idb.TxHandle, error) {
 	// Ok, to begin transaction while streaming auto-commit, just empty the stream and continue.
 	if b.state == bolt4_streaming {
 		if b.bufferStream(ctx); b.err != nil {
@@ -970,7 +969,7 @@ func (b *bolt4) callGetRoutingTable(ctx context.Context,
 		runCommand.Cypher = "CALL dbms.routing.getRoutingTable($context, $database)"
 		runCommand.Params["database"] = database
 	}
-	txConfig := idb.TxConfig{Mode: idb.ReadMode, Bookmarks: bookmarks}
+	txConfig := idb.TxConfig{Mode: idb.ReadMode, Bookmarks: bookmarks, Timeout: idb.DefaultTxConfigTimeout}
 	streamHandle, err := b.Run(ctx, runCommand, txConfig)
 	if err != nil {
 		return nil, err

--- a/neo4j/internal/db/connection.go
+++ b/neo4j/internal/db/connection.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
+	"math"
 	"time"
 )
 
@@ -53,6 +54,8 @@ type TxConfig struct {
 	ImpersonatedUser string
 	Meta             map[string]interface{}
 }
+
+const DefaultTxConfigTimeout = math.MinInt
 
 // Connection defines an abstract database server connection.
 type Connection interface {

--- a/neo4j/result_helpers.go
+++ b/neo4j/result_helpers.go
@@ -88,7 +88,7 @@ func Collect(result Result, err error) ([]*Record, error) {
 
 // AsRecords passes any existing error or casts from to a slice of records.
 // Use in combination with Collect and transactional functions:
-//   records, err := neo4j.AsRecords(session.ReadTransaction(func (tx neo4j.Transaction) {
+//   records, err := neo4j.AsRecords(session.ExecuteRead(func (tx neo4j.Transaction) {
 //       return neo4j.Collect(tx.Run(...))
 //   }))
 func AsRecords(from interface{}, err error) ([]*Record, error) {
@@ -106,7 +106,7 @@ func AsRecords(from interface{}, err error) ([]*Record, error) {
 
 // AsRecord passes any existing error or casts from to a record.
 // Use in combination with Single and transactional functions:
-//   record, err := neo4j.AsRecord(session.ReadTransaction(func (tx neo4j.Transaction) {
+//   record, err := neo4j.AsRecord(session.ExecuteRead(func (tx neo4j.Transaction) {
 //       return neo4j.Single(tx.Run(...))
 //   }))
 func AsRecord(from interface{}, err error) (*Record, error) {

--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -77,7 +77,7 @@ func (s *session) BeginTransaction(configurers ...func(*TransactionConfig)) (Tra
 func (s *session) ReadTransaction(
 	work TransactionWork, configurers ...func(*TransactionConfig)) (interface{}, error) {
 
-	return s.delegate.ReadTransaction(
+	return s.delegate.ExecuteRead(
 		context.Background(),
 		transactionWorkBridge(work),
 		configurers...,
@@ -87,7 +87,7 @@ func (s *session) ReadTransaction(
 func (s *session) WriteTransaction(
 	work TransactionWork, configurers ...func(*TransactionConfig)) (interface{}, error) {
 
-	return s.delegate.WriteTransaction(
+	return s.delegate.ExecuteWrite(
 		context.Background(),
 		transactionWorkBridge(work),
 		configurers...,

--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -108,8 +108,8 @@ func (s *session) Close() error {
 	return s.delegate.Close(context.Background())
 }
 
-func transactionWorkBridge(work TransactionWork) TransactionWorkWithContext {
-	return func(txc TransactionWithContext) (interface{}, error) {
+func transactionWorkBridge(work TransactionWork) ManagedTransactionWork {
+	return func(txc ManagedTransaction) (interface{}, error) {
 		return work(txc.legacy())
 	}
 }

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -48,12 +48,12 @@ type SessionWithContext interface {
 	lastBookmark() string
 	// BeginTransaction starts a new explicit transaction on this session
 	BeginTransaction(ctx context.Context, configurers ...func(*TransactionConfig)) (ExplicitTransaction, error)
-	// ReadTransaction executes the given unit of work in a AccessModeRead transaction with
+	// ExecuteRead executes the given unit of work in a AccessModeRead transaction with
 	// retry logic in place
-	ReadTransaction(ctx context.Context, work ManagedTransactionWork, configurers ...func(*TransactionConfig)) (interface{}, error)
-	// WriteTransaction executes the given unit of work in a AccessModeWrite transaction with
+	ExecuteRead(ctx context.Context, work ManagedTransactionWork, configurers ...func(*TransactionConfig)) (interface{}, error)
+	// ExecuteWrite executes the given unit of work in a AccessModeWrite transaction with
 	// retry logic in place
-	WriteTransaction(ctx context.Context, work ManagedTransactionWork, configurers ...func(*TransactionConfig)) (interface{}, error)
+	ExecuteWrite(ctx context.Context, work ManagedTransactionWork, configurers ...func(*TransactionConfig)) (interface{}, error)
 	// Run executes an auto-commit statement and returns a result
 	Run(ctx context.Context, cypher string, params map[string]interface{}, configurers ...func(*TransactionConfig)) (ResultWithContext, error)
 	// Close closes any open resources and marks this session as unusable
@@ -371,13 +371,13 @@ func (s *sessionWithContext) runRetriable(
 	return nil, err
 }
 
-func (s *sessionWithContext) ReadTransaction(ctx context.Context,
+func (s *sessionWithContext) ExecuteRead(ctx context.Context,
 	work ManagedTransactionWork, configurers ...func(*TransactionConfig)) (interface{}, error) {
 
 	return s.runRetriable(ctx, db.ReadMode, work, configurers...)
 }
 
-func (s *sessionWithContext) WriteTransaction(ctx context.Context,
+func (s *sessionWithContext) ExecuteWrite(ctx context.Context,
 	work ManagedTransactionWork, configurers ...func(*TransactionConfig)) (interface{}, error) {
 
 	return s.runRetriable(ctx, db.WriteMode, work, configurers...)
@@ -546,10 +546,10 @@ func (s *erroredSessionWithContext) lastBookmark() string {
 func (s *erroredSessionWithContext) BeginTransaction(context.Context, ...func(*TransactionConfig)) (ExplicitTransaction, error) {
 	return nil, s.err
 }
-func (s *erroredSessionWithContext) ReadTransaction(context.Context, ManagedTransactionWork, ...func(*TransactionConfig)) (interface{}, error) {
+func (s *erroredSessionWithContext) ExecuteRead(context.Context, ManagedTransactionWork, ...func(*TransactionConfig)) (interface{}, error) {
 	return nil, s.err
 }
-func (s *erroredSessionWithContext) WriteTransaction(context.Context, ManagedTransactionWork, ...func(*TransactionConfig)) (interface{}, error) {
+func (s *erroredSessionWithContext) ExecuteWrite(context.Context, ManagedTransactionWork, ...func(*TransactionConfig)) (interface{}, error) {
 	return nil, s.err
 }
 func (s *erroredSessionWithContext) Run(context.Context, string, map[string]interface{}, ...func(*TransactionConfig)) (ResultWithContext, error) {

--- a/neo4j/session_with_context_test.go
+++ b/neo4j/session_with_context_test.go
@@ -84,7 +84,7 @@ func TestSession(st *testing.T) {
 			pool.BorrowConn = conn
 			transientErr := &db.Neo4jError{Code: "Neo.TransientError.General.MemoryPoolOutOfMemoryError"}
 			numRetries := 0
-			_, err := sess.WriteTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			_, err := sess.ExecuteWrite(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				// Previous connection should be returned to pool since it failed
 				if numRetries > 0 && numReturns != numRetries {
 					t.Errorf("Should have returned previous connection to pool")
@@ -110,7 +110,7 @@ func TestSession(st *testing.T) {
 			causeOfRollbackErr := errors.New("UserErrorFake")
 			pool.BorrowConn = &ConnFake{Alive: true, TxRollbackErr: rollbackErr}
 			numRetries := 0
-			_, err := sess.WriteTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			_, err := sess.ExecuteWrite(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				numRetries++
 				return nil, causeOfRollbackErr
 			})
@@ -126,7 +126,7 @@ func TestSession(st *testing.T) {
 			_, pool, sess := createSession()
 			pool.BorrowConn = &ConnFake{Alive: false, TxCommitErr: io.EOF}
 			numRetries := 0
-			_, err := sess.WriteTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			_, err := sess.ExecuteWrite(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				numRetries++
 				return nil, nil
 			})
@@ -155,7 +155,7 @@ func TestSession(st *testing.T) {
 				return []string{"aserver"}, nil
 			}
 
-			sess.WriteTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			sess.ExecuteWrite(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				return nil, nil
 			})
 			_, err := sess.BeginTransaction(context.Background())
@@ -181,10 +181,10 @@ func TestSession(st *testing.T) {
 
 			sess.Run(context.Background(), "cypher", nil)
 			sess.BeginTransaction(context.Background())
-			sess.ReadTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			sess.ExecuteRead(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				return nil, errors.New("something")
 			})
-			sess.WriteTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			sess.ExecuteWrite(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				return nil, errors.New("something")
 			})
 			AssertLen(t, conn.RecordedTxs, 4)
@@ -248,8 +248,8 @@ func TestSession(st *testing.T) {
 			pool.BorrowConn = conn
 			sess.Run(context.Background(), "cypher", nil)
 			AssertIntEqual(t, bufferCalls, 0)
-			// Run transaction function. assumes code is shared between ReadTransaction/WriteTransaction
-			sess.ReadTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			// Run transaction function. assumes code is shared between ExecuteRead/ExecuteWrite
+			sess.ExecuteRead(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				return nil, errors.New("somehting")
 			})
 			AssertLen(t, conn.RecordedTxs, 2)
@@ -401,7 +401,7 @@ func TestSession(st *testing.T) {
 			conn := &ConnFake{Alive: true}
 			pool.BorrowConn = conn
 
-			_, err := sess.WriteTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			_, err := sess.ExecuteWrite(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				return nil, tokenExpiredErr
 			})
 
@@ -413,7 +413,7 @@ func TestSession(st *testing.T) {
 			conn := &ConnFake{Alive: true}
 			pool.BorrowConn = conn
 
-			_, err := sess.ReadTransaction(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
+			_, err := sess.ExecuteRead(context.Background(), func(tx ManagedTransaction) (interface{}, error) {
 				return nil, tokenExpiredErr
 			})
 

--- a/neo4j/test-integration/session_test.go
+++ b/neo4j/test-integration/session_test.go
@@ -481,7 +481,7 @@ func TestSession(outer *testing.T) {
 			assertTrue(t, matched)
 		})
 
-		inner.Run("should set transaction metadata on ReadTransaction", func(t *testing.T) {
+		inner.Run("should set transaction metadata on ExecuteRead", func(t *testing.T) {
 			metadata := map[string]interface{}{
 				"m1": int64(1),
 				"m2": "some string",
@@ -498,7 +498,7 @@ func TestSession(outer *testing.T) {
 			assertTrue(t, matched.(bool))
 		})
 
-		inner.Run("should set transaction metadata on WriteTransaction", func(t *testing.T) {
+		inner.Run("should set transaction metadata on ExecuteWrite", func(t *testing.T) {
 			metadata := map[string]interface{}{
 				"m1": true,
 				"m2": []byte{0x00, 0x01, 0x02},
@@ -542,7 +542,7 @@ func TestSession(outer *testing.T) {
 			//Expect(err).To(BeTransientError(nil, ContainSubstring("terminated")))
 		})
 
-		inner.Run("should set transaction timeout on WriteTransaction", func(t *testing.T) {
+		inner.Run("should set transaction timeout on ExecuteWrite", func(t *testing.T) {
 			createNode(t, session, "WriteTransactionTxTimeOut", nil)
 
 			session2, tx2 := newSessionAndTx(t, driver, neo4j.AccessModeWrite)

--- a/neo4j/test-integration/transaction_test.go
+++ b/neo4j/test-integration/transaction_test.go
@@ -53,7 +53,7 @@ func TestTransaction(outer *testing.T) {
 	outer.Run("Retry Mechanism", func(inner *testing.T) {
 		transientError := &neo4j.Neo4jError{Code: "Neo.TransientError.Transaction.Outdated"}
 
-		inner.Run("should work on WriteTransaction", func(t *testing.T) {
+		inner.Run("should work on ExecuteWrite", func(t *testing.T) {
 			times := 0
 			_, err = session.WriteTransaction(func(transaction neo4j.Transaction) (interface{}, error) {
 				times++
@@ -65,7 +65,7 @@ func TestTransaction(outer *testing.T) {
 			assertTrue(t, times > 10)
 		})
 
-		inner.Run("should work on ReadTransaction", func(t *testing.T) {
+		inner.Run("should work on ExecuteRead", func(t *testing.T) {
 			times := 0
 			_, err = session.ReadTransaction(func(transaction neo4j.Transaction) (interface{}, error) {
 				times++

--- a/neo4j/transaction.go
+++ b/neo4j/transaction.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Transaction represents a transaction in the Neo4j database
-// Deprecated: use TransactionWithContext instead.
-// TransactionWithContext is available via SessionWithContext.
+// Deprecated: use ExplicitTransaction instead.
+// ExplicitTransaction is available via SessionWithContext.
 // SessionWithContext is available via the context-aware driver/returned
 // by NewDriverWithContext.
 // Transaction will be removed in 6.0.
@@ -43,7 +43,7 @@ type Transaction interface {
 
 // Transaction implementation when explicit transaction started
 type transaction struct {
-	delegate TransactionWithContext
+	delegate ExplicitTransaction
 }
 
 func (tx *transaction) Run(cypher string, params map[string]interface{}) (Result, error) {

--- a/neo4j/transaction_config.go
+++ b/neo4j/transaction_config.go
@@ -40,10 +40,10 @@ type TransactionConfig struct {
 //	session.Run("RETURN 1", nil, WithTxTimeout(5*time.Second))
 //
 // To apply a transaction timeout to a read transaction function:
-//	session.ReadTransaction(DoWork, WithTxTimeout(5*time.Second))
+//	session.ExecuteRead(DoWork, WithTxTimeout(5*time.Second))
 //
 // To apply a transaction timeout to a write transaction function:
-//	session.WriteTransaction(DoWork, WithTxTimeout(5*time.Second))
+//	session.ExecuteWrite(DoWork, WithTxTimeout(5*time.Second))
 func WithTxTimeout(timeout time.Duration) func(*TransactionConfig) {
 	return func(config *TransactionConfig) {
 		config.Timeout = timeout
@@ -59,10 +59,10 @@ func WithTxTimeout(timeout time.Duration) func(*TransactionConfig) {
 //	session.Run("RETURN 1", nil, WithTxMetadata(map[string)interface{}{"work-id": 1}))
 //
 // To attach a metadata to a read transaction function:
-//	session.ReadTransaction(DoWork, WithTxMetadata(map[string)interface{}{"work-id": 1}))
+//	session.ExecuteRead(DoWork, WithTxMetadata(map[string)interface{}{"work-id": 1}))
 //
 // To attach a metadata to a write transaction function:
-//	session.WriteTransaction(DoWork, WithTxMetadata(map[string)interface{}{"work-id": 1}))
+//	session.ExecuteWrite(DoWork, WithTxMetadata(map[string)interface{}{"work-id": 1}))
 func WithTxMetadata(metadata map[string]interface{}) func(*TransactionConfig) {
 	return func(config *TransactionConfig) {
 		config.Metadata = metadata

--- a/test-stress/executors.go
+++ b/test-stress/executors.go
@@ -136,7 +136,7 @@ func ReadQueryInTxExecutor(driver neo4j.Driver, useBookmark bool) func(ctx *Test
 	}
 }
 
-// ReadQueryWithReadTransactionExecutor returns a new test executor which reads using Session.ReadTransaction
+// ReadQueryWithReadTransactionExecutor returns a new test executor which reads using Session.ExecuteRead
 func ReadQueryWithReadTransactionExecutor(driver neo4j.Driver, useBookmark bool) func(ctx *TestContext) {
 	return func(ctx *TestContext) {
 		session := newStressSession(driver, useBookmark, neo4j.AccessModeRead, ctx)
@@ -211,7 +211,7 @@ func WriteQueryInTxExecutor(driver neo4j.Driver, useBookmark bool) func(ctx *Tes
 	}
 }
 
-// WriteQueryWithWriteTransactionExecutor returns a new test executor which writes using Session.WriteTransaction
+// WriteQueryWithWriteTransactionExecutor returns a new test executor which writes using Session.ExecuteWrite
 func WriteQueryWithWriteTransactionExecutor(driver neo4j.Driver, useBookmark bool) func(ctx *TestContext) {
 	return func(ctx *TestContext) {
 		session := newStressSession(driver, useBookmark, neo4j.AccessModeWrite, ctx)
@@ -294,7 +294,7 @@ func FailingQueryInTxExecutor(driver neo4j.Driver, useBookmark bool) func(ctx *T
 	}
 }
 
-// FailingQueryWithReadTransactionExecutor returns a new test executor which fails in streaming using Session.ReadTransaction
+// FailingQueryWithReadTransactionExecutor returns a new test executor which fails in streaming using Session.ExecuteRead
 func FailingQueryWithReadTransactionExecutor(driver neo4j.Driver, useBookmark bool) func(ctx *TestContext) {
 	return func(ctx *TestContext) {
 		session := newStressSession(driver, useBookmark, neo4j.AccessModeRead, ctx)
@@ -316,7 +316,7 @@ func FailingQueryWithReadTransactionExecutor(driver neo4j.Driver, useBookmark bo
 	}
 }
 
-// FailingQueryWithWriteTransactionExecutor returns a new test executor which fails in streaming using Session.WriteTransaction
+// FailingQueryWithWriteTransactionExecutor returns a new test executor which fails in streaming using Session.ExecuteWrite
 func FailingQueryWithWriteTransactionExecutor(driver neo4j.Driver, useBookmark bool) func(ctx *TestContext) {
 	return func(ctx *TestContext) {
 		session := newStressSession(driver, useBookmark, neo4j.AccessModeRead, ctx)

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -898,7 +898,5 @@ func testSkips() map[string]string {
 		"stub.summary.test_summary.TestSummary.test_server_info":                                                     "Needs some kind of server address DNS resolution",
 		"stub.summary.test_summary.TestSummary.test_invalid_query_type":                                              "Driver does not verify query type returned from server.",
 		"stub.routing.*.test_should_drop_connections_failing_liveness_check":                                         "Needs support for GetConnectionPoolMetrics",
-		"stub.tx_lifetime.test_tx_lifetime.TestTxLifetime.test_managed_tx_raises_tx_managed_exec":                    "Failed tx functions cause a RESET not a ROLLBACK",
-		"stub.tx_lifetime.test_tx_lifetime.TestTxLifetime.test_unmanaged_tx_raises_tx_closed_exec":                   "tx.commit, tx.rollback, and tx.close are noops if the tx has already been closed",
 	}
 }

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"regexp"
 	"strings"
@@ -231,7 +232,7 @@ func (b *backend) toRequest(s string) map[string]interface{} {
 }
 
 func (b *backend) toTransactionConfigApply(data map[string]interface{}) func(*neo4j.TransactionConfig) {
-	txConfig := neo4j.TransactionConfig{}
+	txConfig := neo4j.TransactionConfig{Timeout: math.MinInt}
 	// Optional transaction meta data
 	if data["txMeta"] != nil {
 		txConfig.Metadata = data["txMeta"].(map[string]interface{})
@@ -244,7 +245,7 @@ func (b *backend) toTransactionConfigApply(data map[string]interface{}) func(*ne
 		if txConfig.Metadata != nil {
 			conf.Metadata = txConfig.Metadata
 		}
-		if txConfig.Timeout != 0 {
+		if txConfig.Timeout != math.MinInt {
 			conf.Timeout = txConfig.Timeout
 		}
 	}


### PR DESCRIPTION
There is now no need to explicit roll back a failed transaction
(run).

Commit and Rollback can only be called once.

Rollback does not return an error from a failed run anymore.