### PR TITLE
Fix #538

### DIFF
--- a/neo4j/internal/router/router.go
+++ b/neo4j/internal/router/router.go
@@ -183,7 +183,7 @@ func (r *Router) getOrUpdateTable(ctx context.Context, bookmarksFn func(context.
 		*unlock = sync.Once{}
 		// notify all waiters
 		for _, waiter := range r.updating[database] {
-			waiter <- struct{}{}
+			close(waiter)
 		}
 		delete(r.updating, database)
 		return table, err


### PR DESCRIPTION
This PR is a fix for issue #538 

Suppose there are 2 goroutines A and B. Assume A is updating the routing table. While this happening, B comes and sees that someone is already updating the routing table, and appends its channel to get notified once A updates the table.

### Happy case
If B's context is not `Done()`,  then A will send an empty `struct{}` to the channel and then B continues with its flow.

### Failing case
If B's context is done before A updates the routing table, then B stops listening to the channel it just pushed to be notified on. Now once A updates the table, it goes to send empty `struct{}` to the channel, but this results in a panic situation because there is no one to listen on that channel anymore.

### Fix
Instead of notifying the goroutines by sending an empty `struct{}`, we should rather just close the channel. Closing the channel is panic safe, and will continue on with the existing flow.