### PR TITLE
Introduce message queue to better correlate requests and responses

### DIFF
--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -951,14 +951,12 @@ func (b *bolt5) resetResponseHandler() responseHandler {
 		onSuccess: func(resetSuccess *success) {
 			b.state = bolt5Ready
 		},
-		onRecord: onRecordNoOp,
 		onFailure: func(*db.Neo4jError) {
 			b.state = bolt5Dead
 		},
 		onUnknown: func(any) {
 			b.state = bolt5Dead
 		},
-		onIgnored: onIgnoredNoOp,
 	}
 }
 

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -478,7 +478,7 @@ func (b *bolt5) pauseStream(ctx context.Context) {
 // resumeStream marks the current stream as current and requests PULL
 func (b *bolt5) resumeStream(ctx context.Context, s *stream) {
 	b.streams.resume(s)
-	b.queue.appendPullN(s.fetchSize, b.pullResponseHandler(s))
+	b.appendPullN(s)
 	b.queue.send(ctx)
 }
 

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -483,7 +483,7 @@ func (b *bolt5) sendPullN(ctx context.Context) {
 	}
 }
 
-// Collects all records in current stream if in streaming state and there is a current stream.
+// bufferStream pulls all the records of the current stream if there is a current stream.
 func (b *bolt5) bufferStream(ctx context.Context) {
 	stream := b.streams.curr
 	if stream == nil {
@@ -505,8 +505,7 @@ func (b *bolt5) bufferStream(ctx context.Context) {
 	}
 }
 
-// Prepares the current stream for being switched out by collecting all records in the current
-// stream up until the next batch. Assumes that we are in a streaming state.
+// pauseStream pulls all the records of the current stream ongoing batch of records and unsets the stream as current
 func (b *bolt5) pauseStream(ctx context.Context) {
 	stream := b.streams.curr
 	if stream == nil {
@@ -527,12 +526,10 @@ func (b *bolt5) pauseStream(ctx context.Context) {
 	}
 }
 
+// resumeStream marks the current stream as current and requests PULL
 func (b *bolt5) resumeStream(ctx context.Context, s *stream) {
 	b.streams.resume(s)
 	b.sendPullN(ctx)
-	if b.err != nil {
-		return
-	}
 }
 
 func (b *bolt5) run(ctx context.Context, cypher string, params map[string]any, fetchSize int, tx *internalTx5) (*stream, error) {

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -580,12 +580,11 @@ func (b *bolt5) Next(ctx context.Context, streamHandle idb.StreamHandle) (
 		return nil, nil, err
 	}
 
-	buf, rec, sum, err := stream.bufferedNext()
-	if buf {
-		return rec, sum, err
-	}
-
 	for {
+		buf, rec, sum, err := stream.bufferedNext()
+		if buf {
+			return rec, sum, err
+		}
 		if stream.endOfBatch {
 			b.appendPullN(stream)
 			if b.queue.send(ctx); b.err != nil {
@@ -602,10 +601,6 @@ func (b *bolt5) Next(ctx context.Context, streamHandle idb.StreamHandle) (
 		}
 		if b.err != nil {
 			return nil, nil, b.err
-		}
-		buf, rec, sum, err = stream.bufferedNext()
-		if buf {
-			return rec, sum, err
 		}
 	}
 }

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -867,7 +867,8 @@ func (b *bolt5) rollbackResponseHandler() responseHandler {
 func (b *bolt5) discardResponseHandler(stream *stream) responseHandler {
 	return responseHandler{
 		onIgnored: func(*ignored) {
-			b.streams.detach(nil, fmt.Errorf("stream interrupted while discarding results"))
+			stream.err = fmt.Errorf("stream interrupted while discarding results")
+			b.streams.remove(stream)
 			b.checkStreams()
 		},
 		onSuccess: func(discardSuccess *success) {
@@ -880,7 +881,7 @@ func (b *bolt5) discardResponseHandler(stream *stream) responseHandler {
 				b.bookmark = summary.Bookmark
 			}
 			stream.sum = summary
-			b.streams.detach(summary, nil)
+			b.streams.remove(stream)
 			b.checkStreams()
 		},
 		onFailure: func(failure *db.Neo4jError) {
@@ -906,7 +907,8 @@ func (b *bolt5) pullResponseHandler(stream *stream) responseHandler {
 			b.queue.pushFront(b.pullResponseHandler(stream))
 		},
 		onIgnored: func(*ignored) {
-			b.streams.detach(nil, fmt.Errorf("stream interrupted while pulling results"))
+			stream.err = fmt.Errorf("stream interrupted while pulling results")
+			b.streams.remove(stream)
 			b.checkStreams()
 		},
 		onSuccess: func(pullSuccess *success) {
@@ -922,7 +924,7 @@ func (b *bolt5) pullResponseHandler(stream *stream) responseHandler {
 				b.bookmark = summary.Bookmark
 			}
 			stream.sum = summary
-			b.streams.detach(summary, nil)
+			b.streams.remove(stream)
 			b.checkStreams()
 		},
 		onFailure: func(failure *db.Neo4jError) {

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -495,9 +495,8 @@ func (b *bolt5) run(ctx context.Context, cypher string, params map[string]any, r
 
 	fetchSize := b.normalizeFetchSize(rawFetchSize)
 	stream := &stream{fetchSize: fetchSize}
-	b.queue.appendRun(cypher, params, tx.toMeta(), fetchSize,
-		b.runResponseHandler(stream),
-		b.pullResponseHandler(stream))
+	b.queue.appendRun(cypher, params, tx.toMeta(), b.runResponseHandler(stream))
+	b.queue.appendPullN(fetchSize, b.pullResponseHandler(stream))
 	if b.queue.send(ctx); b.err != nil {
 		return nil, b.err
 	}

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -116,7 +116,7 @@ func NewBolt5(serverName string, conn net.Conn, logger log.Logger, boltLog log.B
 	}
 	b.queue = newMessageQueue(
 		conn,
-		incoming{
+		&incoming{
 			buf: make([]byte, 4096),
 			hyd: hydrator{
 				boltLogger: boltLog,
@@ -125,7 +125,7 @@ func NewBolt5(serverName string, conn net.Conn, logger log.Logger, boltLog log.B
 			},
 			connReadTimeout: -1,
 		},
-		outgoing{
+		&outgoing{
 			chunker:    newChunker(),
 			packer:     packstream.Packer{},
 			onErr:      func(err error) { b.setError(err, true) },

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -112,7 +112,7 @@ func TestBolt5(outer *testing.T) {
 
 		bolt := c.(*bolt5)
 		assertBoltState(t, bolt5Ready, bolt)
-		if !bolt.out.useUtc {
+		if !bolt.queue.out.useUtc {
 			t.Fatalf("Bolt 5+ connections must always send and receive UTC datetimes")
 		}
 		return bolt, cleanup
@@ -131,7 +131,7 @@ func TestBolt5(outer *testing.T) {
 
 		AssertStringEqual(t, bolt.ServerName(), "serverName")
 		AssertTrue(t, bolt.IsAlive())
-		AssertTrue(t, reflect.DeepEqual(bolt.in.connReadTimeout, time.Duration(-1)))
+		AssertTrue(t, reflect.DeepEqual(bolt.queue.in.connReadTimeout, time.Duration(-1)))
 	})
 
 	outer.Run("Connect success in 5.1", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestBolt5(outer *testing.T) {
 		// Check Bolt properties
 		AssertStringEqual(t, bolt.ServerName(), "serverName")
 		AssertTrue(t, bolt.IsAlive())
-		AssertTrue(t, reflect.DeepEqual(bolt.in.connReadTimeout, time.Duration(-1)))
+		AssertTrue(t, reflect.DeepEqual(bolt.queue.in.connReadTimeout, time.Duration(-1)))
 	})
 
 	outer.Run("Connect success with timeout hint", func(t *testing.T) {
@@ -164,7 +164,7 @@ func TestBolt5(outer *testing.T) {
 		defer cleanup()
 		defer bolt.Close(context.Background())
 
-		AssertTrue(t, reflect.DeepEqual(bolt.in.connReadTimeout, 42*time.Second))
+		AssertTrue(t, reflect.DeepEqual(bolt.queue.in.connReadTimeout, 42*time.Second))
 	})
 
 	outer.Run("Connect success with timeout hint in 5.1", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestBolt5(outer *testing.T) {
 		defer cleanup()
 		defer bolt.Close(context.Background())
 
-		AssertTrue(t, reflect.DeepEqual(bolt.in.connReadTimeout, 42*time.Second))
+		AssertTrue(t, reflect.DeepEqual(bolt.queue.in.connReadTimeout, 42*time.Second))
 	})
 
 	invalidValues := []any{4.2, "42", -42}
@@ -220,7 +220,7 @@ func TestBolt5(outer *testing.T) {
 			defer cleanup()
 			defer bolt.Close(context.Background())
 
-			AssertTrue(t, reflect.DeepEqual(bolt.in.connReadTimeout, time.Duration(-1)))
+			AssertTrue(t, reflect.DeepEqual(bolt.queue.in.connReadTimeout, time.Duration(-1)))
 		})
 	}
 

--- a/neo4j/internal/bolt/bolt_logging.go
+++ b/neo4j/internal/bolt/bolt_logging.go
@@ -3,7 +3,6 @@ package bolt
 import (
 	"encoding/json"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
-	"strconv"
 	"strings"
 )
 
@@ -48,9 +47,9 @@ type loggedSuccess struct {
 	Server       string              `json:"server,omitempty"`
 	ConnectionId string              `json:"connection_id,omitempty"`
 	Fields       []string            `json:"fields,omitempty"`
-	TFirst       string              `json:"t_first,omitempty"`
+	TFirst       int64               `json:"t_first,omitempty"`
 	Bookmark     string              `json:"bookmark,omitempty"`
-	TLast        string              `json:"t_last,omitempty"`
+	TLast        int64               `json:"t_last,omitempty"`
 	HasMore      bool                `json:"has_more,omitempty"`
 	Db           string              `json:"db,omitempty"`
 	Qid          int64               `json:"qid,omitempty"`
@@ -63,12 +62,16 @@ func (s loggableSuccess) String() string {
 		Server:       s.server,
 		ConnectionId: s.connectionId,
 		Fields:       s.fields,
-		TFirst:       formatOmittingZero(s.tfirst),
 		Bookmark:     s.bookmark,
-		TLast:        formatOmittingZero(s.tlast),
 		HasMore:      s.hasMore,
 		Db:           s.db,
 		ConfigHints:  s.configurationHints,
+	}
+	if s.tfirst > -1 {
+		success.TFirst = s.tfirst
+	}
+	if s.tlast > -1 {
+		success.TFirst = s.tlast
 	}
 	if s.qid > -1 {
 		success.Qid = s.qid
@@ -92,13 +95,6 @@ type loggedRoutingTable struct {
 	Routers      []string `json:"routers,omitempty"`
 	Readers      []string `json:"readers,omitempty"`
 	Writers      []string `json:"writers,omitempty"`
-}
-
-func formatOmittingZero(i int64) string {
-	if i == 0 {
-		return ""
-	}
-	return strconv.FormatInt(i, 10)
 }
 
 type loggableFailure db.Neo4jError

--- a/neo4j/internal/bolt/message_queue.go
+++ b/neo4j/internal/bolt/message_queue.go
@@ -56,12 +56,9 @@ func (q *messageQueue) appendBegin(meta map[string]any, handler responseHandler)
 	q.enqueueCallback(handler)
 }
 
-func (q *messageQueue) appendRun(cypher string, params, meta map[string]any, fetchSize int,
-	runHandler responseHandler, pullHandler responseHandler) {
-
+func (q *messageQueue) appendRun(cypher string, params, meta map[string]any, runHandler responseHandler) {
 	q.out.appendRun(cypher, params, meta)
 	q.enqueueCallback(runHandler)
-	q.appendPullN(fetchSize, pullHandler)
 }
 
 func (q *messageQueue) appendPullN(fetchSize int, handler responseHandler) {

--- a/neo4j/internal/bolt/message_queue.go
+++ b/neo4j/internal/bolt/message_queue.go
@@ -1,0 +1,207 @@
+package bolt
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
+	"net"
+)
+
+type messageQueue struct {
+	in               incoming
+	out              outgoing
+	callbacks        list.List // List[responseHandler]
+	targetConnection net.Conn
+	protocolVersion  boltVersion
+	err              error
+
+	onNextMessage    func()
+	onNextMessageErr func(error)
+}
+
+func newMessageQueue(
+	target net.Conn,
+	in incoming, out outgoing,
+	onNext func(),
+	onNextErr func(error)) messageQueue {
+
+	return messageQueue{
+		in:               in,
+		out:              out,
+		callbacks:        list.List{},
+		targetConnection: target,
+		onNextMessage:    onNext,
+		onNextMessageErr: onNextErr,
+	}
+}
+
+func (q *messageQueue) appendHello(protocolVersion boltVersion, hello, token map[string]any,
+	helloHandler responseHandler, logonHandler responseHandler) {
+	q.protocolVersion = protocolVersion
+	q.out.appendHello(hello)
+	q.enqueueCallback(helloHandler)
+	if q.protocolVersion.greaterThanOrEqual(5, 1) {
+		q.out.appendLogon(token)
+		q.enqueueCallback(logonHandler)
+	}
+}
+
+func (q *messageQueue) appendRoute(routingContext map[string]string, bookmarks []string, extras map[string]any, handler responseHandler) {
+	q.out.appendRoute(routingContext, bookmarks, extras)
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendBegin(meta map[string]any, handler responseHandler) {
+	q.out.appendBegin(meta)
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendRun(cypher string, params, meta map[string]any, fetchSize int,
+	runHandler responseHandler, pullHandler responseHandler) {
+
+	q.out.appendRun(cypher, params, meta)
+	q.enqueueCallback(runHandler)
+	q.appendPullN(fetchSize, pullHandler)
+}
+
+func (q *messageQueue) appendPullN(fetchSize int, handler responseHandler) {
+	q.out.appendPullN(fetchSize)
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendPullNQid(fetchSize int, qid int64, handler responseHandler) {
+	q.out.appendPullNQid(fetchSize, qid)
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendCommit(handler responseHandler) {
+	q.out.appendCommit()
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendRollback(handler responseHandler) {
+	q.out.appendRollback()
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendDiscardNQid(fetchSize int, qid int64, handler responseHandler) {
+	q.out.appendDiscardNQid(fetchSize, qid)
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendDiscardN(fetchSize int, handler responseHandler) {
+	q.out.appendDiscardN(fetchSize)
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendReset(handler responseHandler) {
+	q.out.appendReset()
+	q.enqueueCallback(handler)
+}
+
+func (q *messageQueue) appendGoodbye() {
+	q.out.appendGoodbye()
+	// no response expected here
+}
+
+func (q *messageQueue) send(ctx context.Context) {
+	q.out.send(ctx, q.targetConnection)
+}
+
+func (q *messageQueue) receiveAll(ctx context.Context) error {
+	for {
+		if q.callbacks.Len() == 0 {
+			return nil
+		}
+		if err := q.receive(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func (q *messageQueue) receive(ctx context.Context) error {
+	res := q.receiveMsg(ctx)
+	if q.err != nil {
+		return q.err
+	}
+
+	if q.callbacks.Len() == 0 {
+		return errors.New("no more response callback to apply")
+	}
+	callback := q.pop()
+	switch message := res.(type) {
+	case *db.Record:
+		callback.onRecord(message)
+	case *success:
+		callback.onSuccess(message)
+	case *db.Neo4jError:
+		callback.onFailure(message)
+		return message
+	case *ignored:
+		callback.onIgnored(message)
+	default:
+		callback.onUnknown(message)
+	}
+	return nil
+}
+
+func (q *messageQueue) pop() responseHandler {
+	return q.callbacks.Remove(q.callbacks.Front()).(responseHandler)
+}
+
+func (q *messageQueue) receiveMsg(ctx context.Context) any {
+	// Potentially dangerous to receive when an error has occurred, could hang.
+	// Important, a lot of code has been simplified relying on this check.
+	if q.err != nil {
+		return nil
+	}
+
+	msg, err := q.in.next(ctx, q.targetConnection)
+	q.err = err
+	if err != nil {
+		q.onNextMessageErr(err)
+	} else {
+		q.onNextMessage()
+	}
+	return msg
+}
+
+func (q *messageQueue) enqueueCallback(callbacks responseHandler) {
+	q.callbacks.PushBack(callbacks)
+}
+
+func (q *messageQueue) setLogId(logId string) {
+	q.in.hyd.logId = logId
+	q.out.logId = logId
+}
+
+func (q *messageQueue) setBoltLogger(logger log.BoltLogger) {
+	q.in.hyd.boltLogger = logger
+	q.out.boltLogger = logger
+}
+
+func (q *messageQueue) reset() {
+	q.callbacks.Init()
+}
+
+func (q *messageQueue) replaceFront(handler responseHandler) {
+	q.pop()
+	q.callbacks.PushFront(handler)
+}
+
+type boltVersion struct {
+	major int
+	minor int
+}
+
+func (v *boltVersion) greaterThanOrEqual(major int, minor int) bool {
+	if v.major < major {
+		return false
+	}
+	if v.major == major {
+		return v.minor >= minor
+	}
+	return true
+}

--- a/neo4j/internal/bolt/message_queue.go
+++ b/neo4j/internal/bolt/message_queue.go
@@ -147,6 +147,10 @@ func (q *messageQueue) receive(ctx context.Context) error {
 	return nil
 }
 
+func (q *messageQueue) pushFront(handler responseHandler) {
+	q.callbacks.PushFront(handler)
+}
+
 func (q *messageQueue) pop() responseHandler {
 	return q.callbacks.Remove(q.callbacks.Front()).(responseHandler)
 }
@@ -180,15 +184,6 @@ func (q *messageQueue) setLogId(logId string) {
 func (q *messageQueue) setBoltLogger(logger log.BoltLogger) {
 	q.in.hyd.boltLogger = logger
 	q.out.boltLogger = logger
-}
-
-func (q *messageQueue) reset() {
-	q.callbacks.Init()
-}
-
-func (q *messageQueue) replaceFront(handler responseHandler) {
-	q.pop()
-	q.callbacks.PushFront(handler)
 }
 
 type boltVersion struct {

--- a/neo4j/internal/bolt/message_queue.go
+++ b/neo4j/internal/bolt/message_queue.go
@@ -186,6 +186,10 @@ func (q *messageQueue) setBoltLogger(logger log.BoltLogger) {
 	q.out.boltLogger = logger
 }
 
+func (q *messageQueue) isEmpty() bool {
+	return q.callbacks.Len() == 0
+}
+
 type boltVersion struct {
 	major int
 	minor int

--- a/neo4j/internal/bolt/message_queue_test.go
+++ b/neo4j/internal/bolt/message_queue_test.go
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package bolt
+
+import (
+	"bytes"
+	"context"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestMessageQueue(outer *testing.T) {
+	outer.Parallel()
+
+	outer.Run("appends", func(inner *testing.T) {
+		inner.Parallel()
+
+		writer := outgoing{}
+
+		handlers := map[byte]responseHandler{
+			// at least 1 non-nil function is needed per handler to ensure proper equality check
+			// see assertEqualResponseHandlers
+			msgHello:    {onSuccess: func(*success) {}},
+			msgLogon:    {onFailure: func(*db.Neo4jError) {}},
+			msgRoute:    {onIgnored: func(*ignored) {}},
+			msgBegin:    {onUnknown: func(any) {}},
+			msgRun:      {onRecord: func(*db.Record) {}},
+			msgPullN:    {onSuccess: func(*success) {}},
+			msgCommit:   {onFailure: func(*db.Neo4jError) {}},
+			msgRollback: {onIgnored: func(*ignored) {}},
+			msgDiscardN: {onUnknown: func(any) {}},
+			msgReset:    {onRecord: func(*db.Record) {}},
+			msgGoodbye:  {onSuccess: func(*success) {}},
+		}
+		tests := []struct {
+			description         string
+			action              func(*messageQueue)
+			expectedMessageType byte
+			skipsHandler        bool
+		}{
+			{
+				description: "HELLO",
+				action: func(queue *messageQueue) {
+					queue.appendHello(nil, handlers[msgHello])
+				},
+				expectedMessageType: msgHello,
+			},
+			{
+				description: "LOGON",
+				action: func(queue *messageQueue) {
+					queue.appendLogon(nil, handlers[msgLogon])
+				},
+				expectedMessageType: msgLogon,
+			},
+			{
+				description: "ROUTE",
+				action: func(queue *messageQueue) {
+					queue.appendRoute(nil, nil, nil, handlers[msgRoute])
+				},
+				expectedMessageType: msgRoute,
+			},
+			{
+				description: "BEGIN",
+				action: func(queue *messageQueue) {
+					queue.appendBegin(nil, handlers[msgBegin])
+				},
+				expectedMessageType: msgBegin,
+			},
+			{
+				description: "RUN",
+				action: func(queue *messageQueue) {
+					queue.appendRun("", nil, nil, handlers[msgRun])
+				},
+				expectedMessageType: msgRun,
+			},
+			{
+				description: "PULL",
+				action: func(queue *messageQueue) {
+					queue.appendPullN(0, handlers[msgPullN])
+					// note: appendPullNQid is also PULL, so skipping it
+				},
+				expectedMessageType: msgPullN,
+			},
+			{
+				description: "COMMIT",
+				action: func(queue *messageQueue) {
+					queue.appendCommit(handlers[msgCommit])
+				},
+				expectedMessageType: msgCommit,
+			},
+			{
+				description: "ROLLBACK",
+				action: func(queue *messageQueue) {
+					queue.appendRollback(handlers[msgRollback])
+				},
+				expectedMessageType: msgRollback,
+			},
+			{
+				description: "DISCARD",
+				action: func(queue *messageQueue) {
+					queue.appendDiscardN(0, handlers[msgDiscardN])
+					// note: appendDiscardNQid is also DISCARD, so skipping it
+				},
+				expectedMessageType: msgDiscardN,
+			},
+			{
+				description: "RESET",
+				action: func(queue *messageQueue) {
+					queue.appendReset(handlers[msgReset])
+				},
+				expectedMessageType: msgReset,
+			},
+			{
+				description: "GOODBYE",
+				action: func(queue *messageQueue) {
+					queue.appendGoodbye()
+				},
+				expectedMessageType: msgGoodbye,
+				skipsHandler:        true,
+			},
+		}
+
+		queue := newMessageQueue(nil, nil, &writer, nil, nil)
+
+		for _, test := range tests {
+			inner.Run(test.description, func(t *testing.T) {
+				initialLength := queue.handlers.Len()
+
+				test.action(&queue)
+
+				actualLength := queue.handlers.Len()
+				if test.skipsHandler {
+					AssertIntEqual(t, actualLength, initialLength)
+				} else {
+					AssertIntEqual(t, actualLength, initialLength+1)
+					expectedHandler := handlers[test.expectedMessageType]
+					enqueuedHandler := queue.handlers.Back().Value.(responseHandler)
+					assertEqualResponseHandlers(t, expectedHandler, enqueuedHandler)
+				}
+				AssertTrue(t, bytes.Contains(writer.chunker.buf, []byte{test.expectedMessageType}))
+			})
+		}
+
+	})
+
+	outer.Run("queues handlers", func(inner *testing.T) {
+		ctx := context.Background()
+		client, server := net.Pipe()
+
+		reader := incoming{
+			buf: make([]byte, 4096),
+			hyd: hydrator{
+				boltMajor: 5,
+				useUtc:    true,
+			},
+			connReadTimeout: -1,
+		}
+		writer := &outgoing{}
+
+		queue := newMessageQueue(client, &reader, nil, func() {}, nil)
+
+		inner.Run("receives single message, executes the first handler", func(t *testing.T) {
+			defer func() {
+				queue.handlers.Init()
+			}()
+			done := make(chan any)
+			called := make(chan bool)
+			queue.enqueueCallback(responseHandler{onSuccess: func(s *success) { called <- true }})
+			queue.enqueueCallback(responseHandler{onSuccess: func(s *success) { t.Errorf("don't call me") }})
+
+			go func() {
+				AssertTrue(t, <-called)
+				done <- struct{}{}
+			}()
+			go func() {
+				AssertNoError(t, queue.receive(ctx))
+			}()
+
+			writer.appendX(msgSuccess, map[string]any{})
+			writer.send(ctx, server)
+			<-done
+		})
+
+		inner.Run("receives all messages, executes all handlers", func(t *testing.T) {
+			done := make(chan any)
+			called := make(chan bool)
+			queue.enqueueCallback(responseHandler{onSuccess: func(s *success) { called <- true }})
+			queue.enqueueCallback(responseHandler{onIgnored: func(*ignored) { called <- true }})
+			queue.enqueueCallback(responseHandler{onRecord: func(*db.Record) { called <- true }})
+
+			go func() {
+				AssertTrue(t, <-called)
+				AssertTrue(t, <-called)
+				AssertTrue(t, <-called)
+				done <- struct{}{}
+			}()
+			go func() {
+				AssertNoError(t, queue.receiveAll(ctx))
+			}()
+
+			writer.appendX(msgSuccess, map[string]any{})
+			writer.send(ctx, server)
+			writer.appendX(msgIgnored)
+			writer.send(ctx, server)
+			writer.appendX(msgRecord, []any{})
+			writer.send(ctx, server)
+			<-done
+		})
+	})
+}
+
+func assertEqualResponseHandlers(t *testing.T, handler1, handler2 responseHandler) {
+	t.Helper()
+	// reflect.DeepEqual does not support comparison of non-nil functions (the same function is not equal to itself)
+	// reflect.DeepEqual only considers equal a nil function with another nil function
+	// reflect.DeepEqual therefore considers an empty responseHandler (all nil functions) to equal to any other empty responseHandler
+	if !functionEqual(handler1.onSuccess, handler2.onSuccess) {
+		t.Errorf("expected onSuccess callbacks to be equal")
+	}
+	if !functionEqual(handler1.onIgnored, handler2.onIgnored) {
+		t.Errorf("expected onIgnored callbacks to be equal")
+	}
+	if !functionEqual(handler1.onRecord, handler2.onRecord) {
+		t.Errorf("expected onRecord callbacks to be equal")
+	}
+	if !functionEqual(handler1.onFailure, handler2.onFailure) {
+		t.Errorf("expected onFailure callbacks to be equal")
+	}
+	if !functionEqual(handler1.onUnknown, handler2.onUnknown) {
+		t.Errorf("expected onUnknown callbacks to be equal")
+	}
+}
+
+func functionEqual(func1, func2 any) bool {
+	return reflect.ValueOf(func1).Pointer() == reflect.ValueOf(func2).Pointer()
+}

--- a/neo4j/internal/bolt/response_handler.go
+++ b/neo4j/internal/bolt/response_handler.go
@@ -1,6 +1,8 @@
 package bolt
 
-import "github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+import (
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+)
 
 type responseHandler struct {
 	onSuccess func(*success)

--- a/neo4j/internal/bolt/response_handler.go
+++ b/neo4j/internal/bolt/response_handler.go
@@ -12,6 +12,5 @@ type responseHandler struct {
 	onIgnored func(*ignored)
 }
 
-func onSuccessNoOp(*success)  {}
-func onRecordNoOp(*db.Record) {}
-func onIgnoredNoOp(*ignored)  {}
+func onSuccessNoOp(*success) {}
+func onIgnoredNoOp(*ignored) {}

--- a/neo4j/internal/bolt/response_handler.go
+++ b/neo4j/internal/bolt/response_handler.go
@@ -1,0 +1,15 @@
+package bolt
+
+import "github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+
+type responseHandler struct {
+	onSuccess func(*success)
+	onRecord  func(*db.Record)
+	onFailure func(*db.Neo4jError)
+	onUnknown func(any)
+	onIgnored func(*ignored)
+}
+
+func onSuccessNoOp(*success)  {}
+func onRecordNoOp(*db.Record) {}
+func onIgnoredNoOp(*ignored)  {}

--- a/neo4j/internal/bolt/stream.go
+++ b/neo4j/internal/bolt/stream.go
@@ -29,13 +29,14 @@ import (
 )
 
 type stream struct {
-	keys      []string
-	fifo      list.List
-	sum       *db.Summary
-	err       error
-	qid       int64
-	fetchSize int
-	key       int64
+	keys       []string
+	fifo       list.List
+	sum        *db.Summary
+	err        error
+	qid        int64
+	fetchSize  int
+	key        int64
+	endOfBatch bool
 }
 
 // Acts on buffered data, first return value indicates if buffering

--- a/neo4j/internal/bolt/stream.go
+++ b/neo4j/internal/bolt/stream.go
@@ -37,6 +37,7 @@ type stream struct {
 	fetchSize  int
 	key        int64
 	endOfBatch bool
+	discarding bool
 }
 
 // Acts on buffered data, first return value indicates if buffering
@@ -55,6 +56,13 @@ func (s *stream) bufferedNext() (bool, *db.Record, *db.Summary, error) {
 	}
 
 	return false, nil, nil, nil
+}
+
+func (s *stream) emptyRecords() {
+	if s.fifo.Len() == 0 {
+		return
+	}
+	s.fifo.Init()
 }
 
 // Delayed error until fifo emptied

--- a/neo4j/test-integration/dbconn_test.go
+++ b/neo4j/test-integration/dbconn_test.go
@@ -22,6 +22,8 @@ package test_integration
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"math"
 	"math/big"
@@ -31,7 +33,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/bolt"
 	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
@@ -101,382 +102,390 @@ func TestConnectionConformance(outer *testing.T) {
 		return bid.Int64()
 	}
 
-	// All of these tests should leave the connection in a good state without the need
-	// for a reset. All tests share the same connection.
-	cases := []struct {
-		name string
-		fun  func(*testing.T, idb.Connection)
-	}{
-		{
-			// Leaves the connection in perfect state after creating and iterating through all records
-			name: "Run autocommit, full consume",
-			fun: func(t *testing.T, c idb.Connection) {
-				s, err := c.Run(context.Background(),
-					idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n",
-						Params: map[string]any{"r": randInt()}},
-					idb.TxConfig{Mode: idb.WriteMode})
-				AssertNoError(t, err)
-				rec, sum, err := c.Next(context.Background(), s)
-				AssertNextOnlyRecord(t, rec, sum, err)
-				rec, sum, err = c.Next(context.Background(), s)
-				AssertNextOnlySummary(t, rec, sum, err)
-			},
-		},
-		{
-			// Let the connection buffer the result before next autocommit.
-			// Leaves the connection in streaming state from the last Run.
-			name: "Run autocommit twice, no consume",
-			fun: func(t *testing.T, c idb.Connection) {
-				_, err := c.Run(context.Background(),
-					idb.Command{Cypher: "CREATE (n:Rand {val: $r})",
-						Params: map[string]any{"r": randInt()}},
-					idb.TxConfig{Mode: idb.WriteMode})
-				AssertNoError(t, err)
-				_, err = c.Run(context.Background(),
-					idb.Command{Cypher: "CREATE (n:Rand {val: $r})",
-						Params: map[string]any{"r": randInt()}},
-					idb.TxConfig{Mode: idb.WriteMode})
-				AssertNoError(t, err)
-			},
-		},
-		{
-			// Iterate everything before committing
-			name: "Run explicit commit, full consume",
-			fun: func(t *testing.T, c idb.Connection) {
-				txHandle, err := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.WriteMode,
-						Timeout: 10 * time.Minute})
-				AssertNoError(t, err)
-				r := randInt()
-				s, err := c.RunTx(context.Background(), txHandle,
-					idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n", Params: map[string]any{"r": r}})
-				AssertNoError(t, err)
-				rec, sum, err := c.Next(context.Background(), s)
-				AssertNextOnlyRecord(t, rec, sum, err)
-				rec, sum, err = c.Next(context.Background(), s)
-				AssertNextOnlySummary(t, rec, sum, err)
-				err = c.TxCommit(context.Background(), txHandle)
-				AssertNoError(t, err)
-				// Make sure it's commited
-				s, err = c.Run(context.Background(),
-					idb.Command{Cypher: "MATCH (n:Rand {val: $r}) RETURN n",
-						Params: map[string]any{"r": r}},
-					idb.TxConfig{Mode: idb.ReadMode})
-				AssertNoError(t, err)
-				rec, sum, err = c.Next(context.Background(), s)
-				AssertNextOnlyRecord(t, rec, sum, err)
-				// Not everything consumed from the read check, but that is also fine
-			},
-		},
-		{
-			// Do not consume anything before commiting
-			name: "Run explicit commit, no consume",
-			fun: func(t *testing.T, c idb.Connection) {
-				txHandle, err := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.WriteMode,
-						Timeout: 10 * time.Minute})
-				AssertNoError(t, err)
-				r := randInt()
-				_, err = c.RunTx(context.Background(), txHandle,
-					idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n", Params: map[string]any{"r": r}})
-				AssertNoError(t, err)
-				err = c.TxCommit(context.Background(), txHandle)
-				AssertNoError(t, err)
-				// Make sure it's committed
-				s, err := c.Run(context.Background(),
-					idb.Command{Cypher: "MATCH (n:Rand {val: $r}) RETURN n",
-						Params: map[string]any{"r": r}},
-					idb.TxConfig{Mode: idb.ReadMode})
-				AssertNoError(t, err)
-				rec, sum, err := c.Next(context.Background(), s)
-				AssertNextOnlyRecord(t, rec, sum, err)
-				// Not everything consumed from the read check, but that is also fine
-			},
-		},
-		{
-			// Iterate everything returned from create before rolling back
-			name: "Run explicit rollback, full consume",
-			fun: func(t *testing.T, c idb.Connection) {
-				txHandle, err := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.WriteMode,
-						Timeout: 10 * time.Minute})
-				AssertNoError(t, err)
-				r := randInt()
-				s, err := c.RunTx(context.Background(), txHandle,
-					idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n", Params: map[string]any{"r": r}})
-				AssertNoError(t, err)
-				rec, sum, err := c.Next(context.Background(), s)
-				AssertNextOnlyRecord(t, rec, sum, err)
-				rec, sum, err = c.Next(context.Background(), s)
-				AssertNextOnlySummary(t, rec, sum, err)
-				err = c.TxRollback(context.Background(), txHandle)
-				AssertNoError(t, err)
-				// Make sure it's rolled back
-				s, err = c.Run(context.Background(),
-					idb.Command{Cypher: "MATCH (n:Rand {val: $r}) RETURN n",
-						Params: map[string]any{"r": r}},
-					idb.TxConfig{Mode: idb.ReadMode})
-				AssertNoError(t, err)
-				rec, sum, err = c.Next(context.Background(), s)
-				AssertNextOnlySummary(t, rec, sum, err)
-			},
-		},
-		{
-			// Do not consume anything before rolling back
-			name: "Run explicit rollback, no consume",
-			fun: func(t *testing.T, c idb.Connection) {
-				txHandle, err := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.WriteMode,
-						Timeout: 10 * time.Minute})
-				AssertNoError(t, err)
-				r := randInt()
-				_, err = c.RunTx(context.Background(), txHandle,
-					idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n", Params: map[string]any{"r": r}})
-				AssertNoError(t, err)
-				err = c.TxRollback(context.Background(), txHandle)
-				AssertNoError(t, err)
-				// Make sure it's committed
-				s, err := c.Run(context.Background(),
-					idb.Command{Cypher: "MATCH (n:Rand {val: $r}) RETURN n",
-						Params: map[string]any{"r": r}},
-					idb.TxConfig{Mode: idb.ReadMode})
-				AssertNoError(t, err)
-				rec, sum, err := c.Next(context.Background(), s)
-				AssertNextOnlySummary(t, rec, sum, err)
-			},
-		},
-		{
-			name: "Nested results in transaction, iterate outer result",
-			fun: func(t *testing.T, c idb.Connection) {
-				tx, err := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.ReadMode})
-				AssertNoError(t, err)
-				r1, err := c.RunTx(context.Background(), tx,
-					idb.Command{Cypher: "UNWIND RANGE(0, 100) AS n RETURN n"})
-				AssertNoError(t, err)
-				n := int64(0)
-				rec, _, _ := c.Next(context.Background(), r1)
-				for ; rec != nil; rec, _, _ = c.Next(context.Background(), r1) {
-					n = rec.Values[0].(int64)
-					_, err := c.RunTx(context.Background(), tx,
-						idb.Command{Cypher: "UNWIND RANGE (0, $x) AS x RETURN x", Params: map[string]any{"x": n}})
+	outer.Run("without reset", func(inner *testing.T) {
+		// All of these tests should leave the connection in a good state without the need
+		// for a reset. All tests share the same connection.
+		cases := []struct {
+			name string
+			fun  func(*testing.T, idb.Connection)
+		}{
+			{
+				// Leaves the connection in perfect state after creating and iterating through all records
+				name: "Run autocommit, full consume",
+				fun: func(t *testing.T, c idb.Connection) {
+					s, err := c.Run(context.Background(),
+						idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n",
+							Params: map[string]any{"r": randInt()}},
+						idb.TxConfig{Mode: idb.WriteMode})
 					AssertNoError(t, err)
-				}
-				if n != 100 {
-					t.Errorf("n should have reached 100: %d", n)
-				}
-				err = c.TxCommit(context.Background(), tx)
-				AssertNoError(t, err)
-				bookmark := c.Bookmark()
-				AssertStringNotEmpty(t, bookmark)
+					rec, sum, err := c.Next(context.Background(), s)
+					AssertNextOnlyRecord(t, rec, sum, err)
+					rec, sum, err = c.Next(context.Background(), s)
+					AssertNextOnlySummary(t, rec, sum, err)
+				},
 			},
-		},
-		{
-			name: "Next without streaming",
-			fun: func(t *testing.T, c idb.Connection) {
-				rec, sum, err := c.Next(context.Background(), 3)
-				AssertNextOnlyError(t, rec, sum, err)
+			{
+				// Let the connection buffer the result before next autocommit.
+				// Leaves the connection in streaming state from the last Run.
+				name: "Run autocommit twice, no consume",
+				fun: func(t *testing.T, c idb.Connection) {
+					_, err := c.Run(context.Background(),
+						idb.Command{Cypher: "CREATE (n:Rand {val: $r})",
+							Params: map[string]any{"r": randInt()}},
+						idb.TxConfig{Mode: idb.WriteMode})
+					AssertNoError(t, err)
+					_, err = c.Run(context.Background(),
+						idb.Command{Cypher: "CREATE (n:Rand {val: $r})",
+							Params: map[string]any{"r": randInt()}},
+						idb.TxConfig{Mode: idb.WriteMode})
+					AssertNoError(t, err)
+				},
 			},
-		},
-		{
-			name: "Next passed the summary",
-			fun: func(t *testing.T, c idb.Connection) {
+			{
+				// Iterate everything before committing
+				name: "Run explicit commit, full consume",
+				fun: func(t *testing.T, c idb.Connection) {
+					txHandle, err := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.WriteMode,
+							Timeout: 10 * time.Minute})
+					AssertNoError(t, err)
+					r := randInt()
+					s, err := c.RunTx(context.Background(), txHandle,
+						idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n", Params: map[string]any{"r": r}})
+					AssertNoError(t, err)
+					rec, sum, err := c.Next(context.Background(), s)
+					AssertNextOnlyRecord(t, rec, sum, err)
+					rec, sum, err = c.Next(context.Background(), s)
+					AssertNextOnlySummary(t, rec, sum, err)
+					err = c.TxCommit(context.Background(), txHandle)
+					AssertNoError(t, err)
+					// Make sure it's commited
+					s, err = c.Run(context.Background(),
+						idb.Command{Cypher: "MATCH (n:Rand {val: $r}) RETURN n",
+							Params: map[string]any{"r": r}},
+						idb.TxConfig{Mode: idb.ReadMode})
+					AssertNoError(t, err)
+					rec, sum, err = c.Next(context.Background(), s)
+					AssertNextOnlyRecord(t, rec, sum, err)
+					// Not everything consumed from the read check, but that is also fine
+				},
+			},
+			{
+				// Do not consume anything before committing
+				name: "Run explicit commit, no consume",
+				fun: func(t *testing.T, c idb.Connection) {
+					txHandle, err := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.WriteMode,
+							Timeout: 10 * time.Minute})
+					AssertNoError(t, err)
+					r := randInt()
+					_, err = c.RunTx(context.Background(), txHandle,
+						idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n", Params: map[string]any{"r": r}})
+					AssertNoError(t, err)
+					err = c.TxCommit(context.Background(), txHandle)
+					AssertNoError(t, err)
+					// Make sure it's committed
+					s, err := c.Run(context.Background(),
+						idb.Command{Cypher: "MATCH (n:Rand {val: $r}) RETURN n",
+							Params: map[string]any{"r": r}},
+						idb.TxConfig{Mode: idb.ReadMode})
+					AssertNoError(t, err)
+					rec, sum, err := c.Next(context.Background(), s)
+					AssertNextOnlyRecord(t, rec, sum, err)
+					// Not everything consumed from the read check, but that is also fine
+				},
+			},
+			{
+				// Iterate everything returned from create before rolling back
+				name: "Run explicit rollback, full consume",
+				fun: func(t *testing.T, c idb.Connection) {
+					txHandle, err := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.WriteMode,
+							Timeout: 10 * time.Minute})
+					AssertNoError(t, err)
+					r := randInt()
+					s, err := c.RunTx(context.Background(), txHandle,
+						idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n", Params: map[string]any{"r": r}})
+					AssertNoError(t, err)
+					rec, sum, err := c.Next(context.Background(), s)
+					AssertNextOnlyRecord(t, rec, sum, err)
+					rec, sum, err = c.Next(context.Background(), s)
+					AssertNextOnlySummary(t, rec, sum, err)
+					err = c.TxRollback(context.Background(), txHandle)
+					AssertNoError(t, err)
+					// Make sure it's rolled back
+					s, err = c.Run(context.Background(),
+						idb.Command{Cypher: "MATCH (n:Rand {val: $r}) RETURN n",
+							Params: map[string]any{"r": r}},
+						idb.TxConfig{Mode: idb.ReadMode})
+					AssertNoError(t, err)
+					rec, sum, err = c.Next(context.Background(), s)
+					AssertNextOnlySummary(t, rec, sum, err)
+				},
+			},
+			{
+				// Do not consume anything before rolling back
+				name: "Run explicit rollback, no consume",
+				fun: func(t *testing.T, c idb.Connection) {
+					txHandle, err := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.WriteMode,
+							Timeout: 10 * time.Minute})
+					AssertNoError(t, err)
+					r := randInt()
+					_, err = c.RunTx(context.Background(), txHandle,
+						idb.Command{Cypher: "CREATE (n:Rand {val: $r}) RETURN n", Params: map[string]any{"r": r}})
+					AssertNoError(t, err)
+					err = c.TxRollback(context.Background(), txHandle)
+					AssertNoError(t, err)
+					// Make sure it's committed
+					s, err := c.Run(context.Background(),
+						idb.Command{Cypher: "MATCH (n:Rand {val: $r}) RETURN n",
+							Params: map[string]any{"r": r}},
+						idb.TxConfig{Mode: idb.ReadMode})
+					AssertNoError(t, err)
+					rec, sum, err := c.Next(context.Background(), s)
+					AssertNextOnlySummary(t, rec, sum, err)
+				},
+			},
+			{
+				name: "Nested results in transaction, iterate outer result",
+				fun: func(t *testing.T, c idb.Connection) {
+					tx, err := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.ReadMode})
+					AssertNoError(t, err)
+					r1, err := c.RunTx(context.Background(), tx,
+						idb.Command{Cypher: "UNWIND RANGE(0, 100) AS n RETURN n"})
+					AssertNoError(t, err)
+					n := int64(0)
+					rec, _, _ := c.Next(context.Background(), r1)
+					for ; rec != nil; rec, _, _ = c.Next(context.Background(), r1) {
+						n = rec.Values[0].(int64)
+						_, err := c.RunTx(context.Background(), tx,
+							idb.Command{Cypher: "UNWIND RANGE (0, $x) AS x RETURN x", Params: map[string]any{"x": n}})
+						AssertNoError(t, err)
+					}
+					if n != 100 {
+						t.Errorf("n should have reached 100: %d", n)
+					}
+					err = c.TxCommit(context.Background(), tx)
+					AssertNoError(t, err)
+					bookmark := c.Bookmark()
+					AssertStringNotEmpty(t, bookmark)
+				},
+			},
+			{
+				name: "Next without streaming",
+				fun: func(t *testing.T, c idb.Connection) {
+					rec, sum, err := c.Next(context.Background(), 3)
+					AssertNextOnlyError(t, rec, sum, err)
+				},
+			},
+			{
+				name: "Next passed the summary",
+				fun: func(t *testing.T, c idb.Connection) {
+					s, err := boltConn.Run(context.Background(),
+						idb.Command{Cypher: "RETURN 42"},
+						idb.TxConfig{Mode: idb.ReadMode})
+					AssertNoError(t, err)
+					rec, sum, err := c.Next(context.Background(), s)
+					AssertNextOnlyRecord(t, rec, sum, err)
+					rec, sum, err = c.Next(context.Background(), s)
+					AssertNextOnlySummary(t, rec, sum, err)
+					rec, sum, err = c.Next(context.Background(), s)
+					AssertNextOnlySummary(t, rec, sum, err)
+				},
+			},
+			{
+				name: "Run autocommit while in tx",
+				fun: func(t *testing.T, c idb.Connection) {
+					txHandle, err := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.WriteMode,
+							Timeout: 10 * time.Minute})
+					AssertNoError(t, err)
+					defer c.TxRollback(context.Background(), txHandle)
+					s, err := c.Run(context.Background(),
+						idb.Command{Cypher: "CREATE (n:Rand {val: $r})",
+							Params: map[string]any{"r": randInt()}},
+						idb.TxConfig{Mode: idb.WriteMode})
+					if s != nil || err == nil {
+						t.Fatal("Should fail to run auto commit when in transaction")
+					}
+					// TODO: Assert type of error!
+				},
+			},
+			{
+				name: "Commit while not in tx",
+				fun: func(t *testing.T, c idb.Connection) {
+					err := c.TxCommit(context.Background(), 1)
+					if err == nil {
+						t.Fatal("Should have failed")
+					}
+					// TODO: Assert type of error!
+				},
+			},
+			{
+				name: "Rollback while not in tx",
+				fun: func(t *testing.T, c idb.Connection) {
+					err := c.TxRollback(context.Background(), 3)
+					if err == nil {
+						t.Fatal("Should have failed")
+					}
+					// TODO: Assert type of error!
+				},
+			},
+		}
+		// Run all above in sequence
+		for _, c := range cases {
+			inner.Run(c.name, func(t *testing.T) {
+				c.fun(t, boltConn)
+				if !boltConn.IsAlive() {
+					t.Error("Connection died")
+				}
+			})
+		}
+		// Run some of the above at random as one test
+		inner.Run("Random sequence", func(t *testing.T) {
+			randoms := make([]int, 25)
+			for i := range randoms {
+				randoms[i] = int(randInt() % int64(len(cases)))
+			}
+
+			for _, i := range randoms {
+				c := cases[i]
+				fmt.Printf("Running now %s\n", c.name)
+				c.fun(t, boltConn)
+				if !boltConn.IsAlive() {
+					t.Error("Connection died")
+				}
+			}
+		})
+	})
+
+	outer.Run("with reset", func(inner *testing.T) {
+		// All of these tests should leave the connection in a good state after a
+		//reset/but not necessarily without it. All tests share the same connection.
+		cases := []struct {
+			name string
+			fun  func(*testing.T, idb.Connection)
+		}{
+			// Connection is in failed state due to syntax error
+			{
+				name: "Run autocommit with syntax error",
+				fun: func(t *testing.T, c idb.Connection) {
+					s, err := c.Run(context.Background(),
+						idb.Command{Cypher: "MATCH (n:Rand {val: $r} ",
+							Params: map[string]any{"r": randInt()}},
+						idb.TxConfig{Mode: idb.ReadMode})
+					if err == nil || s != nil {
+						t.Fatal("Should have received error")
+					}
+					_, isDbError := err.(*db.Neo4jError)
+					if !isDbError {
+						t.Error("Should be connection error")
+					}
+				},
+			},
+			//{
+			//	name: "Run autocommit with division by zero in result",
+			//	fun: func(t *testing.T, c idb.Connection) {
+			//		s, err := c.Run(context.Background(),
+			//			idb.Command{Cypher: "UNWIND [0] AS x RETURN 10 / x",
+			//				Params: map[string]any{"r": randInt()}},
+			//			idb.TxConfig{Mode: idb.ReadMode})
+			//		AssertNoError(t, err)
+			//		// Should get error while iterating
+			//		_, _, err = c.Next(context.Background(), s)
+			//		if err == nil {
+			//			t.Error("Should have error")
+			//		}
+			//		_, isDbError := err.(*db.Neo4jError)
+			//		if !isDbError {
+			//			t.Error("Should be connection error")
+			//		}
+			//	},
+			//},
+			//// Connection is in transaction (lazy)
+			//{
+			//	name: "Set connection in transaction mode",
+			//	fun: func(t *testing.T, c idb.Connection) {
+			//		_, err := c.TxBegin(context.Background(),
+			//			idb.TxConfig{Mode: idb.WriteMode})
+			//		AssertNoError(t, err)
+			//	},
+			//},
+			//// Connection is in transaction
+			//{
+			//	name: "Set connection in transaction mode",
+			//	fun: func(t *testing.T, c idb.Connection) {
+			//		tx, _ := c.TxBegin(context.Background(),
+			//			idb.TxConfig{Mode: idb.WriteMode})
+			//		_, err := c.RunTx(context.Background(), tx,
+			//			idb.Command{Cypher: "UNWIND [1] AS n RETURN n"})
+			//		AssertNoError(t, err)
+			//	},
+			//},
+			//// Really big stream streaming
+			//{
+			//	name: "Streaming big stream (autocommit)",
+			//	fun: func(t *testing.T, c idb.Connection) {
+			//		_, err := c.Run(context.Background(),
+			//			idb.Command{Cypher: "UNWIND RANGE (0, " +
+			//				"1000000) AS x RETURN x"}, idb.TxConfig{Mode: idb.
+			//				ReadMode})
+			//		AssertNoError(t, err)
+			//	},
+			//},
+			//// Big nested streams in an uncommitted tx
+			//{
+			//	name: "Streaming big stream (explicit tx)",
+			//	fun: func(t *testing.T, c idb.Connection) {
+			//		tx, _ := c.TxBegin(context.Background(),
+			//			idb.TxConfig{Mode: idb.WriteMode})
+			//		_, err := c.RunTx(context.Background(), tx,
+			//			idb.Command{Cypher: "UNWIND RANGE (0, 1000000) AS n RETURN n"})
+			//		AssertNoError(t, err)
+			//		_, err = c.RunTx(context.Background(), tx,
+			//			idb.Command{Cypher: "UNWIND RANGE (0, 1000000) AS n RETURN n"})
+			//		AssertNoError(t, err)
+			//	},
+			//},
+		}
+		for _, c := range cases {
+			inner.Run(c.name, func(t *testing.T) {
+				c.fun(t, boltConn)
+				if !boltConn.IsAlive() {
+					t.Error("Connection died")
+				}
+				boltConn.Reset(context.Background())
+				// Should be working now
 				s, err := boltConn.Run(context.Background(),
 					idb.Command{Cypher: "RETURN 42"},
 					idb.TxConfig{Mode: idb.ReadMode})
 				AssertNoError(t, err)
-				rec, sum, err := c.Next(context.Background(), s)
-				AssertNextOnlyRecord(t, rec, sum, err)
-				rec, sum, err = c.Next(context.Background(), s)
-				AssertNextOnlySummary(t, rec, sum, err)
-				rec, sum, err = c.Next(context.Background(), s)
-				AssertNextOnlySummary(t, rec, sum, err)
-			},
-		},
-		{
-			name: "Run autocommit while in tx",
-			fun: func(t *testing.T, c idb.Connection) {
-				txHandle, err := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.WriteMode,
-						Timeout: 10 * time.Minute})
-				AssertNoError(t, err)
-				defer c.TxRollback(context.Background(), txHandle)
-				s, err := c.Run(context.Background(),
-					idb.Command{Cypher: "CREATE (n:Rand {val: $r})",
-						Params: map[string]any{"r": randInt()}},
-					idb.TxConfig{Mode: idb.WriteMode})
-				if s != nil || err == nil {
-					t.Fatal("Should fail to run auto commit when in transaction")
+				if s == nil {
+					t.Fatal("Didn't get a stream")
 				}
-				// TODO: Assert type of error!
-			},
-		},
-		{
-			name: "Commit while not in tx",
-			fun: func(t *testing.T, c idb.Connection) {
-				err := c.TxCommit(context.Background(), 1)
-				if err == nil {
-					t.Fatal("Should have failed")
-				}
-				// TODO: Assert type of error!
-			},
-		},
-		{
-			name: "Rollback while not in tx",
-			fun: func(t *testing.T, c idb.Connection) {
-				err := c.TxRollback(context.Background(), 3)
-				if err == nil {
-					t.Fatal("Should have failed")
-				}
-				// TODO: Assert type of error!
-			},
-		},
-	}
-	// Run all above in sequence
-	for _, c := range cases {
-		outer.Run(c.name, func(t *testing.T) {
-			c.fun(t, boltConn)
-			if !boltConn.IsAlive() {
-				t.Error("Connection died")
-			}
-		})
-	}
-	// Run some of the above at random as one test
-	outer.Run("Random sequence", func(t *testing.T) {
-		randoms := make([]int, 25)
-		for i := range randoms {
-			randoms[i] = int(randInt() % int64(len(cases)))
+				boltConn.Next(context.Background(), s)
+				boltConn.Next(context.Background(), s)
+			})
 		}
-		for _, i := range randoms {
-			c := cases[i]
-			c.fun(t, boltConn)
-			if !boltConn.IsAlive() {
-				t.Error("Connection died")
-			}
-		}
-	})
 
-	// All of these tests should leave the connection in a good state after a
-	//reset/but not necessarily without it. All tests share the same connection.
-	cases = []struct {
-		name string
-		fun  func(*testing.T, idb.Connection)
-	}{
-		// Connection is in failed state due to syntax error
-		{
-			name: "Run autocommit with syntax error",
-			fun: func(t *testing.T, c idb.Connection) {
-				s, err := c.Run(context.Background(),
-					idb.Command{Cypher: "MATCH (n:Rand {val: $r} ",
-						Params: map[string]any{"r": randInt()}},
-					idb.TxConfig{Mode: idb.ReadMode})
-				if err == nil || s != nil {
-					t.Fatal("Should have received error")
-				}
-				_, isDbError := err.(*db.Neo4jError)
-				if !isDbError {
-					t.Error("Should be connection error")
-				}
-			},
-		},
-		{
-			name: "Run autocommit with division by zero in result",
-			fun: func(t *testing.T, c idb.Connection) {
-				s, err := c.Run(context.Background(),
-					idb.Command{Cypher: "UNWIND [0] AS x RETURN 10 / x",
-						Params: map[string]any{"r": randInt()}},
-					idb.TxConfig{Mode: idb.ReadMode})
-				AssertNoError(t, err)
-				// Should get error while iterating
-				_, _, err = c.Next(context.Background(), s)
-				if err == nil {
-					t.Error("Should have error")
-				}
-				_, isDbError := err.(*db.Neo4jError)
-				if !isDbError {
-					t.Error("Should be connection error")
-				}
-			},
-		},
-		// Connection is in transaction (lazy)
-		{
-			name: "Set connection in transaction mode",
-			fun: func(t *testing.T, c idb.Connection) {
-				_, err := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.WriteMode})
-				AssertNoError(t, err)
-			},
-		},
-		// Connection is in transaction
-		{
-			name: "Set connection in transaction mode",
-			fun: func(t *testing.T, c idb.Connection) {
-				tx, _ := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.WriteMode})
-				_, err := c.RunTx(context.Background(), tx,
-					idb.Command{Cypher: "UNWIND [1] AS n RETURN n"})
-				AssertNoError(t, err)
-			},
-		},
-		// Really big stream streaming
-		{
-			name: "Streaming big stream",
-			fun: func(t *testing.T, c idb.Connection) {
-				_, err := c.Run(context.Background(),
-					idb.Command{Cypher: "UNWIND RANGE (0, " +
-						"1000000) AS x RETURN x"}, idb.TxConfig{Mode: idb.
-						ReadMode})
-				AssertNoError(t, err)
-			},
-		},
-		// Big nested streams in an uncommitted tx
-		{
-			name: "Streaming big stream",
-			fun: func(t *testing.T, c idb.Connection) {
-				tx, _ := c.TxBegin(context.Background(),
-					idb.TxConfig{Mode: idb.WriteMode})
-				_, err := c.RunTx(context.Background(), tx,
-					idb.Command{Cypher: "UNWIND RANGE (0, 1000000) AS n RETURN n"})
-				AssertNoError(t, err)
-				_, err = c.RunTx(context.Background(), tx,
-					idb.Command{Cypher: "UNWIND RANGE (0, 1000000) AS n RETURN n"})
-				AssertNoError(t, err)
-			},
-		},
-	}
-	for _, c := range cases {
-		outer.Run(c.name, func(t *testing.T) {
-			c.fun(t, boltConn)
-			if !boltConn.IsAlive() {
-				t.Error("Connection died")
+		// Run some of the above at random as one test
+		outer.Run("Random reset sequence", func(t *testing.T) {
+			randoms := make([]int, 25)
+			for i := range randoms {
+				randoms[i] = int(randInt() % int64(len(cases)))
 			}
-			boltConn.Reset(context.Background())
-			// Should be working now
-			s, err := boltConn.Run(context.Background(),
-				idb.Command{Cypher: "RETURN 42"},
-				idb.TxConfig{Mode: idb.ReadMode})
-			AssertNoError(t, err)
-			if s == nil {
-				t.Fatal("Didn't get a stream")
+			for _, i := range randoms {
+				c := cases[i]
+				fmt.Printf("Running now %s (test %d)\n", c.name, i)
+				c.fun(t, boltConn)
+				if !boltConn.IsAlive() {
+					t.Error("Connection died")
+				}
+				boltConn.Reset(context.Background())
 			}
-			boltConn.Next(context.Background(), s)
-			boltConn.Next(context.Background(), s)
 		})
-	}
-	// Run some of the above at random as one test
-	outer.Run("Random reset sequence", func(t *testing.T) {
-		randoms := make([]int, 25)
-		for i := range randoms {
-			randoms[i] = int(randInt() % int64(len(cases)))
-		}
-		for _, i := range randoms {
-			c := cases[i]
-			c.fun(t, boltConn)
-			if !boltConn.IsAlive() {
-				t.Error("Connection died")
-			}
-			boltConn.Reset(context.Background())
-		}
 	})
 
 	// Write really big query

--- a/neo4j/test-integration/dbconn_test.go
+++ b/neo4j/test-integration/dbconn_test.go
@@ -385,70 +385,70 @@ func TestConnectionConformance(outer *testing.T) {
 					}
 				},
 			},
-			//{
-			//	name: "Run autocommit with division by zero in result",
-			//	fun: func(t *testing.T, c idb.Connection) {
-			//		s, err := c.Run(context.Background(),
-			//			idb.Command{Cypher: "UNWIND [0] AS x RETURN 10 / x",
-			//				Params: map[string]any{"r": randInt()}},
-			//			idb.TxConfig{Mode: idb.ReadMode})
-			//		AssertNoError(t, err)
-			//		// Should get error while iterating
-			//		_, _, err = c.Next(context.Background(), s)
-			//		if err == nil {
-			//			t.Error("Should have error")
-			//		}
-			//		_, isDbError := err.(*db.Neo4jError)
-			//		if !isDbError {
-			//			t.Error("Should be connection error")
-			//		}
-			//	},
-			//},
-			//// Connection is in transaction (lazy)
-			//{
-			//	name: "Set connection in transaction mode",
-			//	fun: func(t *testing.T, c idb.Connection) {
-			//		_, err := c.TxBegin(context.Background(),
-			//			idb.TxConfig{Mode: idb.WriteMode})
-			//		AssertNoError(t, err)
-			//	},
-			//},
-			//// Connection is in transaction
-			//{
-			//	name: "Set connection in transaction mode",
-			//	fun: func(t *testing.T, c idb.Connection) {
-			//		tx, _ := c.TxBegin(context.Background(),
-			//			idb.TxConfig{Mode: idb.WriteMode})
-			//		_, err := c.RunTx(context.Background(), tx,
-			//			idb.Command{Cypher: "UNWIND [1] AS n RETURN n"})
-			//		AssertNoError(t, err)
-			//	},
-			//},
-			//// Really big stream streaming
-			//{
-			//	name: "Streaming big stream (autocommit)",
-			//	fun: func(t *testing.T, c idb.Connection) {
-			//		_, err := c.Run(context.Background(),
-			//			idb.Command{Cypher: "UNWIND RANGE (0, " +
-			//				"1000000) AS x RETURN x"}, idb.TxConfig{Mode: idb.
-			//				ReadMode})
-			//		AssertNoError(t, err)
-			//	},
-			//},
-			//// Big nested streams in an uncommitted tx
-			//{
-			//	name: "Streaming big stream (explicit tx)",
-			//	fun: func(t *testing.T, c idb.Connection) {
-			//		tx, _ := c.TxBegin(context.Background(),
-			//			idb.TxConfig{Mode: idb.WriteMode})
-			//		_, err := c.RunTx(context.Background(), tx,
-			//			idb.Command{Cypher: "UNWIND RANGE (0, 1000000) AS n RETURN n"})
-			//		AssertNoError(t, err)
-			//		_, err = c.RunTx(context.Background(), tx,
-			//			idb.Command{Cypher: "UNWIND RANGE (0, 1000000) AS n RETURN n"})
-			//		AssertNoError(t, err)
-			//	},
-			//},
+			{
+				name: "Run autocommit with division by zero in result",
+				fun: func(t *testing.T, c idb.Connection) {
+					s, err := c.Run(context.Background(),
+						idb.Command{Cypher: "UNWIND [0] AS x RETURN 10 / x",
+							Params: map[string]any{"r": randInt()}},
+						idb.TxConfig{Mode: idb.ReadMode})
+					AssertNoError(t, err)
+					// Should get error while iterating
+					_, _, err = c.Next(context.Background(), s)
+					if err == nil {
+						t.Error("Should have error")
+					}
+					_, isDbError := err.(*db.Neo4jError)
+					if !isDbError {
+						t.Error("Should be connection error")
+					}
+				},
+			},
+			// Connection is in transaction (lazy)
+			{
+				name: "Set connection in transaction mode",
+				fun: func(t *testing.T, c idb.Connection) {
+					_, err := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.WriteMode})
+					AssertNoError(t, err)
+				},
+			},
+			// Connection is in transaction
+			{
+				name: "Set connection in transaction mode",
+				fun: func(t *testing.T, c idb.Connection) {
+					tx, _ := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.WriteMode})
+					_, err := c.RunTx(context.Background(), tx,
+						idb.Command{Cypher: "UNWIND [1] AS n RETURN n"})
+					AssertNoError(t, err)
+				},
+			},
+			// Really big stream streaming
+			{
+				name: "Streaming big stream (autocommit)",
+				fun: func(t *testing.T, c idb.Connection) {
+					_, err := c.Run(context.Background(),
+						idb.Command{Cypher: "UNWIND RANGE (0, " +
+							"1000000) AS x RETURN x"}, idb.TxConfig{Mode: idb.
+							ReadMode})
+					AssertNoError(t, err)
+				},
+			},
+			// Big nested streams in an uncommitted tx
+			{
+				name: "Streaming big stream (explicit tx)",
+				fun: func(t *testing.T, c idb.Connection) {
+					tx, _ := c.TxBegin(context.Background(),
+						idb.TxConfig{Mode: idb.WriteMode})
+					_, err := c.RunTx(context.Background(), tx,
+						idb.Command{Cypher: "UNWIND RANGE (0, 1000000) AS n RETURN n"})
+					AssertNoError(t, err)
+					_, err = c.RunTx(context.Background(), tx,
+						idb.Command{Cypher: "UNWIND RANGE (0, 1000000) AS n RETURN n"})
+					AssertNoError(t, err)
+				},
+			},
 		}
 		for _, c := range cases {
 			inner.Run(c.name, func(t *testing.T) {

--- a/neo4j/test-integration/examples_test.go
+++ b/neo4j/test-integration/examples_test.go
@@ -109,12 +109,14 @@ func TestExamples(outer *testing.T) {
 			assertNil(t, err)
 			assertNotNil(t, driver)
 			defer driver.Close(ctx)
+			initialCount, err := countNodes(ctx, driver, "Person", "name", "Tom")
+			assertNil(t, err)
 
 			err = addPersonInSession(ctx, driver, "Tom")
 			assertNil(t, err)
 			count, err := countNodes(ctx, driver, "Person", "name", "Tom")
 			assertNil(t, err)
-			assertEquals(t, count, int64(1))
+			assertEquals(t, count, initialCount+int64(1))
 		})
 
 		inner.Run("Autocommit Transaction", func(t *testing.T) {
@@ -122,12 +124,14 @@ func TestExamples(outer *testing.T) {
 			assertNil(t, err)
 			assertNotNil(t, driver)
 			defer driver.Close(ctx)
+			initialCount, err := countNodes(ctx, driver, "Person", "name", "Shanon")
+			assertNil(t, err)
 
 			err = addPersonInAutoCommitTx(ctx, driver, "Shanon")
 			assertNil(t, err)
 			count, err := countNodes(ctx, driver, "Person", "name", "Shanon")
 			assertNil(t, err)
-			assertEquals(t, count, int64(1))
+			assertEquals(t, count, initialCount+int64(1))
 		})
 
 		inner.Run("Pass Bookmarks", func(t *testing.T) {
@@ -135,25 +139,33 @@ func TestExamples(outer *testing.T) {
 			assertNil(t, err)
 			assertNotNil(t, driver)
 			defer driver.Close(ctx)
+			initialAliceCount, err := countNodes(ctx, driver, "Person", "name", "Alice")
+			assertNil(t, err)
+			initialBobCount, err := countNodes(ctx, driver, "Person", "name", "Bob")
+			assertNil(t, err)
+			initialLexCorpCount, err := countNodes(ctx, driver, "Company", "name", "LexCorp")
+			assertNil(t, err)
+			initialWayneEnterpriseCount, err := countNodes(ctx, driver, "Company", "name", "Wayne Enterprises")
+			assertNil(t, err)
 
 			err = addEmployAndMakeFriends(ctx, driver)
 			assertNil(t, err)
 
 			count, err := countNodes(ctx, driver, "Person", "name", "Alice")
 			assertNil(t, err)
-			assertEquals(t, count, int64(1))
+			assertEquals(t, count, initialAliceCount+int64(1))
 
 			count, err = countNodes(ctx, driver, "Person", "name", "Bob")
 			assertNil(t, err)
-			assertEquals(t, count, int64(1))
+			assertEquals(t, count, initialBobCount+int64(1))
 
 			count, err = countNodes(ctx, driver, "Company", "name", "LexCorp")
 			assertNil(t, err)
-			assertEquals(t, count, int64(1))
+			assertEquals(t, count, initialLexCorpCount+int64(1))
 
 			count, err = countNodes(ctx, driver, "Company", "name", "Wayne Enterprises")
 			assertNil(t, err)
-			assertEquals(t, count, int64(1))
+			assertEquals(t, count, initialWayneEnterpriseCount+int64(1))
 		})
 
 		inner.Run("Read/Write Transaction", func(t *testing.T) {

--- a/neo4j/test-integration/transaction_test.go
+++ b/neo4j/test-integration/transaction_test.go
@@ -81,11 +81,12 @@ func TestTransaction(outer *testing.T) {
 	})
 
 	outer.Run("should commit if work function doesn't return error", func(t *testing.T) {
+		initialCount := readTransactionWithIntWork(ctx, t, session, intReturningWork(ctx, t, "MATCH (n:Person1) RETURN count(n)", nil))
 		createResult := writeTransactionWithIntWork(ctx, t, session, intReturningWork(ctx, t, "CREATE (n:Person1) RETURN count(n)", nil))
 		assertEquals(t, createResult, 1)
 
 		matchResult := readTransactionWithIntWork(ctx, t, session, intReturningWork(ctx, t, "MATCH (n:Person1) RETURN count(n)", nil))
-		assertEquals(t, matchResult, 1)
+		assertEquals(t, matchResult, initialCount+createResult)
 	})
 
 	outer.Run("should rollback if work function returns error", func(t *testing.T) {

--- a/neo4j/test-integration/utils_test.go
+++ b/neo4j/test-integration/utils_test.go
@@ -32,17 +32,14 @@ import (
 
 func intReturningWork(ctx context.Context, t *testing.T, query string, params map[string]any) neo4j.ManagedTransactionWork {
 	return func(tx neo4j.ManagedTransaction) (any, error) {
-		create, err := tx.Run(ctx, query, params)
+		results, err := tx.Run(ctx, query, params)
 		assertNil(t, err)
 
-		returnValue := int64(0)
-		if create.Next(ctx) {
-			returnValue = create.Record().Values[0].(int64)
-		}
-		assertFalse(t, create.Next(ctx))
-		assertNil(t, create.Err())
-
-		return returnValue, nil
+		record, err := results.Single(ctx)
+		assertNil(t, err)
+		result, ok := record.Values[0].(int64)
+		assertTrue(t, ok)
+		return result, nil
 	}
 }
 


### PR DESCRIPTION
This is currently only applied to Bolt 5.x, but can be ported to
older protocol connections as well.

This removes some fragile heuristics on response correlation
(see e.g. success#isResetResponse).

This also paves the way for a cleaner implementation of re-auth.

Big kudos to @robsdedude for guiding through this, as he already
implemented a similar approach in the Python driver.