### PR TITLE
Add generic GetProperty on nodes and relationships

### DIFF
--- a/neo4j/aliases.go
+++ b/neo4j/aliases.go
@@ -41,6 +41,7 @@ type (
 	Time          = dbtype.Time
 	OffsetTime    = dbtype.Time
 	Duration      = dbtype.Duration
+	Entity        = dbtype.Entity
 	Node          = dbtype.Node
 	Relationship  = dbtype.Relationship
 	Path          = dbtype.Path

--- a/neo4j/dbtype/graph.go
+++ b/neo4j/dbtype/graph.go
@@ -20,6 +20,13 @@
 // Package dbtype contains definitions of supported database types.
 package dbtype
 
+type Entity interface {
+	// Deprecated: GetId is deprecated and will be removed in 6.0. Use GetElementId instead.
+	GetId() int64
+	GetElementId() string
+	GetProperties() map[string]any
+}
+
 // Node represents a node in the neo4j graph database
 type Node struct {
 	// Deprecated: Id is deprecated and will be removed in 6.0. Use ElementId instead.
@@ -27,6 +34,18 @@ type Node struct {
 	ElementId string         // ElementId of this Node.
 	Labels    []string       // Labels attached to this Node.
 	Props     map[string]any // Properties of this Node.
+}
+
+func (n Node) GetId() int64 {
+	return n.Id
+}
+
+func (n Node) GetElementId() string {
+	return n.ElementId
+}
+
+func (n Node) GetProperties() map[string]any {
+	return n.Props
 }
 
 // Relationship represents a relationship in the neo4j graph database
@@ -42,6 +61,18 @@ type Relationship struct {
 	EndElementId string         // ElementId of the end Node of this Relationship.
 	Type         string         // Type of this Relationship.
 	Props        map[string]any // Properties of this Relationship.
+}
+
+func (r Relationship) GetId() int64 {
+	return r.Id
+}
+
+func (r Relationship) GetElementId() string {
+	return r.ElementId
+}
+
+func (r Relationship) GetProperties() map[string]any {
+	return r.Props
 }
 
 // Path represents a directed sequence of relationships between two nodes.

--- a/neo4j/graph.go
+++ b/neo4j/graph.go
@@ -23,10 +23,18 @@ import (
 	"fmt"
 )
 
+type PropertyValue interface {
+	bool | int64 | float64 | string |
+		Point2D | Point3D |
+		Date | LocalTime | LocalDateTime | Time | Duration | /* OffsetTime == Time == dbtype.Time */
+		[]byte | []any
+}
+
 // GetProperty returns the value matching the property of the given neo4j.Node or neo4j.Relationship
+// The property type T must adhere to neo4j.PropertyValue
 // If the property does not exist, an error is returned
 // If the property type does not match the type specification, an error is returned
-func GetProperty[T any](entity Entity, key string) (T, error) {
+func GetProperty[T PropertyValue](entity Entity, key string) (T, error) {
 	rawValue, found := entity.GetProperties()[key]
 	if !found {
 		return *new(T), fmt.Errorf("could not find any property named %s", key)

--- a/neo4j/graph.go
+++ b/neo4j/graph.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package neo4j
+
+import (
+	"fmt"
+)
+
+// GetProperty returns the value matching the property of the given neo4j.Node or neo4j.Relationship
+// If the property does not exist, an error is returned
+// If the property type does not match the type specification, an error is returned
+func GetProperty[T any](entity Entity, key string) (T, error) {
+	rawValue, found := entity.GetProperties()[key]
+	if !found {
+		return *new(T), fmt.Errorf("could not find any property named %s", key)
+	}
+	value, ok := rawValue.(T)
+	if !ok {
+		zeroValue := *new(T)
+		return zeroValue, fmt.Errorf("expected value to have type %T but found type %T", zeroValue, rawValue)
+	}
+	return value, nil
+}

--- a/neo4j/graph_example_test.go
+++ b/neo4j/graph_example_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package neo4j_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+func ExampleGetProperty() {
+	ctx := context.Background()
+	driver, err := createDriver()
+	handleError(err)
+	defer handleClose(ctx, driver)
+	session := driver.NewSession(ctx, neo4j.SessionConfig{})
+	defer handleClose(ctx, session)
+
+	result, err := session.Run(ctx, "MATCH (p:Person) RETURN p LIMIT 1", nil)
+	handleError(err)
+	personNode, err := getPersonNode(ctx, result)
+	handleError(err)
+
+	// GetProperty extracts the node's or relationship's property by the specified name
+	// it also makes sure it matches the specified type parameter
+	name, err := neo4j.GetProperty[string](personNode, "name")
+	handleError(err)
+	login, err := neo4j.GetProperty[string](personNode, "login")
+	person := Person{
+		Name:  name,
+		Login: login,
+	}
+	fmt.Println(person)
+}
+
+func getPersonNode(ctx context.Context, result neo4j.ResultWithContext) (neo4j.Node, error) {
+	record, err := result.Single(ctx)
+	handleError(err)
+
+	rawPersonNode, found := record.Get("p")
+	if !found {
+		return neo4j.Node{}, fmt.Errorf("person record not found")
+	}
+	personNode, ok := rawPersonNode.(neo4j.Node)
+	if !ok {
+		return neo4j.Node{}, fmt.Errorf("expected person record to be a node, but was %T", rawPersonNode)
+	}
+	return personNode, nil
+}

--- a/neo4j/graph_test.go
+++ b/neo4j/graph_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package neo4j_test
+
+import (
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"testing"
+	"testing/quick"
+)
+
+func TestGetProperty(outer *testing.T) {
+	outer.Parallel()
+
+	type testCase struct {
+		description string
+		make        func(string, int) neo4j.Entity
+	}
+
+	testCases := []testCase{
+		{
+			description: "Node",
+			make: func(k string, v int) neo4j.Entity {
+				return neo4j.Node{Props: singleProp(k, v)}
+			},
+		},
+		{
+			description: "Rel",
+			make: func(k string, v int) neo4j.Entity {
+				return neo4j.Relationship{Props: singleProp(k, v)}
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		outer.Run(test.description, func(t *testing.T) {
+			check := func(key string, value int) bool {
+				entity := test.make(key, value)
+
+				validValue, noErr := neo4j.GetProperty[int](entity, key)
+				_, err1 := neo4j.GetProperty[int](entity, key + "_nope")
+				_, err2 := neo4j.GetProperty[string](entity, key)
+
+				return validValue == value && noErr == nil && err1 != nil && err2 != nil
+			}
+			if err := quick.Check(check, nil); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+
+}
+
+func singleProp[T any](key string, value T) map[string]any {
+	return map[string]any{key: value}
+}

--- a/neo4j/graph_test.go
+++ b/neo4j/graph_test.go
@@ -20,9 +20,12 @@
 package neo4j_test
 
 import (
+	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 	"testing"
 	"testing/quick"
+	"time"
 )
 
 func TestGetProperty(outer *testing.T) {
@@ -30,31 +33,31 @@ func TestGetProperty(outer *testing.T) {
 
 	type testCase struct {
 		description string
-		make        func(string, int) neo4j.Entity
+		make        func(map[string]any) neo4j.Entity
 	}
 
 	testCases := []testCase{
 		{
 			description: "Node",
-			make: func(k string, v int) neo4j.Entity {
-				return neo4j.Node{Props: singleProp(k, v)}
+			make: func(props map[string]any) neo4j.Entity {
+				return neo4j.Node{Props: props}
 			},
 		},
 		{
 			description: "Rel",
-			make: func(k string, v int) neo4j.Entity {
-				return neo4j.Relationship{Props: singleProp(k, v)}
+			make: func(props map[string]any) neo4j.Entity {
+				return neo4j.Relationship{Props: props}
 			},
 		},
 	}
 
 	for _, test := range testCases {
-		outer.Run(test.description, func(t *testing.T) {
-			check := func(key string, value int) bool {
-				entity := test.make(key, value)
+		outer.Run(fmt.Sprintf("[%s] gets property", test.description), func(t *testing.T) {
+			check := func(key string, value int64) bool {
+				entity := test.make(singleProp(key, value))
 
-				validValue, noErr := neo4j.GetProperty[int](entity, key)
-				_, err1 := neo4j.GetProperty[int](entity, key + "_nope")
+				validValue, noErr := neo4j.GetProperty[int64](entity, key)
+				_, err1 := neo4j.GetProperty[int64](entity, key+"_nope")
 				_, err2 := neo4j.GetProperty[string](entity, key)
 
 				return validValue == value && noErr == nil && err1 != nil && err2 != nil
@@ -63,6 +66,137 @@ func TestGetProperty(outer *testing.T) {
 				t.Error(err)
 			}
 		})
+
+		outer.Run(fmt.Sprintf("[%s] supports only valid property types", test.description), func(inner *testing.T) {
+			now := time.Now()
+
+			inner.Run("booleans", func(t *testing.T) {
+				entity := test.make(singleProp("k", true))
+
+				prop, err := neo4j.GetProperty[bool](entity, "k")
+
+				AssertDeepEquals(t, prop, true)
+				AssertNoError(t, err)
+			})
+
+			inner.Run("longs", func(t *testing.T) {
+				entity := test.make(singleProp("k", int64(98)))
+
+				prop, err := neo4j.GetProperty[int64](entity, "k")
+
+				AssertDeepEquals(t, prop, int64(98))
+				AssertNoError(t, err)
+			})
+
+			inner.Run("doubles", func(t *testing.T) {
+				entity := test.make(singleProp("k", float64(99.42)))
+
+				prop, err := neo4j.GetProperty[float64](entity, "k")
+
+				AssertDeepEquals(t, prop, float64(99.42))
+				AssertNoError(t, err)
+			})
+
+			inner.Run("strings", func(t *testing.T) {
+				entity := test.make(singleProp("k", "v"))
+
+				prop, err := neo4j.GetProperty[string](entity, "k")
+
+				AssertDeepEquals(t, prop, "v")
+				AssertNoError(t, err)
+			})
+
+			inner.Run("point2Ds", func(t *testing.T) {
+				entity := test.make(singleProp("k", neo4j.Point2D{X: 3, Y: 14, SpatialRefId: 7203}))
+
+				prop, err := neo4j.GetProperty[neo4j.Point2D](entity, "k")
+
+				AssertDeepEquals(t, prop, neo4j.Point2D{X: 3, Y: 14, SpatialRefId: 7203})
+				AssertNoError(t, err)
+			})
+
+			inner.Run("point3Ds", func(t *testing.T) {
+				entity := test.make(singleProp("k", neo4j.Point3D{X: 3, Y: 1, Z: 4, SpatialRefId: 4979}))
+
+				prop, err := neo4j.GetProperty[neo4j.Point3D](entity, "k")
+
+				AssertDeepEquals(t, prop, neo4j.Point3D{X: 3, Y: 1, Z: 4, SpatialRefId: 4979})
+				AssertNoError(t, err)
+			})
+
+			inner.Run("dates", func(t *testing.T) {
+				entity := test.make(singleProp("k", neo4j.DateOf(now)))
+
+				prop, err := neo4j.GetProperty[neo4j.Date](entity, "k")
+
+				AssertDeepEquals(t, prop, neo4j.DateOf(now))
+				AssertNoError(t, err)
+			})
+
+			inner.Run("local times", func(t *testing.T) {
+				entity := test.make(singleProp("k", neo4j.LocalTimeOf(now)))
+
+				prop, err := neo4j.GetProperty[neo4j.LocalTime](entity, "k")
+
+				AssertDeepEquals(t, prop, neo4j.LocalTimeOf(now))
+				AssertNoError(t, err)
+			})
+
+			inner.Run("local datetimes", func(t *testing.T) {
+				entity := test.make(singleProp("k", neo4j.LocalDateTimeOf(now)))
+
+				prop, err := neo4j.GetProperty[neo4j.LocalDateTime](entity, "k")
+
+				AssertDeepEquals(t, prop, neo4j.LocalDateTimeOf(now))
+				AssertNoError(t, err)
+			})
+
+			inner.Run("times", func(t *testing.T) {
+				entity := test.make(singleProp("k", neo4j.Time(now)))
+
+				prop, err := neo4j.GetProperty[neo4j.Time](entity, "k")
+
+				AssertDeepEquals(t, prop, neo4j.Time(now))
+				AssertNoError(t, err)
+			})
+
+			inner.Run("offset times", func(t *testing.T) {
+				entity := test.make(singleProp("k", neo4j.OffsetTimeOf(now)))
+
+				prop, err := neo4j.GetProperty[neo4j.OffsetTime](entity, "k")
+
+				AssertDeepEquals(t, prop, neo4j.OffsetTimeOf(now))
+				AssertNoError(t, err)
+			})
+
+			inner.Run("durations", func(t *testing.T) {
+				entity := test.make(singleProp("k", neo4j.DurationOf(5, 4, 3, 2)))
+
+				prop, err := neo4j.GetProperty[neo4j.Duration](entity, "k")
+
+				AssertDeepEquals(t, prop, neo4j.DurationOf(5, 4, 3, 2))
+				AssertNoError(t, err)
+			})
+
+			inner.Run("byte arrays", func(t *testing.T) {
+				entity := test.make(singleProp("k", []byte{1, 2, 3}))
+
+				prop, err := neo4j.GetProperty[[]byte](entity, "k")
+
+				AssertDeepEquals(t, prop, []byte{1, 2, 3})
+				AssertNoError(t, err)
+			})
+
+			inner.Run("slices", func(t *testing.T) {
+				entity := test.make(singleProp("k", []any{1, 2, 3}))
+
+				prop, err := neo4j.GetProperty[[]any](entity, "k")
+
+				AssertDeepEquals(t, prop, []any{1, 2, 3})
+				AssertNoError(t, err)
+			})
+		})
+
 	}
 
 }

--- a/neo4j/transaction_helpers_example_test.go
+++ b/neo4j/transaction_helpers_example_test.go
@@ -31,6 +31,10 @@ type Person struct {
 	Login string
 }
 
+func (p *Person) String() string {
+	return fmt.Sprintf("name: %s, login: %s", p.Name, p.Login)
+}
+
 func (p *Person) asNodeProps() map[string]any {
 	return map[string]any{
 		"name":  p.Name,


### PR DESCRIPTION
These are generic helpers to extract properties from nodes and relationships in a type-safe way.

Relates to #373