### PR TITLE
Change default TLS min version to 1.2

### DIFF
--- a/neo4j/internal/connector/connector.go
+++ b/neo4j/internal/connector/connector.go
@@ -84,7 +84,12 @@ func (c Connector) Connect(address string, boltLogger log.BoltLogger) (db.Connec
 		conn.Close()
 		return nil, err
 	}
-	config := tls.Config{InsecureSkipVerify: c.SkipVerify, RootCAs: c.RootCAs, ServerName: serverName}
+	config := tls.Config{
+		InsecureSkipVerify: c.SkipVerify,
+		RootCAs:            c.RootCAs,
+		ServerName:         serverName,
+		MinVersion:         tls.VersionTLS12,
+	}
 	tlsconn := tls.Client(conn, &config)
 	err = tlsconn.Handshake()
 	if err != nil {

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -713,7 +713,6 @@ func (b *backend) handleRequest(req map[string]interface{}) {
 				"Feature:Bolt:4.4",
 				"Feature:Bolt:Patch:UTC",
 				"Feature:Impersonation",
-				"Feature:TLS:1.1",
 				"Feature:TLS:1.2",
 				"Feature:TLS:1.3",
 				"Optimization:ConnectionReuse",


### PR DESCRIPTION
The current default (before this commit) depends on the Go version.

This driver has a Go 1.16 baseline, meaning:

 - 1.0 is the platform default min TLS version for Go 1.16 and Go 1.17
 - 1.2 for clients in Go 1.18 and Go 1.19

This commit now hardcodes the minimum TLS version to 1.12, as a better security default.

If users do not specify the minimum TLS version, 1.2 will be set.