### PR TITLE
Prevent bogus logging on multiple Driver.Close()

### DIFF
--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -397,9 +397,9 @@ func (d *driverWithContext) Close(ctx context.Context) error {
 		if err := d.pool.Close(ctx); err != nil {
 			return err
 		}
+		d.pool = nil
+		d.log.Infof(log.Driver, d.logId, "Closed")
 	}
-	d.pool = nil
-	d.log.Infof(log.Driver, d.logId, "Closed")
 	return nil
 }
 


### PR DESCRIPTION
I was surprised that calling `Driver.close()` twice didn't raise any errors, so I dag a bit.

Currently, this code

```go
package main

import (
    "context"
    "fmt"
    "github.com/neo4j/neo4j-go-driver/v5/neo4j"
)

func main() {
    ctx := context.Background()
    dbUri := "neo4j://localhost"
    dbUser := "neo4j"
    dbPassword := "verysecret"
    useConsoleLogger := func(level neo4j.LogLevel) func(config *neo4j.Config) {
        return func(config *neo4j.Config) {
            config.Log = neo4j.ConsoleLogger(level)
        }
    }
    driver, _ := neo4j.NewDriverWithContext(dbUri, neo4j.BasicAuth(dbUser, dbPassword, ""), useConsoleLogger(neo4j.INFO))
    driver.VerifyConnectivity(ctx)
    driver.Close(ctx)
    driver.Close(ctx)
    driver.Close(ctx)
}
```

results in this output

```
2023-06-13 04:40:19.529   INFO  [pool 1] Created
2023-06-13 04:40:19.529   INFO  [router 1] Created {context: map[address:localhost:7687]}
2023-06-13 04:40:19.529   INFO  [driver 1] Created { target: localhost:7687 }
2023-06-13 04:40:19.529   INFO  [router 1] Reading routing table from initial router: localhost:7687
2023-06-13 04:40:19.529   INFO  [pool 1] Connecting to localhost:7687
2023-06-13 04:40:19.533   INFO  [bolt5 bolt-14@localhost:7687] Connected
2023-06-13 04:40:19.533   INFO  [bolt5 bolt-14@localhost:7687] Retrieving routing table
2023-06-13 04:40:19.535   INFO  [bolt5 bolt-14@localhost:7687] Close
2023-06-13 04:40:19.535   INFO  [pool 1] Closed
2023-06-13 04:40:19.535   INFO  [driver 1] Closed
2023-06-13 04:40:19.535   INFO  [driver 1] Closed
2023-06-13 04:40:19.535   INFO  [driver 1] Closed
```

i.e. you can call `Driver.Close()` as many times as you wish and logging tells you that you have closed it multiple times. In truth, the driver is checking whether the pool is already closed, and in that case not doing anything, except setting to `nil` a var which already is so and outputting to log. 

This PR changes this behavior so that multiple calls to `Driver.Close()` are silently ignored.