### PR TITLE
Enhance Neo4j integration test configuration For Feature Request #428

### DIFF
--- a/neo4j/test-integration/dbserver/version.go
+++ b/neo4j/test-integration/dbserver/version.go
@@ -46,19 +46,15 @@ var (
 )
 
 func VersionOf(server string) Version {
-	if server == "" {
-		return defaultVersion
-	} else {
-		if versionMatcher == nil {
-			versionMatcher = regexp.MustCompile(versionPattern)
-		}
-		matches := versionMatcher.FindStringSubmatch(server)
-		if matches != nil {
-			major, _ := strconv.Atoi(matches[2])
-			minor := parseMinor(matches[3])
-			patch, _ := strconv.Atoi(matches[4])
-			return Version{major, minor, patch}
-		}
+	if versionMatcher == nil {
+		versionMatcher = regexp.MustCompile(versionPattern)
+	}
+	matches := versionMatcher.FindStringSubmatch(server)
+	if matches != nil {
+		major, _ := strconv.Atoi(matches[2])
+		minor := parseMinor(matches[3])
+		patch, _ := strconv.Atoi(matches[4])
+		return Version{major, minor, patch}
 	}
 
 	return noVersion


### PR DESCRIPTION
- Add `getVersionFromDB` to `DbServer` for dynamic version detection
- Remove default version in `VersionOf` if empty
- Default `GetDbServer` to localhost when `TEST_NEO4J_HOST` unset
- https://github.com/neo4j/neo4j-go-driver/issues/428