### PR TITLE
Clarify ResultWithContext#Single API docs

### DIFF
--- a/neo4j/result_with_context.go
+++ b/neo4j/result_with_context.go
@@ -46,7 +46,7 @@ type ResultWithContext interface {
 	// Collect fetches all remaining records and returns them.
 	Collect(ctx context.Context) ([]*Record, error)
 	// Single returns the only remaining record from the stream.
-	// If none or more than one record are left, an error is returned.
+	// If none or more than one record is left, an error is returned.
 	// The result is fully consumed after this call and its summary is immediately available when calling Consume.
 	Single(ctx context.Context) (*Record, error)
 	// Consume discards all remaining records and returns the summary information

--- a/neo4j/result_with_context.go
+++ b/neo4j/result_with_context.go
@@ -45,8 +45,9 @@ type ResultWithContext interface {
 	Record() *Record
 	// Collect fetches all remaining records and returns them.
 	Collect(ctx context.Context) ([]*Record, error)
-	// Single returns one and only one record from the stream.
-	// If the result stream contains zero or more than one records, error is returned.
+	// Single returns the only remaining record from the stream.
+	// If none or more than one record are left, an error is returned.
+	// The result is fully consumed after this call and its summary is immediately available when calling Consume.
 	Single(ctx context.Context) (*Record, error)
 	// Consume discards all remaining records and returns the summary information
 	// about the statement execution.


### PR DESCRIPTION
In particular, highlight that Single consumes the result cursor.