### PR TITLE
Improve pool connection list ownership

### DIFF
--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -180,7 +180,7 @@ func (p *Pool) tryBorrow(serverName string, boltLogger log.BoltLogger) (db.Conne
 
 	// Ok, got a connection, register the connection
 	srv.registerBusy(c)
-	srv.notifySuccesfulConnect()
+	srv.notifySuccessfulConnect()
 	return c, nil
 }
 

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -164,7 +164,7 @@ func (p *Pool) tryBorrow(serverName string, boltLogger log.BoltLogger) (db.Conne
 		}
 	} else {
 		// Make sure that there is a server in the map
-		srv = &server{}
+		srv = NewServer()
 		p.servers[serverName] = srv
 	}
 

--- a/neo4j/internal/pool/server.go
+++ b/neo4j/internal/pool/server.go
@@ -151,16 +151,16 @@ func (s *server) removeIdleOlderThan(now time.Time, maxAge time.Duration) {
 	}
 }
 
+func (s *server) closeAll() {
+	closeAndEmptyConnections(s.idle)
+	// Closing the busy connections could mean here that we do close from another thread.
+	closeAndEmptyConnections(s.busy)
+}
+
 func closeAndEmptyConnections(l list.List) {
 	for e := l.Front(); e != nil; e = e.Next() {
 		c := e.Value.(db.Connection)
 		c.Close()
 	}
 	l.Init()
-}
-
-func (s *server) closeAll() {
-	closeAndEmptyConnections(s.idle)
-	// Closing the busy connections could mean here that we do close from another thread.
-	closeAndEmptyConnections(s.busy)
 }

--- a/neo4j/internal/pool/server.go
+++ b/neo4j/internal/pool/server.go
@@ -41,7 +41,7 @@ var sharedRoundRobin uint32
 
 const rememberFailedConnectDuration = 3 * time.Minute
 
-// Returns a idle connection if any
+// Returns an idle connection if any
 func (s *server) getIdle() db.Connection {
 	// Remove from idle list and add to busy list
 	e := s.idle.Front()
@@ -60,7 +60,7 @@ func (s *server) notifyFailedConnect(now time.Time) {
 	s.failedConnectAt = now
 }
 
-func (s *server) notifySuccesfulConnect() {
+func (s *server) notifySuccessfulConnect() {
 	s.failedConnectAt = time.Time{}
 }
 
@@ -78,7 +78,7 @@ const newConnectionPenalty = uint32(1 << 8)
 func (s *server) calculatePenalty(now time.Time) uint32 {
 	penalty := uint32(0)
 
-	// If a connect to the server has failed recently, add a penalty
+	// If a connection to the server has failed recently, add a penalty
 	if s.hasFailedConnect(now) {
 		penalty = 1 << 31
 	}
@@ -96,7 +96,7 @@ func (s *server) calculatePenalty(now time.Time) uint32 {
 	// Use last round-robin value as lowest priority penalty, so when all other is equal we will
 	// make sure to spread usage among the servers. And yes it will wrap around once in a while
 	// but since number of busy servers weights higher it will even out pretty fast.
-	penalty |= (s.roundRobin & 0xff)
+	penalty |= s.roundRobin & 0xff
 
 	return penalty
 }

--- a/neo4j/internal/pool/server_test.go
+++ b/neo4j/internal/pool/server_test.go
@@ -111,7 +111,7 @@ func TestServer(ot *testing.T) {
 			s.returnBusy(c)
 		}
 
-		// Let the conn in the middle be too old
+		// Make the connection in the middle too old
 		conns[1].Birth = now.Add(-20 * time.Second)
 		s.removeIdleOlderThan(now, 10*time.Second)
 		assertSize(t, s, 2)
@@ -186,7 +186,7 @@ func TestServerPenalty(t *testing.T) {
 	srv2.registerBusy(c22)
 	srv2.returnBusy(c22)
 
-	// Both servers have two idle connections, srv2 was last used so it should have higher penalty.
+	// Both servers have two idle connections, srv2 was last used, so it should have higher penalty.
 	assertGt(srv2, srv1, now)
 	// Get both idle connections from srv1
 	srv1.getIdle()
@@ -205,7 +205,7 @@ func TestServerPenalty(t *testing.T) {
 	// Everything returned, srv2 should have higher penalty since it was last used
 	assertGt(srv2, srv1, now)
 
-	// Punish srv1 by faking that a connect to it failed, after that it should have much higher
+	// Punish srv1 by faking that a connection to it failed, after that it should have much higher
 	// penalty than srv2
 	srv1.notifyFailedConnect(now)
 	assertGt(srv1, srv2, now)
@@ -221,7 +221,7 @@ func TestServerPenalty(t *testing.T) {
 	// should prefer srv1
 	assertGt(srv2, srv1, now.Add(3*time.Hour))
 
-	// Alternatively a succesful connect should clear the problem
-	srv1.notifySuccesfulConnect()
+	// Alternatively a successful connect should clear the problem
+	srv1.notifySuccessfulConnect()
 	assertGt(srv2, srv1, now)
 }


### PR DESCRIPTION
Lists were copied around, which could make Remove calls fail
but the element under some circumstances.
The returned element  would sometimes stay in the target list
because its referred list differed from the target one.