### PR TITLE
Add TestKit test skip

### DIFF
--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -993,14 +993,15 @@ func testSkips() map[string]string {
 		"stub.iteration.test_result_scope.TestResultScope.*":                                                                     "Results are always valid but don't return records when out of scope",
 		"stub.*.test_0_timeout":        "Driver omits 0 as tx timeout value",
 		"stub.*.test_negative_timeout": "Driver omits negative tx timeout values",
-		"stub.routing.*.*.test_should_request_rt_from_all_initial_routers_until_successful_on_unknown_failure":                              "Add DNS resolver TestKit message and connection timeout support",
-		"stub.routing.*.*.test_should_request_rt_from_all_initial_routers_until_successful_on_authorization_expired":                        "Add DNS resolver TestKit message and connection timeout support",
-		"stub.summary.test_summary.TestSummary.test_server_info":                                                                            "Needs some kind of server address DNS resolution",
-		"stub.summary.test_summary.TestSummary.test_invalid_query_type":                                                                     "Driver does not verify query type returned from server.",
-		"stub.routing.*.test_should_drop_connections_failing_liveness_check":                                                                "Needs support for GetConnectionPoolMetrics",
-		"stub.connectivity_check.test_get_server_info.TestGetServerInfo.test_routing_fail_when_no_reader_are_available":                     "Won't fix - Go driver retries routing table when no readers are available",
-		"stub.connectivity_check.test_verify_connectivity.TestVerifyConnectivity.test_routing_fail_when_no_reader_are_available":            "Won't fix - Go driver retries routing table when no readers are available",
-		"stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_*": "Won't fix - ConnectionAcquisitionTimeout spans the whole process including db resolution, RT updates, connection acquisition from the pool, and creation of new connections.",
+		"stub.routing.*.*.test_should_request_rt_from_all_initial_routers_until_successful_on_unknown_failure":                                     "Add DNS resolver TestKit message and connection timeout support",
+		"stub.routing.*.*.test_should_request_rt_from_all_initial_routers_until_successful_on_authorization_expired":                               "Add DNS resolver TestKit message and connection timeout support",
+		"stub.summary.test_summary.TestSummary.test_server_info":                                                                                   "Needs some kind of server address DNS resolution",
+		"stub.summary.test_summary.TestSummary.test_invalid_query_type":                                                                            "Driver does not verify query type returned from server.",
+		"stub.routing.*.test_should_drop_connections_failing_liveness_check":                                                                       "Needs support for GetConnectionPoolMetrics",
+		"stub.connectivity_check.test_get_server_info.TestGetServerInfo.test_routing_fail_when_no_reader_are_available":                            "Won't fix - Go driver retries routing table when no readers are available",
+		"stub.connectivity_check.test_verify_connectivity.TestVerifyConnectivity.test_routing_fail_when_no_reader_are_available":                   "Won't fix - Go driver retries routing table when no readers are available",
+		"stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_not_encompass_router_*":        "Won't fix - ConnectionAcquisitionTimeout spans the whole process including db resolution, RT updates, connection acquisition from the pool, and creation of new connections.",
+		"stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_router_handshake_has_own_timeout_*": "Won't fix - ConnectionAcquisitionTimeout spans the whole process including db resolution, RT updates, connection acquisition from the pool, and creation of new connections.",
 	}
 }
 


### PR DESCRIPTION
`test_does_not_encompass_router_handshake` got updated and was replaced with
`test_router_handshake_has_own_timeout_in_time` and
`test_router_handshake_has_own_timeout_too_slow`.