### PR TITLE
Fix bug:  log infomation args missing

### DIFF
--- a/neo4j/internal/router/router.go
+++ b/neo4j/internal/router/router.go
@@ -94,7 +94,7 @@ func (r *Router) readTable(ctx context.Context, dbRouter *databaseRouter, bookma
 	// Use hook to retrieve possibly different set of routers and retry
 	if table == nil && r.getRouters != nil {
 		routers := r.getRouters()
-		r.log.Infof(log.Router, r.logId, "Reading routing table for '%s' from custom routers: %v", routers)
+		r.log.Infof(log.Router, r.logId, "Reading routing table for '%s' from custom routers: %v", database, routers)
 		table, err = readTable(ctx, r.pool, routers, r.routerContext, bookmarks, database, impersonatedUser, boltLogger)
 	}
 


### PR DESCRIPTION

log missing args.

```
INFO  [router 1] Reading routing table for '[local1:8697 local2:8688 local31:8697]' from custom routers: %!v(MISSING)
```

