### PR TITLE
Get rid of redundant onUnknown response handler callback

### DIFF
--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -1014,9 +1014,6 @@ func (b *bolt4) discardResponseHandler(stream *stream) responseHandler {
 			stream.err = failure
 			b.onFailure(ctx, failure) // Will detach the stream
 		},
-		onUnknown: func(msg any) {
-			b.setError(fmt.Errorf("unknown response %v", msg), true)
-		},
 	}
 }
 
@@ -1056,9 +1053,6 @@ func (b *bolt4) pullResponseHandler(stream *stream) responseHandler {
 			stream.err = failure
 			b.onFailure(ctx, failure) // will detach the stream
 		},
-		onUnknown: func(msg any) {
-			b.setError(fmt.Errorf("unknown response %v", msg), true)
-		},
 	}
 
 }
@@ -1082,9 +1076,6 @@ func (b *bolt4) resetResponseHandler() responseHandler {
 		},
 		onFailure: func(ctx context.Context, failure *db.Neo4jError) {
 			_ = b.onNeo4jError(ctx, b, failure)
-			b.state = bolt4_dead
-		},
-		onUnknown: func(any) {
 			b.state = bolt4_dead
 		},
 	}
@@ -1123,7 +1114,6 @@ func (b *bolt4) expectedSuccessHandler(onSuccess func(*success)) responseHandler
 	return responseHandler{
 		onSuccess: onSuccess,
 		onFailure: b.onFailure,
-		onUnknown: b.onUnknown,
 		onIgnored: onIgnoredNoOp,
 	}
 }
@@ -1143,10 +1133,6 @@ func (b *bolt4) onFailure(ctx context.Context, failure *db.Neo4jError) {
 		err = errorutil.CombineErrors(failure, callbackErr)
 	}
 	b.setError(err, isFatalError(failure))
-}
-
-func (b *bolt4) onUnknown(msg any) {
-	b.setError(fmt.Errorf("expected success or database error, got %v", msg), true)
 }
 
 const readTimeoutHintName = "connection.recv_timeout_seconds"

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -1015,9 +1015,6 @@ func (b *bolt5) discardResponseHandler(stream *stream) responseHandler {
 			stream.err = failure
 			b.onFailure(ctx, failure) // Will detach the stream
 		},
-		onUnknown: func(msg any) {
-			b.setError(fmt.Errorf("unknown response %v", msg), true)
-		},
 	}
 }
 
@@ -1057,9 +1054,6 @@ func (b *bolt5) pullResponseHandler(stream *stream) responseHandler {
 			stream.err = failure
 			b.onFailure(ctx, failure) // Will detach the stream
 		},
-		onUnknown: func(msg any) {
-			b.setError(fmt.Errorf("unknown response %v", msg), true)
-		},
 	}
 }
 
@@ -1072,9 +1066,6 @@ func (b *bolt5) resetResponseHandler() responseHandler {
 			_ = b.onNeo4jError(ctx, b, failure)
 			b.state = bolt5Dead
 		},
-		onUnknown: func(any) {
-			b.state = bolt5Dead
-		},
 	}
 }
 
@@ -1082,7 +1073,6 @@ func (b *bolt5) expectedSuccessHandler(onSuccess func(*success)) responseHandler
 	return responseHandler{
 		onSuccess: onSuccess,
 		onFailure: b.onFailure,
-		onUnknown: b.onUnknown,
 		onIgnored: onIgnoredNoOp,
 	}
 }
@@ -1118,10 +1108,6 @@ func (b *bolt5) onFailure(ctx context.Context, failure *db.Neo4jError) {
 		err = errorutil.CombineErrors(callbackErr, failure)
 	}
 	b.setError(err, isFatalError(failure))
-}
-
-func (b *bolt5) onUnknown(msg any) {
-	b.setError(fmt.Errorf("expected success or database error, got %v", msg), true)
 }
 
 func (b *bolt5) initializeReadTimeoutHint(hints map[string]any) {

--- a/neo4j/internal/bolt/message_queue.go
+++ b/neo4j/internal/bolt/message_queue.go
@@ -23,6 +23,7 @@ import (
 	"container/list"
 	"context"
 	"errors"
+	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 	"net"
@@ -165,7 +166,7 @@ func (q *messageQueue) receive(ctx context.Context) error {
 	case *ignored:
 		callback.onIgnored(message)
 	default:
-		callback.onUnknown(message)
+		panic(fmt.Errorf("did not expect message %v", res))
 	}
 	return nil
 }

--- a/neo4j/internal/bolt/message_queue_test.go
+++ b/neo4j/internal/bolt/message_queue_test.go
@@ -43,12 +43,12 @@ func TestMessageQueue(outer *testing.T) {
 			msgHello:    {onSuccess: func(*success) {}},
 			msgLogon:    {onFailure: func(context.Context, *db.Neo4jError) {}},
 			msgRoute:    {onIgnored: func(*ignored) {}},
-			msgBegin:    {onUnknown: func(any) {}},
+			msgBegin:    {onSuccess: func(*success) {}},
 			msgRun:      {onRecord: func(*db.Record) {}},
 			msgPullN:    {onSuccess: func(*success) {}},
 			msgCommit:   {onFailure: func(context.Context, *db.Neo4jError) {}},
 			msgRollback: {onIgnored: func(*ignored) {}},
-			msgDiscardN: {onUnknown: func(any) {}},
+			msgDiscardN: {onSuccess: func(*success) {}},
 			msgReset:    {onRecord: func(*db.Record) {}},
 			msgGoodbye:  {onSuccess: func(*success) {}},
 		}
@@ -246,9 +246,6 @@ func assertEqualResponseHandlers(t *testing.T, handler1, handler2 responseHandle
 	}
 	if !functionEqual(handler1.onFailure, handler2.onFailure) {
 		t.Errorf("expected onFailure callbacks to be equal")
-	}
-	if !functionEqual(handler1.onUnknown, handler2.onUnknown) {
-		t.Errorf("expected onUnknown callbacks to be equal")
 	}
 }
 

--- a/neo4j/internal/bolt/response_handler.go
+++ b/neo4j/internal/bolt/response_handler.go
@@ -9,7 +9,6 @@ type responseHandler struct {
 	onSuccess func(*success)
 	onRecord  func(*db.Record)
 	onFailure func(context.Context, *db.Neo4jError)
-	onUnknown func(any)
 	onIgnored func(*ignored)
 }
 


### PR DESCRIPTION
`hydrator#hydrate` supports only a limited number of response message types, which are then returned to the message queue.