### PR TITLE
Fix tfirst tracking for interleaved runs of same transaction

### DIFF
--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -416,7 +416,7 @@ func (b *bolt4) discardStream(ctx context.Context) {
 		}
 		discarded = true
 		stream.fetchSize = -1 // request infinite batch to consume the rest
-		if b.state == bolt5StreamingTx && stream.qid != b.lastQid {
+		if b.state == bolt4_streamingtx && stream.qid != b.lastQid {
 			b.queue.appendDiscardNQid(stream.fetchSize, stream.qid, b.discardResponseHandler(stream))
 		} else {
 			b.queue.appendDiscardN(stream.fetchSize, b.discardResponseHandler(stream))

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -1323,4 +1323,37 @@ func TestBolt5(outer *testing.T) {
 			})
 		}
 	})
+
+	outer.Run("tracks tfirst properly", func(t *testing.T) {
+		ctx := context.Background()
+		bolt, cleanup := connectToServer(t, func(srv *bolt5server) {
+			srv.accept(5)
+			srv.waitForTxBegin()
+			srv.sendSuccess(nil)
+			srv.waitForRun(nil)
+			srv.waitForPullN(1)
+			srv.send(msgSuccess, map[string]any{"fields": []any{"x"}, "t_first": int64(10)})
+			srv.send(msgRecord, []any{"1"})
+			srv.send(msgSuccess, map[string]any{"has_more": true})
+			srv.waitForRun(nil)
+			srv.waitForPullN(-1)
+			srv.send(msgSuccess, map[string]any{"fields": []any{"x"}, "t_first": int64(20)})
+			srv.send(msgRecord, []any{"3"})
+			srv.send(msgRecord, []any{"4"})
+			srv.send(msgSuccess, map[string]any{"bookmark": "b2", "type": "r"})
+			srv.send(msgRecord, []any{"2"})
+			srv.send(msgSuccess, map[string]any{"bookmark": "b1", "type": "r"})
+		})
+		defer cleanup()
+		defer bolt.Close(ctx)
+
+		tx1, _ := bolt.TxBegin(ctx, idb.TxConfig{Mode: idb.ReadMode})
+		results1, _ := bolt.RunTx(ctx, tx1, idb.Command{Cypher: "UNWIND [1,2] AS x RETURN x", FetchSize: 1})
+		results2, _ := bolt.RunTx(ctx, tx1, idb.Command{Cypher: "UNWIND [3,4] AS x RETURN x", FetchSize: -1})
+		summary2, _ := bolt.Consume(ctx, results2)
+		summary1, _ := bolt.Consume(ctx, results1)
+
+		AssertIntEqual(t, int(summary1.TFirst), 10)
+		AssertIntEqual(t, int(summary2.TFirst), 20)
+	})
 }

--- a/neo4j/internal/bolt/stream.go
+++ b/neo4j/internal/bolt/stream.go
@@ -38,6 +38,7 @@ type stream struct {
 	key        int64
 	endOfBatch bool
 	discarding bool
+	tfirst     int64 // Time that server started streaming
 }
 
 // Acts on buffered data, first return value indicates if buffering


### PR DESCRIPTION
Since the connection instance tracks the last seen RUN's SUCCESS'
tfirst, a subsequent run of the same transaction overwrites the
tfirst of partially consumed results of a previous run.

Having each stream track their own tfirst avoids this problem.

Note: this only happens to Bolt4 and Bolt5, since it is not
possible to pull partial results with Bolt3 (only PULALL is
available).