### PR TITLE
feat: support connect failed to force refresh routing table

### DIFF
--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -282,6 +282,9 @@ func (s *session) runRetriable(
 	for state.Continue() {
 		if workResult, successfullyCompleted := s.tryRun(&state, mode, &config, work); successfullyCompleted {
 			return workResult, nil
+		} else {
+			// Force refresh table routing
+			s.router.Invalidate(s.databaseName)
 		}
 	}
 

--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -283,7 +283,7 @@ func (s *session) runRetriable(
 		if workResult, successfullyCompleted := s.tryRun(&state, mode, &config, work); successfullyCompleted {
 			return workResult, nil
 		} else {
-			// Force refresh table routing
+			// Force refresh routing table
 			s.router.Invalidate(s.databaseName)
 		}
 	}


### PR DESCRIPTION
when one of the neo4j cluster's instance shutdown, the connection will be failed, becuase the routing table ttl is 300s. In the 300s, the routing table can not refresh, the session is failed until next routing table refresh. if modifiy router ttl's value short on neo4j server, the cache is no valueable .

now, if session connection failed, client will be forced refresh routing table and retry connection neo4j server. 

```go
s.router.Invalidate(s.databaseName)
```

The router make the database invalidate, when it next try to connection neo4j cluster ,the router will be create new routing table.
