### PR TITLE
Classify pool closed error as usage error

### DIFF
--- a/neo4j/error.go
+++ b/neo4j/error.go
@@ -153,6 +153,8 @@ func wrapError(err error) error {
 		// Usage of a type not supported by database network protocol or feature
 		// not supported by current version or edition.
 		return &UsageError{Message: err.Error()}
+	case *pool.PoolClosed:
+		return &UsageError{Message: err.Error()}
 	case *connector.TlsError, net.Error:
 		return &ConnectivityError{inner: err}
 	case *pool.PoolTimeout, *pool.PoolFull:

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -235,7 +235,7 @@ func (s *sessionWithContext) BeginTransaction(ctx context.Context, configurers .
 	// Get a connection from the pool. This could fail in clustered environment.
 	conn, err := s.getConnection(ctx, s.defaultMode, pool.DefaultLivenessCheckThreshold)
 	if err != nil {
-		return nil, err
+		return nil, wrapError(err)
 	}
 
 	// Begin transaction
@@ -509,7 +509,7 @@ func (s *sessionWithContext) Run(ctx context.Context,
 
 	conn, err := s.getConnection(ctx, s.defaultMode, pool.DefaultLivenessCheckThreshold)
 	if err != nil {
-		return nil, err
+		return nil, wrapError(err)
 	}
 
 	runBookmarks, err := s.transactionBookmarks(ctx)


### PR DESCRIPTION
This can happen if a session is used despite the driver (and its shared pool) being closed