### PR TITLE
Update API docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ go get github.com/neo4j/neo4j-go-driver
 ## Documentation
 
 Drivers manual that describes general driver concepts in depth [here](https://neo4j.com/docs/go-manual/current/).
-Go package API documentation [here](https://pkg.go.dev/github.com/neo4j/neo4j-go-driver/v5).
+Go package API documentation [here](https://pkg.go.dev/github.com/neo4j/neo4j-go-driver/v5/neo4j).
 
 ## Preview Features
 


### PR DESCRIPTION
The current link points to the package root, and it's not immediate (at least to me) how to actually access the API docs. The path I had to take is search for a symbol, and then strip part of the URL, and I think that is the correct link we want.