### PR TITLE
Add `bolt_agent` to the `extra` dictionary of the `HELLO` message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ modules](https://go.dev/ref/mod) for dependency resolution.
 You can run unit tests as follows:
 
 ```shell
-go test -short ./...
+go test -tags=internal_testkit -short ./...
 ```
 
 ### Integration and Benchmark Testing

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/auth"
 	iauth "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/auth"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/boltagent"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"net"
@@ -243,6 +244,15 @@ func (b *bolt5) Connect(
 	}
 	if routingContext != nil {
 		hello["routing"] = routingContext
+	}
+	// On bolt >= 5.3 add bolt agent information to hello
+	if b.minor >= 3 {
+		info := boltagent.New()
+		hello["bolt_agent"] = map[string]string{
+			"product":  info.Product(),
+			"platform": info.Platform(),
+			"language": info.Language(),
+		}
 	}
 	if b.minor == 0 {
 		// Merge authentication keys into hello, avoid overwriting existing keys

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	iauth "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/auth"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/boltagent"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 	"io"
@@ -178,13 +177,11 @@ func TestBolt5(outer *testing.T) {
 			handshake := srv.waitForHandshake()
 			AssertVersionInHandshake(t, handshake, 5, 3)
 			srv.acceptVersion(5, 3)
-			// 5.3+ hello must contain mandatory bolt_agent dictionary and mandatory product field
+			// 5.3 hello must contain mandatory bolt_agent dictionary and mandatory product field
 			hmap := srv.waitForHelloWithoutAuthToken()
-			boltAgent, exists := hmap["bolt_agent"].(map[string]any)
-			if !exists {
-				panic("Missing bolt_agent in hello")
-			}
-			AssertStringEqual(t, boltAgent["product"].(string), boltagent.Product)
+			boltAgent, exists := hmap["bolt_agent"]
+			AssertTrue(t, exists)
+			AssertStringContain(t, boltAgent.(map[string]any)["product"].(string), "neo4j-go/")
 			srv.acceptHello()
 
 			srv.waitForLogon()

--- a/neo4j/internal/bolt/connect.go
+++ b/neo4j/internal/bolt/connect.go
@@ -39,7 +39,7 @@ type protocolVersion struct {
 
 // Supported versions in priority order
 var versions = [4]protocolVersion{
-	{major: 5, minor: 2, back: 2},
+	{major: 5, minor: 3, back: 3},
 	{major: 4, minor: 4, back: 2},
 	{major: 4, minor: 1},
 	{major: 3, minor: 0},

--- a/neo4j/internal/boltagent/bolt_agent.go
+++ b/neo4j/internal/boltagent/bolt_agent.go
@@ -21,15 +21,14 @@ package boltagent
 
 import (
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/metadata"
 	"runtime"
 )
 
-const Product = "neo4j-go/" + internal.DriverVersion
-
 var os = runtime.GOOS
 var arch = runtime.GOARCH
-var version = runtime.Version()
+var goVersion = runtime.Version()
+var driverVersion = metadata.DriverVersion
 
 type BoltAgent struct {
 	product  string
@@ -40,9 +39,9 @@ type BoltAgent struct {
 // New returns a BoltAgent containing immutable, preformatted driver information.
 func New() *BoltAgent {
 	return &BoltAgent{
-		product:  Product,
+		product:  fmt.Sprintf("neo4j-go/%s", driverVersion),
 		platform: fmt.Sprintf("%s; %s", os, arch),
-		language: fmt.Sprintf("Go/%s", version),
+		language: fmt.Sprintf("Go/%s", goVersion),
 	}
 }
 

--- a/neo4j/internal/boltagent/bolt_agent.go
+++ b/neo4j/internal/boltagent/bolt_agent.go
@@ -17,10 +17,43 @@
  * limitations under the License.
  */
 
-package neo4j
+package boltagent
 
 import (
+	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal"
+	"runtime"
 )
 
-const UserAgent = "Go Driver/" + internal.DriverVersion
+const Product = "neo4j-go/" + internal.DriverVersion
+
+var os = runtime.GOOS
+var arch = runtime.GOARCH
+var version = runtime.Version()
+
+type BoltAgent struct {
+	product  string
+	platform string
+	language string
+}
+
+// New returns a BoltAgent containing immutable, preformatted driver information.
+func New() *BoltAgent {
+	return &BoltAgent{
+		product:  Product,
+		platform: fmt.Sprintf("%s; %s", os, arch),
+		language: fmt.Sprintf("Go/%s", version),
+	}
+}
+
+func (b *BoltAgent) Product() string {
+	return b.product
+}
+
+func (b *BoltAgent) Platform() string {
+	return b.platform
+}
+
+func (b *BoltAgent) Language() string {
+	return b.language
+}

--- a/neo4j/internal/boltagent/bolt_agent_test.go
+++ b/neo4j/internal/boltagent/bolt_agent_test.go
@@ -8,13 +8,14 @@ import (
 func init() {
 	os = "darwin"
 	arch = "amd64"
-	version = "go1.20.3"
+	goVersion = "go1.20.3"
+	driverVersion = "5.9.0"
 }
 
 func TestNew(t *testing.T) {
 	actual := New()
 
-	AssertStringEqual(t, actual.Product(), Product)
+	AssertStringEqual(t, actual.Product(), "neo4j-go/5.9.0")
 	AssertStringEqual(t, actual.Platform(), "darwin; amd64")
 	AssertStringEqual(t, actual.Language(), "Go/go1.20.3")
 }

--- a/neo4j/internal/boltagent/bolt_agent_test.go
+++ b/neo4j/internal/boltagent/bolt_agent_test.go
@@ -1,0 +1,20 @@
+package boltagent
+
+import (
+	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
+	"testing"
+)
+
+func init() {
+	os = "darwin"
+	arch = "amd64"
+	version = "go1.20.3"
+}
+
+func TestNew(t *testing.T) {
+	actual := New()
+
+	AssertStringEqual(t, actual.Product(), Product)
+	AssertStringEqual(t, actual.Platform(), "darwin; amd64")
+	AssertStringEqual(t, actual.Language(), "Go/go1.20.3")
+}

--- a/neo4j/internal/metadata/metadata.go
+++ b/neo4j/internal/metadata/metadata.go
@@ -1,3 +1,3 @@
-package internal
+package metadata
 
 const DriverVersion = "5.9.0"

--- a/neo4j/internal/version.go
+++ b/neo4j/internal/version.go
@@ -1,0 +1,3 @@
+package internal
+
+const DriverVersion = "5.9.0"

--- a/neo4j/useragent.go
+++ b/neo4j/useragent.go
@@ -20,7 +20,7 @@
 package neo4j
 
 import (
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/metadata"
 )
 
-const UserAgent = "Go Driver/" + internal.DriverVersion
+const UserAgent = "Go Driver/" + metadata.DriverVersion

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1072,6 +1072,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"Feature:Bolt:5.0",
 				"Feature:Bolt:5.1",
 				"Feature:Bolt:5.2",
+				"Feature:Bolt:5.3",
 				"Feature:Bolt:Patch:UTC",
 				"Feature:Impersonation",
 				"Feature:TLS:1.2",


### PR DESCRIPTION
Adds a new field `bolt_agent` to the `extra` dictionary of the `HELLO` message that is mandatory in the Bolt protocol version 5.3.

The `bolt_agent` value is non-configurable and follows a common format among the official drivers.

Go driver bolt_agent sample:

`{"product": "neo4j-go/5.9.0", "platform": "darwin; amd64", "language": "Go/go1.20.3"}`

The update also brings support for the Bolt protocol version 5.3.