### PR TITLE
ADR 019 password rotation

### DIFF
--- a/neo4j/auth/auth_examples_test.go
+++ b/neo4j/auth/auth_examples_test.go
@@ -28,21 +28,23 @@ import (
 	"time"
 )
 
-func ExampleBasic() {
+func ExampleBasicTokenManager() {
 	fetchBasicAuthToken := func(ctx context.Context) (neo4j.AuthToken, error) {
+		// some way of getting basic authentication information
 		username, password, realm, err := getBasicAuth()
 		if err != nil {
 			return neo4j.AuthToken{}, err
 		}
+		// create and return a basic authentication token with provided username, password and realm
 		return neo4j.BasicAuth(username, password, realm), nil
 	}
-
-	_, _ = neo4j.NewDriverWithContext(getUrl(), auth.Basic(fetchBasicAuthToken))
+	// create a new driver with a basic token manager which uses provider to handle basic auth password rotation.
+	_, _ = neo4j.NewDriverWithContext(getUrl(), auth.BasicTokenManager(fetchBasicAuthToken))
 }
 
-func ExampleBearer() {
+func ExampleBearerTokenManager() {
 	fetchAuthTokenFromMyProvider := func(ctx context.Context) (neo4j.AuthToken, *time.Time, error) {
-		// some way to getting a token
+		// some way of getting a token
 		token, err := getSsoToken(ctx)
 		if err != nil {
 			return neo4j.AuthToken{}, nil, err
@@ -54,8 +56,8 @@ func ExampleBearer() {
 		// or return nil instead of `&expiresIn` if we don't expect it to expire
 		return token, &expiresIn, nil
 	}
-
-	_, _ = neo4j.NewDriverWithContext(getUrl(), auth.Bearer(fetchAuthTokenFromMyProvider))
+	// create a new driver with a bearer token manager which uses provider to handle possibly expiring auth tokens.
+	_, _ = neo4j.NewDriverWithContext(getUrl(), auth.BearerTokenManager(fetchAuthTokenFromMyProvider))
 }
 
 func getBasicAuth() (username, password, realm string, error error) {

--- a/neo4j/auth/auth_testkit.go
+++ b/neo4j/auth/auth_testkit.go
@@ -1,3 +1,5 @@
+//go:build internal_testkit
+
 /*
  * Copyright (c) "Neo4j"
  * Neo4j Sweden AB [https://neo4j.com]
@@ -17,20 +19,18 @@
  * limitations under the License.
  */
 
-//go:build internal_testkit
-
 package auth
 
 import "time"
 
 func SetTimer(t TokenManager, timer func() time.Time) {
-	if t, ok := t.(*expirationBasedTokenManager); ok {
+	if t, ok := t.(*neo4jAuthTokenManager); ok {
 		t.now = &timer
 	}
 }
 
 func ResetTime(t TokenManager) {
-	if t, ok := t.(*expirationBasedTokenManager); ok {
+	if t, ok := t.(*neo4jAuthTokenManager); ok {
 		now := time.Now
 		t.now = &now
 	}

--- a/neo4j/db/errors.go
+++ b/neo4j/db/errors.go
@@ -88,6 +88,10 @@ func (e *Neo4jError) reclassify() {
 	}
 }
 
+func (e *Neo4jError) HasSecurityCode() bool {
+	return strings.HasPrefix(e.Code, "Neo.ClientError.Security.")
+}
+
 func (e *Neo4jError) IsAuthenticationFailed() bool {
 	return e.Code == "Neo.ClientError.Security.Unauthorized"
 }

--- a/neo4j/internal/auth/auth.go
+++ b/neo4j/internal/auth/auth.go
@@ -19,7 +19,10 @@
 
 package auth
 
-import "context"
+import (
+	"context"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+)
 
 type Token struct {
 	Tokens map[string]any
@@ -29,4 +32,6 @@ func (a Token) GetAuthToken(context.Context) (Token, error) {
 	return a, nil
 }
 
-func (a Token) OnTokenExpired(context.Context, Token) error { return nil }
+func (a Token) HandleSecurityException(context.Context, Token, *db.Neo4jError) (bool, error) {
+	return false, nil
+}

--- a/neo4j/internal/collections/set.go
+++ b/neo4j/internal/collections/set.go
@@ -75,10 +75,6 @@ func (set Set[T]) Copy() Set[T] {
 }
 
 func (set Set[T]) Contains(value T) bool {
-	for _, a := range set.Values() {
-		if a == value {
-			return true
-		}
-	}
-	return false
+	_, ok := set[value]
+	return ok
 }

--- a/neo4j/internal/collections/set.go
+++ b/neo4j/internal/collections/set.go
@@ -73,3 +73,12 @@ func (set Set[T]) Copy() Set[T] {
 	}
 	return result
 }
+
+func (set Set[T]) Contains(value T) bool {
+	for _, a := range set.Values() {
+		if a == value {
+			return true
+		}
+	}
+	return false
+}

--- a/neo4j/internal/collections/set_test.go
+++ b/neo4j/internal/collections/set_test.go
@@ -155,7 +155,18 @@ func TestSet(outer *testing.T) {
 		})
 		expected := "golang"
 		if found := strings.Contains(expected); !found {
-			t.Errorf("Set does not contain %v", expected)
+			t.Errorf("Set should have contained %v", expected)
+		}
+	})
+
+	outer.Run("does not contain", func(t *testing.T) {
+		strings := collections.NewSet([]string{
+			"golang",
+			"neo4j",
+		})
+		expected := "foobar"
+		if found := strings.Contains(expected); found {
+			t.Errorf("Set should not have contain %v", expected)
 		}
 	})
 }

--- a/neo4j/internal/collections/set_test.go
+++ b/neo4j/internal/collections/set_test.go
@@ -147,6 +147,17 @@ func TestSet(outer *testing.T) {
 			t.Error(err)
 		}
 	})
+
+	outer.Run("contains", func(t *testing.T) {
+		strings := collections.NewSet([]string{
+			"golang",
+			"neo4j",
+		})
+		expected := "golang"
+		if found := strings.Contains(expected); !found {
+			t.Errorf("Set does not contain %v", expected)
+		}
+	})
 }
 
 func containsExactlyOnce[T comparable](values collections.Set[T], search T) bool {

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -178,17 +178,14 @@ func (b *backend) writeError(err error) {
 	// track of this error so that we can reuse the real thing within a retryable tx
 	fmt.Printf("Error: %s (%T)\n", err.Error(), err)
 	code := ""
-	retriable := false
+	retriable := neo4j.IsRetryable(err)
 	_, isHydrationError := err.(*db.ProtocolError)
 	tokenErr, isTokenExpiredErr := err.(*neo4j.TokenExpiredError)
 	if isTokenExpiredErr {
 		code = tokenErr.Code
-		cause := tokenErr.Unwrap().(*db.Neo4jError)
-		retriable = cause.IsRetriable()
 	}
 	if neo4j.IsNeo4jError(err) {
 		code = err.(*db.Neo4jError).Code
-		retriable = err.(*db.Neo4jError).IsRetriable()
 	}
 	isDriverError := isHydrationError ||
 		isTokenExpiredErr ||

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1108,6 +1108,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"Feature:API:Result.Peek",
 				//"Feature:API:Result.Single",
 				//"Feature:API:Result.SingleOptional",
+				"Feature:API:RetryableExceptions",
 				"Feature:API:Session:AuthConfig",
 				//"Feature:API:Session:NotificationsConfig",
 				//"Feature:API:SSLConfig",


### PR DESCRIPTION
This PR updates the preview feature "re-auth" significantly. The changes allow for catering to a wider range of use cases including simple password rotation.

`ExpirationBasedTokenManager` was renamed to `BearerTokenManager` for handling potentially expiring auth information:

```go
func ExampleBearerTokenManager() {
	fetchAuthTokenFromMyProvider := func(ctx context.Context) (neo4j.AuthToken, *time.Time, error) {
		// some way of getting a token
		token, err := getSsoToken(ctx)
		if err != nil {
			return neo4j.AuthToken{}, nil, err
		}
		// assume we know our tokens expire every 60 seconds
		expiresIn := time.Now().Add(60 * time.Second)
		// Include a little buffer so that we fetch a new token *before* the old one expires
		expiresIn = expiresIn.Add(-10 * time.Second)
		// or return nil instead of `&expiresIn` if we don't expect it to expire
		return token, &expiresIn, nil
	}
	// create a new driver with a bearer token manager which uses provider to handle possibly expiring auth tokens.
	_, _ = neo4j.NewDriverWithContext(getUrl(), auth.BearerTokenManager(fetchAuthTokenFromMyProvider))
}
```

A `BasicTokenManager` token manager was added to handle password rotation:
```go
func ExampleBasicTokenManager() {
	fetchBasicAuthToken := func(ctx context.Context) (neo4j.AuthToken, error) {
		// some way of getting basic authentication information
		username, password, realm, err := getBasicAuth()
		if err != nil {
			return neo4j.AuthToken{}, err
		}
		// create and return a basic authentication token with provided username, password and realm
		return neo4j.BasicAuth(username, password, realm), nil
	}
	// create a new driver with a basic token manager which uses provider to handle basic auth password rotation.
	_, _ = neo4j.NewDriverWithContext(getUrl(), auth.BasicTokenManager(fetchBasicAuthToken))
}
```