### PR TITLE
Clarify ResultWithContext#Single API docs

### DIFF
--- a/neo4j/result.go
+++ b/neo4j/result.go
@@ -37,8 +37,9 @@ type Result interface {
 	Record() *Record
 	// Collect fetches all remaining records and returns them.
 	Collect() ([]*Record, error)
-	// Single returns one and only one record from the stream.
-	// If the result stream contains zero or more than one records, error is returned.
+	// Single returns the only remaining record from the stream.
+	// If none or more than one record is left, an error is returned.
+	// The result is fully consumed after this call and its summary is immediately available when calling Consume.
 	Single() (*Record, error)
 	// Consume discards all remaining records and returns the summary information
 	// about the statement execution.


### PR DESCRIPTION
In particular, highlight that Single consumes the result cursor.