### PR TITLE
Improve blocking borrow logic in pool

### DIFF
--- a/neo4j/directrouter.go
+++ b/neo4j/directrouter.go
@@ -38,11 +38,19 @@ func (r *directRouter) InvalidateReader(context.Context, string, string) error {
 	return nil
 }
 
-func (r *directRouter) Readers(context.Context, func(context.Context) ([]string, error), string, *db.ReAuthToken, log.BoltLogger) ([]string, error) {
+func (r *directRouter) GetOrUpdateReaders(context.Context, func(context.Context) ([]string, error), string, *db.ReAuthToken, log.BoltLogger) ([]string, error) {
 	return []string{r.address}, nil
 }
 
-func (r *directRouter) Writers(context.Context, func(context.Context) ([]string, error), string, *db.ReAuthToken, log.BoltLogger) ([]string, error) {
+func (r *directRouter) Readers(context.Context, string) ([]string, error) {
+	return []string{r.address}, nil
+}
+
+func (r *directRouter) GetOrUpdateWriters(context.Context, func(context.Context) ([]string, error), string, *db.ReAuthToken, log.BoltLogger) ([]string, error) {
+	return []string{r.address}, nil
+}
+
+func (r *directRouter) Writers(context.Context, string) ([]string, error) {
 	return []string{r.address}, nil
 }
 

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -294,14 +294,18 @@ func routingContextFromUrl(useRouting bool, u *url.URL) (map[string]string, erro
 }
 
 type sessionRouter interface {
-	// Readers returns the list of servers that can serve reads on the requested database.
+	// GetOrUpdateReaders returns the list of servers that can serve reads on the requested database.
 	// note: bookmarks are lazily supplied, only when a new routing table needs to be fetched
 	// this is needed because custom bookmark managers may provide bookmarks from external systems
 	// they should not be called when it is not needed (e.g. when a routing table is cached)
-	Readers(ctx context.Context, bookmarks func(context.Context) ([]string, error), database string, auth *idb.ReAuthToken, boltLogger log.BoltLogger) ([]string, error)
-	// Writers returns the list of servers that can serve writes on the requested database.
+	GetOrUpdateReaders(ctx context.Context, bookmarks func(context.Context) ([]string, error), database string, auth *idb.ReAuthToken, boltLogger log.BoltLogger) ([]string, error)
+	// Readers returns the list of servers that can serve reads on the requested database.
+	Readers(ctx context.Context, database string) ([]string, error)
+	// GetOrUpdateWriters returns the list of servers that can serve writes on the requested database.
 	// note: bookmarks are lazily supplied, see Readers documentation to learn why
-	Writers(ctx context.Context, bookmarks func(context.Context) ([]string, error), database string, auth *idb.ReAuthToken, boltLogger log.BoltLogger) ([]string, error)
+	GetOrUpdateWriters(ctx context.Context, bookmarks func(context.Context) ([]string, error), database string, auth *idb.ReAuthToken, boltLogger log.BoltLogger) ([]string, error)
+	// Writers returns the list of servers that can serve writes on the requested database.
+	Writers(ctx context.Context, database string) ([]string, error)
 	// GetNameOfDefaultDatabase returns the name of the default database for the specified user.
 	// The correct database name is needed when requesting readers or writers.
 	// the bookmarks are eagerly provided since this method always fetches a new routing table

--- a/neo4j/internal/errorutil/pool.go
+++ b/neo4j/internal/errorutil/pool.go
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package errorutil
 
 import "fmt"
@@ -24,4 +43,11 @@ type PoolClosed struct {
 
 func (e *PoolClosed) Error() string {
 	return "Pool closed"
+}
+
+type PoolOutOfServers struct {
+}
+
+func (e *PoolOutOfServers) Error() string {
+	return "Pool could not find any servers to connect to"
 }

--- a/neo4j/internal/router/no_test.go
+++ b/neo4j/internal/router/no_test.go
@@ -8,13 +8,13 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package router
@@ -32,7 +32,11 @@ type poolFake struct {
 	cancel   context.CancelFunc
 }
 
-func (p *poolFake) Borrow(_ context.Context, servers []string, _ bool, logger log.BoltLogger, _ time.Duration, _ *db.ReAuthToken) (db.Connection, error) {
+func (p *poolFake) Borrow(ctx context.Context, getServers func(context.Context) ([]string, error), _ bool, logger log.BoltLogger, _ time.Duration, _ *db.ReAuthToken) (db.Connection, error) {
+	servers, err := getServers(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return p.borrow(servers, p.cancel, logger)
 }
 

--- a/neo4j/internal/router/readtable.go
+++ b/neo4j/internal/router/readtable.go
@@ -48,7 +48,7 @@ func readTable(
 	// another db.
 	for _, router := range routers {
 		var conn db.Connection
-		if conn, err = connectionPool.Borrow(ctx, []string{router}, true, boltLogger, pool.DefaultLivenessCheckThreshold, auth); err != nil {
+		if conn, err = connectionPool.Borrow(ctx, getStaticServer(router), true, boltLogger, pool.DefaultLivenessCheckThreshold, auth); err != nil {
 			// Check if failed due to context timing out
 			if ctx.Err() != nil {
 				return nil, wrapError(router, ctx.Err())
@@ -73,4 +73,10 @@ func readTable(
 		err = wrapError(router, err)
 	}
 	return nil, err
+}
+
+func getStaticServer(server string) func(context.Context) ([]string, error) {
+	return func(context.Context) ([]string, error) {
+		return []string{server}, nil
+	}
 }

--- a/neo4j/internal/testutil/asserts.go
+++ b/neo4j/internal/testutil/asserts.go
@@ -239,6 +239,14 @@ func AssertDeepEquals(t *testing.T, values ...any) {
 	}
 }
 
+func AssertNotDeepEquals(t *testing.T, value1, value2 any) {
+	t.Helper()
+	if reflect.DeepEqual(value1, value2) {
+		t.Errorf("Expected value %v to not equal value %v", value1, value2)
+		return
+	}
+}
+
 func AssertAfter(t *testing.T, t1, t2 time.Time) {
 	t.Helper()
 	if !t1.After(t2) {

--- a/neo4j/internal/testutil/connfake.go
+++ b/neo4j/internal/testutil/connfake.go
@@ -73,6 +73,7 @@ type ConnFake struct {
 	Idle               time.Time
 	ServerVersionValue string
 	ForceResetHook     func()
+	ReAuthHook         func(context.Context, *idb.ReAuthToken) error
 }
 
 func (c *ConnFake) Connect(
@@ -195,7 +196,10 @@ func (c *ConnFake) SelectDatabase(database string) {
 func (c *ConnFake) SetBoltLogger(log.BoltLogger) {
 }
 
-func (c *ConnFake) ReAuth(context.Context, *idb.ReAuthToken) error {
+func (c *ConnFake) ReAuth(ctx context.Context, token *idb.ReAuthToken) error {
+	if c.ReAuthHook != nil {
+		return c.ReAuthHook(ctx, token)
+	}
 	return nil
 }
 

--- a/neo4j/internal/testutil/poolfake.go
+++ b/neo4j/internal/testutil/poolfake.go
@@ -34,7 +34,7 @@ type PoolFake struct {
 	BorrowHook  func() (db.Connection, error)
 }
 
-func (p *PoolFake) Borrow(context.Context, []string, bool, log.BoltLogger, time.Duration, *db.ReAuthToken) (db.Connection, error) {
+func (p *PoolFake) Borrow(context.Context, func(context.Context) ([]string, error), bool, log.BoltLogger, time.Duration, *db.ReAuthToken) (db.Connection, error) {
 	if p.BorrowHook != nil && (p.BorrowConn != nil || p.BorrowErr != nil) {
 		panic("either use the hook or the desired return values, but not both")
 	}

--- a/neo4j/internal/testutil/routerfake.go
+++ b/neo4j/internal/testutil/routerfake.go
@@ -8,13 +8,13 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package testutil
@@ -28,10 +28,10 @@ import (
 type RouterFake struct {
 	Invalidated            bool
 	InvalidatedDb          string
-	ReadersRet             []string
-	ReadersHook            func(bookmarks func(context.Context) ([]string, error), database string) ([]string, error)
-	WritersRet             []string
-	WritersHook            func(bookmarks func(context.Context) ([]string, error), database string) ([]string, error)
+	GetOrUpdateReadersRet  []string
+	GetOrUpdateReadersHook func(bookmarks func(context.Context) ([]string, error), database string) ([]string, error)
+	GetOrUpdateWritersRet  []string
+	GetOrUpdateWritersHook func(bookmarks func(context.Context) ([]string, error), database string) ([]string, error)
 	Err                    error
 	CleanUpHook            func()
 	GetNameOfDefaultDbHook func(user string) (string, error)
@@ -56,18 +56,26 @@ func (r *RouterFake) Invalidate(ctx context.Context, database string) error {
 	return nil
 }
 
-func (r *RouterFake) Readers(_ context.Context, bookmarksFn func(context.Context) ([]string, error), database string, _ *db.ReAuthToken, _ log.BoltLogger) ([]string, error) {
-	if r.ReadersHook != nil {
-		return r.ReadersHook(bookmarksFn, database)
+func (r *RouterFake) GetOrUpdateReaders(_ context.Context, bookmarksFn func(context.Context) ([]string, error), database string, _ *db.ReAuthToken, _ log.BoltLogger) ([]string, error) {
+	if r.GetOrUpdateReadersHook != nil {
+		return r.GetOrUpdateReadersHook(bookmarksFn, database)
 	}
-	return r.ReadersRet, r.Err
+	return r.GetOrUpdateReadersRet, r.Err
 }
 
-func (r *RouterFake) Writers(_ context.Context, bookmarksFn func(context.Context) ([]string, error), database string, _ *db.ReAuthToken, _ log.BoltLogger) ([]string, error) {
-	if r.WritersHook != nil {
-		return r.WritersHook(bookmarksFn, database)
+func (r *RouterFake) Readers(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (r *RouterFake) GetOrUpdateWriters(_ context.Context, bookmarksFn func(context.Context) ([]string, error), database string, _ *db.ReAuthToken, _ log.BoltLogger) ([]string, error) {
+	if r.GetOrUpdateWritersHook != nil {
+		return r.GetOrUpdateWritersHook(bookmarksFn, database)
 	}
-	return r.WritersRet, r.Err
+	return r.GetOrUpdateWritersRet, r.Err
+}
+
+func (r *RouterFake) Writers(context.Context, string) ([]string, error) {
+	return nil, nil
 }
 
 func (r *RouterFake) GetNameOfDefaultDatabase(_ context.Context, _ []string, user string, _ *db.ReAuthToken, _ log.BoltLogger) (string, error) {

--- a/neo4j/session_with_context_test.go
+++ b/neo4j/session_with_context_test.go
@@ -8,13 +8,13 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package neo4j
@@ -155,7 +155,7 @@ func TestSession(outer *testing.T) {
 				numDefaultDbLookups++
 				return mydb, nil
 			}
-			router.WritersHook = func(_ func(context.Context) ([]string, error), database string) ([]string, error) {
+			router.GetOrUpdateWritersHook = func(_ func(context.Context) ([]string, error), database string) ([]string, error) {
 				AssertStringEqual(t, mydb, database)
 				return []string{"aserver"}, nil
 			}
@@ -338,7 +338,7 @@ func TestSession(outer *testing.T) {
 				numDefaultDbLookups++
 				return mydb, nil
 			}
-			router.ReadersHook = func(_ func(context.Context) ([]string, error), database string) ([]string, error) {
+			router.GetOrUpdateReadersHook = func(_ func(context.Context) ([]string, error), database string) ([]string, error) {
 				AssertStringEqual(t, mydb, database)
 				return []string{"aserver"}, nil
 			}
@@ -506,7 +506,7 @@ func TestSession(outer *testing.T) {
 				numDefaultDbLookups++
 				return mydb, nil
 			}
-			router.ReadersHook = func(_ func(context.Context) ([]string, error), database string) ([]string, error) {
+			router.GetOrUpdateReadersHook = func(_ func(context.Context) ([]string, error), database string) ([]string, error) {
 				AssertStringEqual(t, mydb, database)
 				return []string{"aserver"}, nil
 			}
@@ -622,7 +622,7 @@ func TestSession(outer *testing.T) {
 			router, _, session := createSession()
 			defer session.Close(ctx)
 			expectedErr := fmt.Errorf("server retrieval err")
-			router.ReadersHook = func(func(context.Context) ([]string, error), string) ([]string, error) {
+			router.GetOrUpdateReadersHook = func(func(context.Context) ([]string, error), string) ([]string, error) {
 				return nil, expectedErr
 			}
 


### PR DESCRIPTION
 * After waiting for room in the pool, borrow also considers creating a new connection (if possible)
 * After waiting for room in the pool, borrow reads (but doesn't update) the routing table to get more up-to-date routing info
 * Connections are always fully returned to and then borrowed from the pool. This means the health check and other initializers are guaranteed to be run.