### PR TITLE
Add missing `time.Time` type constraint for records and nodes/rels

### DIFF
--- a/neo4j/graph.go
+++ b/neo4j/graph.go
@@ -21,12 +21,13 @@ package neo4j
 
 import (
 	"fmt"
+	"time"
 )
 
 type PropertyValue interface {
 	bool | int64 | float64 | string |
 		Point2D | Point3D |
-		Date | LocalTime | LocalDateTime | Time | Duration | /* OffsetTime == Time == dbtype.Time */
+		Date | LocalTime | LocalDateTime | Time | Duration | time.Time | /* OffsetTime == Time == dbtype.Time */
 		[]byte | []any
 }
 

--- a/neo4j/graph_test.go
+++ b/neo4j/graph_test.go
@@ -169,6 +169,15 @@ func TestGetProperty(outer *testing.T) {
 				AssertNoError(t, err)
 			})
 
+			inner.Run("datetimes", func(t *testing.T) {
+				entity := test.make(singleProp("k", now))
+
+				prop, err := neo4j.GetProperty[time.Time](entity, "k")
+
+				AssertDeepEquals(t, prop, now)
+				AssertNoError(t, err)
+			})
+
 			inner.Run("durations", func(t *testing.T) {
 				entity := test.make(singleProp("k", neo4j.DurationOf(5, 4, 3, 2)))
 

--- a/neo4j/record.go
+++ b/neo4j/record.go
@@ -19,12 +19,15 @@
 
 package neo4j
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type RecordValue interface {
 	bool | int64 | float64 | string |
 		Point2D | Point3D |
-		Date | LocalTime | LocalDateTime | Time | Duration | /* OffsetTime == Time == dbtype.Time */
+		Date | LocalTime | LocalDateTime | Time | Duration | time.Time | /* OffsetTime == Time == dbtype.Time */
 		[]byte | []any | map[string]any |
 		Node | Relationship | Path
 }

--- a/neo4j/record_test.go
+++ b/neo4j/record_test.go
@@ -168,6 +168,16 @@ func TestGetRecordValue(outer *testing.T) {
 			AssertNoError(t, err)
 		})
 
+		inner.Run("datetimes", func(t *testing.T) {
+			entity := record("k", now)
+
+			value, isNil, err := neo4j.GetRecordValue[time.Time](entity, "k")
+
+			AssertDeepEquals(t, value, now)
+			AssertFalse(t, isNil)
+			AssertNoError(t, err)
+		})
+
 		inner.Run("durations", func(t *testing.T) {
 			entity := record("k", neo4j.DurationOf(5, 4, 3, 2))
 


### PR DESCRIPTION
Fixes #486