### PR TITLE
Pin staticcheck version

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -6,7 +6,7 @@ grep_not(){ ! grep "${@}"; return $?;}
 
 echo "# pre-commit hook"
 printf '%-15s' "## staticcheck "
-cd "$(mktemp -d)" && go install honnef.co/go/tools/cmd/staticcheck@latest && cd - > /dev/null
+cd "$(mktemp -d)" && go install honnef.co/go/tools/cmd/staticcheck@v0.3.3 && cd - > /dev/null
 "${GOBIN:-$(go env GOPATH)/bin}"/staticcheck ./...
 echo "✅"
 

--- a/testkit/build.py
+++ b/testkit/build.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     run(["go", "vet", "./..."], env=defaultEnv)
 
     print("Install staticcheck", flush=True)
-    run(["go", "install", "honnef.co/go/tools/cmd/staticcheck@latest"], env=defaultEnv)
+    run(["go", "install", "honnef.co/go/tools/cmd/staticcheck@v0.3.3"], env=defaultEnv)
 
     print("Run staticcheck", flush=True)
     gopath = Path(


### PR DESCRIPTION
`staticcheck` recent versions have upgraded their Go baseline version to > 1.18, which breaks this driver's build.

We only allow Go version bumps in major releases of the driver, so upgrades of `staticcheck` will not be possible before 6.0!