### PR TITLE
Fix race conditions in unit tests

### DIFF
--- a/neo4j/internal/bolt/bolt3_test.go
+++ b/neo4j/internal/bolt/bolt3_test.go
@@ -240,11 +240,12 @@ func TestBolt3(outer *testing.T) {
 		}
 		inner.Parallel()
 		for _, test := range testCases {
+			testCopy := test
 			inner.Run(fmt.Sprintf("%s for %s", test.description, test.Method), func(t *testing.T) {
 				bolt, cleanup := connectToServer(t, func(srv *bolt3server) {
 					srv.accept(3)
-					if !test.ExpectError {
-						if test.Method == "run" {
+					if !testCopy.ExpectError {
+						if testCopy.Method == "run" {
 							srv.waitForRun()
 						} else {
 							srv.waitForTxBegin()
@@ -872,10 +873,11 @@ func TestBolt3(outer *testing.T) {
 		}
 
 		for _, callback := range callbacks {
+			callbackCopy := callback
 			inner.Run(callback.scenario, func(t *testing.T) {
 				bolt, cleanup := connectToServer(inner, func(srv *bolt3server) {
 					srv.accept(3)
-					callback.server(t, srv)
+					callbackCopy.server(t, srv)
 				})
 				defer cleanup()
 				defer bolt.Close(ctx)

--- a/neo4j/internal/bolt/bolt4_test.go
+++ b/neo4j/internal/bolt/bolt4_test.go
@@ -459,11 +459,12 @@ func TestBolt4(outer *testing.T) {
 		}
 		inner.Parallel()
 		for _, test := range testCases {
+			testCopy := test
 			inner.Run(fmt.Sprintf("%s for %s", test.description, test.Method), func(t *testing.T) {
 				bolt, cleanup := connectToServer(t, func(srv *bolt4server) {
 					srv.acceptWithMinor(4, 4)
-					if !test.ExpectError {
-						if test.Method == "run" {
+					if !testCopy.ExpectError {
+						if testCopy.Method == "run" {
 							srv.waitForRun(nil)
 						} else {
 							srv.waitForTxBegin()
@@ -1418,10 +1419,11 @@ func TestBolt4(outer *testing.T) {
 		}
 
 		for _, callback := range callbacks {
+			callbackCopy := callback
 			inner.Run(callback.scenario, func(t *testing.T) {
 				bolt, cleanup := connectToServer(inner, func(srv *bolt4server) {
 					srv.accept(4)
-					callback.server(t, srv)
+					callbackCopy.server(t, srv)
 				})
 				defer cleanup()
 				defer bolt.Close(ctx)

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -707,11 +707,12 @@ func TestBolt5(outer *testing.T) {
 		}
 		inner.Parallel()
 		for _, test := range testCases {
+			testCopy := test
 			inner.Run(fmt.Sprintf("%s for %s", test.description, test.Method), func(t *testing.T) {
 				bolt, cleanup := connectToServer(t, func(srv *bolt5server) {
 					srv.acceptWithMinor(5, 1)
-					if !test.ExpectError {
-						if test.Method == "run" {
+					if !testCopy.ExpectError {
+						if testCopy.Method == "run" {
 							srv.waitForRun(nil)
 						} else {
 							srv.waitForTxBegin(nil)
@@ -1633,10 +1634,11 @@ func TestBolt5(outer *testing.T) {
 		}
 
 		for _, callback := range callbacks {
+			callbackCopy := callback
 			inner.Run(callback.scenario, func(t *testing.T) {
 				bolt, cleanup := connectToServer(inner, func(srv *bolt5server) {
 					srv.accept(5)
-					callback.server(t, srv)
+					callbackCopy.server(t, srv)
 				})
 				defer cleanup()
 				defer bolt.Close(ctx)

--- a/testkit/integration.py
+++ b/testkit/integration.py
@@ -12,7 +12,7 @@ def run(args):
 
 if __name__ == "__main__":
     package = os.path.join(".", "neo4j", "test-integration", "...")
-    cmd = ["go", "test", "-buildvcs=false"]
+    cmd = ["go", "test", "-race", "-buildvcs=false"]
     if os.environ.get("TEST_IN_TEAMCITY", False):
         cmd = cmd + ["-v", "-json"]
     run(cmd + [package])

--- a/testkit/unittests.py
+++ b/testkit/unittests.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     for extra_args in (
         (), ("-tags", "internal_time_mock")
     ):
-        cmd = ["go", "test", *extra_args]
+        cmd = ["go", "test", "-race", *extra_args]
         if os.environ.get("TEST_IN_TEAMCITY", False):
             cmd = cmd + ["-v", "-json"]
 


### PR DESCRIPTION
Ideally, we'd also be turning on the `-race` flag for tests. But this makes the tests stuck. Needs investigation.