### PR TITLE
Refactor: Move Bookmarks into Dedicated Package

### DIFF
--- a/neo4j/bookmarks/bookmarks.go
+++ b/neo4j/bookmarks/bookmarks.go
@@ -17,12 +17,13 @@
  * limitations under the License.
  */
 
-package neo4j
+package bookmarks
 
 import (
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/collections"
 	"sync"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/collections"
 )
 
 // Bookmarks is a holder for server-side bookmarks which are used for causally-chained sessions.
@@ -56,14 +57,14 @@ type BookmarkManagerConfig struct {
 	BookmarkConsumer func(ctx context.Context, bookmarks Bookmarks) error
 }
 
-type bookmarkManager struct {
+type DefaultBookmarkManager struct {
 	bookmarks        collections.Set[string]
 	supplyBookmarks  func(context.Context) (Bookmarks, error)
 	consumeBookmarks func(context.Context, Bookmarks) error
 	mutex            sync.RWMutex
 }
 
-func (b *bookmarkManager) UpdateBookmarks(ctx context.Context, previousBookmarks, newBookmarks Bookmarks) error {
+func (b *DefaultBookmarkManager) UpdateBookmarks(ctx context.Context, previousBookmarks, newBookmarks Bookmarks) error {
 	if len(newBookmarks) == 0 {
 		return nil
 	}
@@ -79,7 +80,7 @@ func (b *bookmarkManager) UpdateBookmarks(ctx context.Context, previousBookmarks
 	return nil
 }
 
-func (b *bookmarkManager) GetBookmarks(ctx context.Context) (Bookmarks, error) {
+func (b *DefaultBookmarkManager) GetBookmarks(ctx context.Context) (Bookmarks, error) {
 	var extraBookmarks Bookmarks
 	if b.supplyBookmarks != nil {
 		bookmarks, err := b.supplyBookmarks(ctx)
@@ -102,7 +103,7 @@ func (b *bookmarkManager) GetBookmarks(ctx context.Context) (Bookmarks, error) {
 }
 
 func NewBookmarkManager(config BookmarkManagerConfig) BookmarkManager {
-	return &bookmarkManager{
+	return &DefaultBookmarkManager{
 		bookmarks:        collections.NewSet(config.InitialBookmarks),
 		supplyBookmarks:  config.BookmarkSupplier,
 		consumeBookmarks: config.BookmarkConsumer,

--- a/neo4j/bookmarks/bookmarks_test.go
+++ b/neo4j/bookmarks/bookmarks_test.go
@@ -1,16 +1,17 @@
-package neo4j_test
+package bookmarks_test
 
 import (
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 	"testing"
 	"testing/quick"
+
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 )
 
 func TestCombineBookmarks(t *testing.T) {
-	f := func(slices []neo4j.Bookmarks) bool {
-		concatenation := neo4j.CombineBookmarks(slices...)
+	f := func(slices []bm.Bookmarks) bool {
+		concatenation := bm.CombineBookmarks(slices...)
 		totalLen := 0
 		for _, s := range slices {
 			totalLen += len(s)
@@ -40,8 +41,8 @@ func TestBookmarkManager(outer *testing.T) {
 	outer.Parallel()
 
 	outer.Run("deduplicates initial bookmarks", func(t *testing.T) {
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
-			InitialBookmarks: neo4j.Bookmarks{"a", "a", "b"},
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
+			InitialBookmarks: bm.Bookmarks{"a", "a", "b"},
 		})
 
 		bookmarks, err := bookmarkManager.GetBookmarks(ctx)
@@ -51,7 +52,7 @@ func TestBookmarkManager(outer *testing.T) {
 	})
 
 	outer.Run("gets no bookmarks by default", func(t *testing.T) {
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{})
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{})
 		getBookmarks := func(db string) bool {
 			bookmarks, err := bookmarkManager.GetBookmarks(ctx)
 			AssertNoError(t, err)
@@ -64,11 +65,11 @@ func TestBookmarkManager(outer *testing.T) {
 	})
 
 	outer.Run("gets bookmarks along with user-supplied bookmarks", func(t *testing.T) {
-		expectedBookmarks := neo4j.Bookmarks{"a", "b", "c"}
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
-			InitialBookmarks: neo4j.Bookmarks{"a", "b"},
-			BookmarkSupplier: func(context.Context) (neo4j.Bookmarks, error) {
-				return neo4j.Bookmarks{"b", "c"}, nil
+		expectedBookmarks := bm.Bookmarks{"a", "b", "c"}
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
+			InitialBookmarks: bm.Bookmarks{"a", "b"},
+			BookmarkSupplier: func(context.Context) (bm.Bookmarks, error) {
+				return bm.Bookmarks{"b", "c"}, nil
 			},
 		})
 
@@ -80,14 +81,14 @@ func TestBookmarkManager(outer *testing.T) {
 	outer.Run("user-supplied bookmarks do not alter internal bookmarks", func(t *testing.T) {
 		calls := 0
 		expectedBookmarks := []string{"a"}
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
-			InitialBookmarks: neo4j.Bookmarks{"a"},
-			BookmarkSupplier: func(ctx2 context.Context) (neo4j.Bookmarks, error) {
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
+			InitialBookmarks: bm.Bookmarks{"a"},
+			BookmarkSupplier: func(ctx2 context.Context) (bm.Bookmarks, error) {
 				defer func() {
 					calls++
 				}()
 				if calls == 0 {
-					return neo4j.Bookmarks{"b"}, nil
+					return bm.Bookmarks{"b"}, nil
 				}
 				return nil, nil
 			},
@@ -102,8 +103,8 @@ func TestBookmarkManager(outer *testing.T) {
 
 	outer.Run("returned bookmarks are copies", func(t *testing.T) {
 		expectedBookmarks := []string{"a"}
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
-			InitialBookmarks: neo4j.Bookmarks{"a"},
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
+			InitialBookmarks: bm.Bookmarks{"a"},
 		})
 		bookmarks, err := bookmarkManager.GetBookmarks(ctx)
 		AssertNoError(t, err)
@@ -116,8 +117,8 @@ func TestBookmarkManager(outer *testing.T) {
 	})
 
 	outer.Run("updates bookmarks", func(t *testing.T) {
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
-			InitialBookmarks: neo4j.Bookmarks{"a", "b", "c"},
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
+			InitialBookmarks: bm.Bookmarks{"a", "b", "c"},
 		})
 
 		err := bookmarkManager.UpdateBookmarks(ctx, []string{"b", "c"}, []string{"d", "a"})
@@ -132,8 +133,8 @@ func TestBookmarkManager(outer *testing.T) {
 	outer.Run("notifies updated bookmarks for new DB", func(t *testing.T) {
 		notifyHookCalled := false
 		expectedBookmarks := []string{"a", "d"}
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
-			BookmarkConsumer: func(_ context.Context, bookmarks neo4j.Bookmarks) error {
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
+			BookmarkConsumer: func(_ context.Context, bookmarks bm.Bookmarks) error {
 				notifyHookCalled = true
 				AssertEqualsInAnyOrder(t, bookmarks, expectedBookmarks)
 				return nil
@@ -153,9 +154,9 @@ func TestBookmarkManager(outer *testing.T) {
 
 	outer.Run("does not notify updated bookmarks when empty", func(t *testing.T) {
 		initialBookmarks := []string{"a", "b"}
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
 			InitialBookmarks: initialBookmarks,
-			BookmarkConsumer: func(_ context.Context, bookmarks neo4j.Bookmarks) error {
+			BookmarkConsumer: func(_ context.Context, bookmarks bm.Bookmarks) error {
 				t.Error("I must not be called")
 				return nil
 			},
@@ -172,9 +173,9 @@ func TestBookmarkManager(outer *testing.T) {
 	outer.Run("notifies updated bookmarks for existing DB without bookmarks", func(t *testing.T) {
 		notifyHookCalled := false
 		expectedBookmarks := []string{"a", "d"}
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
 			InitialBookmarks: nil,
-			BookmarkConsumer: func(_ context.Context, bookmarks neo4j.Bookmarks) error {
+			BookmarkConsumer: func(_ context.Context, bookmarks bm.Bookmarks) error {
 				notifyHookCalled = true
 				AssertEqualsInAnyOrder(t, bookmarks, expectedBookmarks)
 				return nil
@@ -195,9 +196,9 @@ func TestBookmarkManager(outer *testing.T) {
 	outer.Run("notifies updated bookmarks for existing DB with previous bookmarks", func(t *testing.T) {
 		notifyHookCalled := false
 		expectedBookmarks := []string{"a", "d"}
-		bookmarkManager := neo4j.NewBookmarkManager(neo4j.BookmarkManagerConfig{
-			InitialBookmarks: neo4j.Bookmarks{"a", "b", "c"},
-			BookmarkConsumer: func(_ context.Context, bookmarks neo4j.Bookmarks) error {
+		bookmarkManager := bm.NewBookmarkManager(bm.BookmarkManagerConfig{
+			InitialBookmarks: bm.Bookmarks{"a", "b", "c"},
+			BookmarkConsumer: func(_ context.Context, bookmarks bm.Bookmarks) error {
 				notifyHookCalled = true
 				AssertEqualsInAnyOrder(t, bookmarks, expectedBookmarks)
 				return nil

--- a/neo4j/config.go
+++ b/neo4j/config.go
@@ -20,15 +20,20 @@
 package neo4j
 
 import (
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 	"math"
 	"net/url"
 	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 )
 
 // Deprecated: please use config.Config directly. This alias will be removed in 6.0.
 type Config = config.Config
+
+// Deprecated: please use bookmarks.Bookmarks directly. This alias will be removed in 6.0.
+type Bookmarks = bookmarks.Bookmarks
 
 // Deprecated: please use config.ServerAddressResolver directly. This alias will be removed in 6.0.
 type ServerAddressResolver = config.ServerAddressResolver

--- a/neo4j/driver_test.go
+++ b/neo4j/driver_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router"
 	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 )
@@ -216,7 +217,7 @@ func TestDriverSessionCreation(t *testing.T) {
 		name      string
 		testing   string
 		mode      AccessMode
-		bookmarks Bookmarks
+		bookmarks bm.Bookmarks
 	}{
 		{"Write", "bolt://localhost:7687", AccessModeWrite, []string(nil)},
 		{"Read", "bolt://localhost:7687", AccessModeRead, []string(nil)},

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -23,15 +23,17 @@ package neo4j
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/auth"
-	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/racing"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/auth"
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/racing"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/connector"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
@@ -63,7 +65,7 @@ type DriverWithContext interface {
 	// 	// maintain consistency with sessions as well
 	//	session := driver.NewSession(ctx, neo4j.SessionConfig {BookmarkManager: bookmarkManager})
 	//	// [...] run something within the session
-	ExecuteQueryBookmarkManager() BookmarkManager
+	ExecuteQueryBookmarkManager() bm.BookmarkManager
 	// Target returns the url this driver is bootstrapped
 	Target() url.URL
 	// NewSession creates a new session based on the specified session configuration.
@@ -324,7 +326,7 @@ type driverWithContext struct {
 	executeQueryBookmarkManagerInitializer sync.Once
 	// instance of the bookmark manager only used by default by managed sessions of ExecuteQuery
 	// this is *not* used by default by user-created session (see NewSession)
-	executeQueryBookmarkManager BookmarkManager
+	executeQueryBookmarkManager bm.BookmarkManager
 	auth                        auth.TokenManager
 	now                         func() time.Time
 }
@@ -544,10 +546,10 @@ func ExecuteQuery[T any](
 	return result.(T), err
 }
 
-func (d *driverWithContext) ExecuteQueryBookmarkManager() BookmarkManager {
+func (d *driverWithContext) ExecuteQueryBookmarkManager() bm.BookmarkManager {
 	d.executeQueryBookmarkManagerInitializer.Do(func() {
 		if d.executeQueryBookmarkManager == nil { // this allows tests to init the field themselves
-			d.executeQueryBookmarkManager = NewBookmarkManager(BookmarkManagerConfig{})
+			d.executeQueryBookmarkManager = bm.NewBookmarkManager(bm.BookmarkManagerConfig{})
 		}
 	})
 	return d.executeQueryBookmarkManager
@@ -642,7 +644,7 @@ func ExecuteQueryWithDatabase(db string) ExecuteQueryConfigurationOption {
 }
 
 // ExecuteQueryWithBookmarkManager configures DriverWithContext.ExecuteQuery to rely on the specified BookmarkManager
-func ExecuteQueryWithBookmarkManager(bookmarkManager BookmarkManager) ExecuteQueryConfigurationOption {
+func ExecuteQueryWithBookmarkManager(bookmarkManager bm.BookmarkManager) ExecuteQueryConfigurationOption {
 	return func(configuration *ExecuteQueryConfiguration) {
 		configuration.BookmarkManager = bookmarkManager
 	}
@@ -667,7 +669,7 @@ type ExecuteQueryConfiguration struct {
 	Routing          RoutingControl
 	ImpersonatedUser string
 	Database         string
-	BookmarkManager  BookmarkManager
+	BookmarkManager  bm.BookmarkManager
 	BoltLogger       log.BoltLogger
 }
 

--- a/neo4j/driver_with_context_test.go
+++ b/neo4j/driver_with_context_test.go
@@ -23,14 +23,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/racing"
-	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 	"net/url"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 	"unsafe"
+
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/racing"
+	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 )
 
 func TestDriverExecuteQuery(outer *testing.T) {
@@ -450,7 +452,7 @@ func TestDriverExecuteQuery(outer *testing.T) {
 				callExecuteQueryOrBookmarkManagerGetter(driver, i)
 				storeBookmarkManagerAddress(
 					&bookmarkManagerAddresses,
-					driver.delegate.executeQueryBookmarkManager.(*bookmarkManager))
+					driver.delegate.executeQueryBookmarkManager.(*bm.DefaultBookmarkManager))
 				wait.Done()
 			}(i)
 		}
@@ -464,7 +466,7 @@ func TestDriverExecuteQuery(outer *testing.T) {
 		if len(addressCounts) != 1 {
 			t.Errorf("expected exactly 1 bookmark manager pointer to have been created, got %v", addressCounts)
 		}
-		address := uintptr(unsafe.Pointer(driver.delegate.executeQueryBookmarkManager.(*bookmarkManager)))
+		address := uintptr(unsafe.Pointer(driver.delegate.executeQueryBookmarkManager.(*bm.DefaultBookmarkManager)))
 		if count, found := addressCounts[address]; !found || count != int32(goroutineCount) {
 			t.Errorf("expected pointer address %v to be seen %d time(s), got these instead %v", address, count, addressCounts)
 		}
@@ -481,7 +483,7 @@ func callExecuteQueryOrBookmarkManagerGetter(driver DriverWithContext, i int) {
 	}
 }
 
-func storeBookmarkManagerAddress(bookmarkManagerAddresses *sync.Map, bookmarkMgr *bookmarkManager) {
+func storeBookmarkManagerAddress(bookmarkManagerAddresses *sync.Map, bookmarkMgr *bm.DefaultBookmarkManager) {
 	address := uintptr(unsafe.Pointer(bookmarkMgr))
 	defaultCount := int32(1)
 	if count, loaded := bookmarkManagerAddresses.LoadOrStore(address, &defaultCount); loaded {
@@ -519,7 +521,7 @@ type driverDelegate struct {
 	newSession func(context.Context, SessionConfig) SessionWithContext
 }
 
-func (d *driverDelegate) ExecuteQueryBookmarkManager() BookmarkManager {
+func (d *driverDelegate) ExecuteQueryBookmarkManager() bm.BookmarkManager {
 	return d.delegate.ExecuteQueryBookmarkManager()
 }
 
@@ -562,7 +564,7 @@ type fakeSession struct {
 	closeErr                       error
 }
 
-func (s *fakeSession) LastBookmarks() Bookmarks {
+func (s *fakeSession) LastBookmarks() bm.Bookmarks {
 	panic("implement me")
 }
 

--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -21,6 +21,8 @@ package neo4j
 
 import (
 	"context"
+
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
 )
 
 // Session represents a logical connection (which is not tied to a physical connection)
@@ -34,7 +36,7 @@ type Session interface {
 	// LastBookmarks returns the bookmark received following the last successfully completed transaction.
 	// If no bookmark was received or if this transaction was rolled back, the initial set of bookmarks will be
 	// returned.
-	LastBookmarks() Bookmarks
+	LastBookmarks() bm.Bookmarks
 	// LastBookmark returns the bookmark received following the last successfully completed transaction.
 	// If no bookmark was received or if this transaction was rolled back, the bookmark value will not be changed.
 	// Warning: this method can lead to unexpected behaviour if the session has not yet successfully completed a
@@ -60,7 +62,7 @@ type session struct {
 	delegate *sessionWithContext
 }
 
-func (s *session) LastBookmarks() Bookmarks {
+func (s *session) LastBookmarks() bm.Bookmarks {
 	return s.delegate.LastBookmarks()
 }
 
@@ -124,7 +126,7 @@ func (s *erroredSession) LastBookmark() string {
 	return ""
 }
 
-func (s *erroredSession) LastBookmarks() Bookmarks {
+func (s *erroredSession) LastBookmarks() bm.Bookmarks {
 	return []string{}
 }
 

--- a/neo4j/session_bookmarks.go
+++ b/neo4j/session_bookmarks.go
@@ -19,21 +19,25 @@
 
 package neo4j
 
-import "context"
+import (
+	"context"
+
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+)
 
 type sessionBookmarks struct {
-	bookmarkManager BookmarkManager
-	bookmarks       Bookmarks
+	bookmarkManager bm.BookmarkManager
+	bookmarks       bm.Bookmarks
 }
 
-func newSessionBookmarks(bookmarkManager BookmarkManager, bookmarks Bookmarks) *sessionBookmarks {
+func newSessionBookmarks(bookmarkManager bm.BookmarkManager, bookmarks bm.Bookmarks) *sessionBookmarks {
 	return &sessionBookmarks{
 		bookmarkManager: bookmarkManager,
 		bookmarks:       cleanupBookmarks(bookmarks),
 	}
 }
 
-func (sb *sessionBookmarks) currentBookmarks() Bookmarks {
+func (sb *sessionBookmarks) currentBookmarks() bm.Bookmarks {
 	return sb.bookmarks
 }
 
@@ -66,7 +70,7 @@ func (sb *sessionBookmarks) replaceSessionBookmarks(newBookmark string) {
 	sb.bookmarks = []string{newBookmark}
 }
 
-func (sb *sessionBookmarks) getBookmarks(ctx context.Context) (Bookmarks, error) {
+func (sb *sessionBookmarks) getBookmarks(ctx context.Context) (bm.Bookmarks, error) {
 	if sb.bookmarkManager == nil {
 		return nil, nil
 	}
@@ -75,7 +79,7 @@ func (sb *sessionBookmarks) getBookmarks(ctx context.Context) (Bookmarks, error)
 
 // Remove empty string bookmarks to check for "bad" callers
 // To avoid allocating, first check if this is a problem
-func cleanupBookmarks(bookmarks Bookmarks) Bookmarks {
+func cleanupBookmarks(bookmarks bm.Bookmarks) bm.Bookmarks {
 	hasBad := false
 	for _, b := range bookmarks {
 		if len(b) == 0 {
@@ -88,7 +92,7 @@ func cleanupBookmarks(bookmarks Bookmarks) Bookmarks {
 		return bookmarks
 	}
 
-	cleaned := make(Bookmarks, 0, len(bookmarks)-1)
+	cleaned := make(bm.Bookmarks, 0, len(bookmarks)-1)
 	for _, b := range bookmarks {
 		if len(b) > 0 {
 			cleaned = append(cleaned, b)

--- a/neo4j/session_bookmarks_test.go
+++ b/neo4j/session_bookmarks_test.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
 )
 
 func TestSessionBookmarks(outer *testing.T) {
@@ -132,7 +134,7 @@ type fakeBookmarkManager struct {
 	recordedCalls []invocation
 }
 
-func (f *fakeBookmarkManager) UpdateBookmarks(ctx context.Context, previousBookmarks, newBookmarks Bookmarks) error {
+func (f *fakeBookmarkManager) UpdateBookmarks(ctx context.Context, previousBookmarks, newBookmarks bm.Bookmarks) error {
 	f.recordedCalls = append(f.recordedCalls, invocation{
 		function:  "UpdateBookmarks",
 		arguments: []any{ctx, previousBookmarks, newBookmarks},
@@ -140,7 +142,7 @@ func (f *fakeBookmarkManager) UpdateBookmarks(ctx context.Context, previousBookm
 	return nil
 }
 
-func (f *fakeBookmarkManager) GetBookmarks(ctx context.Context) (Bookmarks, error) {
+func (f *fakeBookmarkManager) GetBookmarks(ctx context.Context) (bm.Bookmarks, error) {
 	f.recordedCalls = append(f.recordedCalls, invocation{
 		function:  "GetBookmarks",
 		arguments: []any{ctx},
@@ -148,7 +150,7 @@ func (f *fakeBookmarkManager) GetBookmarks(ctx context.Context) (Bookmarks, erro
 	return nil, nil
 }
 
-func (f *fakeBookmarkManager) GetAllBookmarks(ctx context.Context) (Bookmarks, error) {
+func (f *fakeBookmarkManager) GetAllBookmarks(ctx context.Context) (bm.Bookmarks, error) {
 	f.recordedCalls = append(f.recordedCalls, invocation{
 		function:  "GetAllBookmarks",
 		arguments: []any{ctx},

--- a/neo4j/session_with_context_test.go
+++ b/neo4j/session_with_context_test.go
@@ -23,13 +23,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"io"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
+
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
@@ -69,7 +71,7 @@ func TestSession(outer *testing.T) {
 		return &router, &pool, sess
 	}
 
-	createSessionWithBookmarks := func(bookmarks Bookmarks) (*RouterFake, *PoolFake, *sessionWithContext) {
+	createSessionWithBookmarks := func(bookmarks bm.Bookmarks) (*RouterFake, *PoolFake, *sessionWithContext) {
 		sessConfig := SessionConfig{AccessMode: AccessModeRead, Bookmarks: bookmarks, BoltLogger: boltLogger}
 		return createSessionFromConfig(sessConfig)
 	}
@@ -199,13 +201,13 @@ func TestSession(outer *testing.T) {
 
 	outer.Run("Bookmarking", func(inner *testing.T) {
 		inner.Run("Initial bookmarks are returned from LastBookmarks", func(t *testing.T) {
-			_, _, sess := createSessionWithBookmarks(BookmarksFromRawValues("b1", "b2"))
-			AssertDeepEquals(t, sess.LastBookmarks(), BookmarksFromRawValues("b1", "b2"))
+			_, _, sess := createSessionWithBookmarks(bm.BookmarksFromRawValues("b1", "b2"))
+			AssertDeepEquals(t, sess.LastBookmarks(), bm.BookmarksFromRawValues("b1", "b2"))
 		})
 
 		inner.Run("Initial bookmarks are used and cleaned up before usage", func(t *testing.T) {
-			dirtyBookmarks := BookmarksFromRawValues("", "b1", "", "b2", "")
-			cleanBookmarks := BookmarksFromRawValues("b1", "b2")
+			dirtyBookmarks := bm.BookmarksFromRawValues("", "b1", "", "b2", "")
+			cleanBookmarks := bm.BookmarksFromRawValues("b1", "b2")
 			_, pool, sess := createSessionWithBookmarks(dirtyBookmarks)
 			err := errors.New("make all fail")
 			conn := &ConnFake{Alive: true, RunErr: err, TxBeginErr: err}
@@ -256,13 +258,13 @@ func TestSession(outer *testing.T) {
 			// Should call Buffer on connection to ensure that first Run is buffered and
 			// it's bookmark retrieved
 			sess.Run(context.Background(), "cypher", nil)
-			AssertDeepEquals(t, BookmarksToRawValues(sess.LastBookmarks()), []string{"buffer-1"})
+			AssertDeepEquals(t, bm.BookmarksToRawValues(sess.LastBookmarks()), []string{"buffer-1"})
 			result, _ := sess.Run(context.Background(), "cypher", nil)
-			AssertDeepEquals(t, BookmarksToRawValues(sess.LastBookmarks()), []string{"buffer-2"})
+			AssertDeepEquals(t, bm.BookmarksToRawValues(sess.LastBookmarks()), []string{"buffer-2"})
 			// And finally consuming the last result should give a new bookmark
 			AssertIntEqual(t, consumeCalls, 0)
 			result.Consume(context.Background())
-			AssertDeepEquals(t, BookmarksToRawValues(sess.LastBookmarks()), []string{"consume-1"})
+			AssertDeepEquals(t, bm.BookmarksToRawValues(sess.LastBookmarks()), []string{"consume-1"})
 		})
 
 		inner.Run("Pending and invoke tx function", func(t *testing.T) {
@@ -287,7 +289,7 @@ func TestSession(outer *testing.T) {
 			if !reflect.DeepEqual([]string{"1"}, rtx.Bookmarks) {
 				t.Errorf("Using unclean or no bookmarks: %+v", rtx)
 			}
-			AssertDeepEquals(t, BookmarksToRawValues(sess.LastBookmarks()), []string{"1"})
+			AssertDeepEquals(t, bm.BookmarksToRawValues(sess.LastBookmarks()), []string{"1"})
 			AssertIntEqual(t, bufferCalls, 1)
 		})
 
@@ -311,7 +313,7 @@ func TestSession(outer *testing.T) {
 			if !reflect.DeepEqual([]string{"1"}, rtx.Bookmarks) {
 				t.Errorf("Using unclean or no bookmarks: %+v", rtx)
 			}
-			AssertDeepEquals(t, BookmarksToRawValues(sess.LastBookmarks()), []string{"1"})
+			AssertDeepEquals(t, bm.BookmarksToRawValues(sess.LastBookmarks()), []string{"1"})
 			AssertIntEqual(t, bufferCalls, 1)
 		})
 
@@ -473,7 +475,7 @@ func TestSession(outer *testing.T) {
 			// Begin and commit a transaction on the session
 			tx, _ := sess.BeginTransaction(context.Background())
 			tx.Commit(context.Background())
-			AssertDeepEquals(t, BookmarksToRawValues(sess.LastBookmarks()), []string{bookmark})
+			AssertDeepEquals(t, bm.BookmarksToRawValues(sess.LastBookmarks()), []string{bookmark})
 			// The bookmark should be used in next transaction
 			sess.BeginTransaction(context.Background())
 			AssertLen(t, conn.RecordedTxs, 2)

--- a/neo4j/test-integration/bookmark_test.go
+++ b/neo4j/test-integration/bookmark_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/test-integration/dbserver"
 )
 
@@ -52,7 +53,7 @@ func TestBookmark(outer *testing.T) {
 		})
 		assertNil(outer, err)
 
-		bookmarks := neo4j.BookmarksToRawValues(session.LastBookmarks())
+		bookmarks := bm.BookmarksToRawValues(session.LastBookmarks())
 		assertEquals(outer, len(bookmarks), 1)
 		return bookmarks[0]
 	}
@@ -83,7 +84,7 @@ func TestBookmark(outer *testing.T) {
 			_, err = result.Consume(ctx)
 
 			assertNil(t, err)
-			assertStringsNotEmpty(t, neo4j.BookmarksToRawValues(session.LastBookmarks()))
+			assertStringsNotEmpty(t, bm.BookmarksToRawValues(session.LastBookmarks()))
 		})
 
 		inner.Run("when a node is created in explicit transaction and committed, last bookmark should not be empty", func(t *testing.T) {
@@ -102,7 +103,7 @@ func TestBookmark(outer *testing.T) {
 			err = tx.Commit(ctx)
 			assertNil(t, err)
 
-			assertStringsNotEmpty(t, neo4j.BookmarksToRawValues(session.LastBookmarks()))
+			assertStringsNotEmpty(t, bm.BookmarksToRawValues(session.LastBookmarks()))
 		})
 
 		inner.Run("when a node is created in explicit transaction and rolled back, last bookmark should be empty", func(t *testing.T) {
@@ -121,7 +122,7 @@ func TestBookmark(outer *testing.T) {
 			err = tx.Rollback(ctx)
 			assertNil(t, err)
 
-			assertStringsEmpty(t, neo4j.BookmarksToRawValues(session.LastBookmarks()))
+			assertStringsEmpty(t, bm.BookmarksToRawValues(session.LastBookmarks()))
 		})
 
 		inner.Run("when a node is created in transaction function, last bookmark should not be empty", func(t *testing.T) {
@@ -140,7 +141,7 @@ func TestBookmark(outer *testing.T) {
 
 			assertNil(t, err)
 			assertEquals(t, result, 1)
-			assertStringsNotEmpty(t, neo4j.BookmarksToRawValues(session.LastBookmarks()))
+			assertStringsNotEmpty(t, bm.BookmarksToRawValues(session.LastBookmarks()))
 		})
 
 		inner.Run("when a node is created in transaction function and rolled back, last bookmark should be empty", func(t *testing.T) {
@@ -160,7 +161,7 @@ func TestBookmark(outer *testing.T) {
 
 			assertEquals(t, err, failWith)
 			assertNil(t, result)
-			assertStringsEmpty(t, neo4j.BookmarksToRawValues(session.LastBookmarks()))
+			assertStringsEmpty(t, bm.BookmarksToRawValues(session.LastBookmarks()))
 		})
 
 		inner.Run("when a node is queried in transaction function, last bookmark should not be empty", func(t *testing.T) {
@@ -182,7 +183,7 @@ func TestBookmark(outer *testing.T) {
 
 			assertNil(t, err)
 			assertEquals(t, result, 1)
-			assertStringsNotEmpty(t, neo4j.BookmarksToRawValues(session.LastBookmarks()))
+			assertStringsNotEmpty(t, bm.BookmarksToRawValues(session.LastBookmarks()))
 		})
 
 		inner.Run("when a node is created in transaction function and rolled back, last bookmark should be empty", func(t *testing.T) {
@@ -205,7 +206,7 @@ func TestBookmark(outer *testing.T) {
 
 			assertEquals(t, err, failWith)
 			assertNil(t, result)
-			assertStringsEmpty(t, neo4j.BookmarksToRawValues(session.LastBookmarks()))
+			assertStringsEmpty(t, bm.BookmarksToRawValues(session.LastBookmarks()))
 		})
 	})
 
@@ -215,7 +216,7 @@ func TestBookmark(outer *testing.T) {
 			bookmark := createNodeInTx(driver)
 			session := driver.NewSession(ctx, neo4j.SessionConfig{
 				AccessMode: neo4j.AccessModeWrite,
-				Bookmarks:  neo4j.BookmarksFromRawValues(bookmark),
+				Bookmarks:  bm.BookmarksFromRawValues(bookmark),
 			})
 			return driver, session, bookmark
 		}
@@ -238,7 +239,7 @@ func TestBookmark(outer *testing.T) {
 			assertNil(t, err)
 			defer tx.Close(ctx)
 
-			assertEquals(t, neo4j.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
+			assertEquals(t, bm.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
 		})
 
 		inner.Run("given bookmarks should be accessible after ROLLBACK", func(t *testing.T) {
@@ -255,7 +256,7 @@ func TestBookmark(outer *testing.T) {
 			err = tx.Rollback(ctx)
 			assertNil(t, err)
 
-			assertEquals(t, neo4j.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
+			assertEquals(t, bm.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
 		})
 
 		inner.Run("given bookmarks should be accessible when transaction fails", func(t *testing.T) {
@@ -271,7 +272,7 @@ func TestBookmark(outer *testing.T) {
 
 			err = tx.Close(ctx)
 			assertNil(t, err)
-			assertEquals(t, neo4j.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
+			assertEquals(t, bm.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
 		})
 
 		inner.Run("given bookmarks should be accessible after run", func(t *testing.T) {
@@ -284,7 +285,7 @@ func TestBookmark(outer *testing.T) {
 			_, err = result.Consume(ctx)
 			assertNil(t, err)
 
-			assertEquals(t, neo4j.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
+			assertEquals(t, bm.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
 		})
 
 		inner.Run("given bookmarks should be accessible after failed run", func(t *testing.T) {
@@ -294,7 +295,7 @@ func TestBookmark(outer *testing.T) {
 			_, err := session.Run(ctx, "RETURN", nil)
 			assertNotNil(t, err)
 
-			assertEquals(t, neo4j.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
+			assertEquals(t, bm.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark})
 		})
 
 	})
@@ -315,7 +316,7 @@ func TestBookmark(outer *testing.T) {
 
 		session = driver.NewSession(ctx, neo4j.SessionConfig{
 			AccessMode: neo4j.AccessModeWrite,
-			Bookmarks:  neo4j.BookmarksFromRawValues(bookmark1, bookmark2),
+			Bookmarks:  bm.BookmarksFromRawValues(bookmark1, bookmark2),
 		})
 
 		defer func() {
@@ -333,7 +334,7 @@ func TestBookmark(outer *testing.T) {
 			assertNil(t, err)
 			defer tx.Close(ctx)
 
-			assertEquals(t, neo4j.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark1, bookmark2})
+			assertEquals(t, bm.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark1, bookmark2})
 		})
 
 		inner.Run("new bookmark should be reported back by the server after committing", func(t *testing.T) {
@@ -351,9 +352,9 @@ func TestBookmark(outer *testing.T) {
 			err = tx.Commit(ctx)
 			assertNil(t, err)
 
-			assertNotNil(t, neo4j.BookmarksToRawValues(session.LastBookmarks()))
-			assertNotEquals(t, neo4j.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark1})
-			assertNotEquals(t, neo4j.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark2})
+			assertNotNil(t, bm.BookmarksToRawValues(session.LastBookmarks()))
+			assertNotEquals(t, bm.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark1})
+			assertNotEquals(t, bm.BookmarksToRawValues(session.LastBookmarks()), []string{bookmark2})
 		})
 
 	})
@@ -367,7 +368,7 @@ func TestBookmark(outer *testing.T) {
 
 			session := driver.NewSession(ctx, neo4j.SessionConfig{
 				AccessMode: neo4j.AccessModeWrite,
-				Bookmarks:  neo4j.BookmarksFromRawValues(bookmark + "0"),
+				Bookmarks:  bm.BookmarksFromRawValues(bookmark + "0"),
 			})
 			return driver, session, bookmark
 		}

--- a/neo4j/test-integration/examples_test.go
+++ b/neo4j/test-integration/examples_test.go
@@ -23,9 +23,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
 	"testing"
 	"time"
+
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
@@ -724,7 +726,7 @@ func printFriendsTxFunc(ctx context.Context) neo4j.ManagedTransactionWork {
 	}
 }
 
-func addAndEmploy(ctx context.Context, driver neo4j.DriverWithContext, person string, company string) (neo4j.Bookmarks, error) {
+func addAndEmploy(ctx context.Context, driver neo4j.DriverWithContext, person string, company string) (bm.Bookmarks, error) {
 	session := driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
 	defer session.Close(ctx)
 
@@ -741,7 +743,7 @@ func addAndEmploy(ctx context.Context, driver neo4j.DriverWithContext, person st
 	return session.LastBookmarks(), nil
 }
 
-func makeFriend(ctx context.Context, driver neo4j.DriverWithContext, person1 string, person2 string, bookmarks neo4j.Bookmarks) (neo4j.Bookmarks, error) {
+func makeFriend(ctx context.Context, driver neo4j.DriverWithContext, person1 string, person2 string, bookmarks bm.Bookmarks) (bm.Bookmarks, error) {
 	session := driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite, Bookmarks: bookmarks})
 	defer session.Close(ctx)
 
@@ -753,7 +755,7 @@ func makeFriend(ctx context.Context, driver neo4j.DriverWithContext, person1 str
 }
 
 func addEmployAndMakeFriends(ctx context.Context, driver neo4j.DriverWithContext) error {
-	var bookmarks1, bookmarks2, bookmarks3 neo4j.Bookmarks
+	var bookmarks1, bookmarks2, bookmarks3 bm.Bookmarks
 	var err error
 
 	if bookmarks1, err = addAndEmploy(ctx, driver, "Alice", "Wayne Enterprises"); err != nil {
@@ -764,13 +766,13 @@ func addEmployAndMakeFriends(ctx context.Context, driver neo4j.DriverWithContext
 		return err
 	}
 
-	if bookmarks3, err = makeFriend(ctx, driver, "Bob", "Alice", neo4j.CombineBookmarks(bookmarks1, bookmarks2)); err != nil {
+	if bookmarks3, err = makeFriend(ctx, driver, "Bob", "Alice", bm.CombineBookmarks(bookmarks1, bookmarks2)); err != nil {
 		return err
 	}
 
 	session := driver.NewSession(ctx, neo4j.SessionConfig{
 		AccessMode: neo4j.AccessModeRead,
-		Bookmarks:  neo4j.CombineBookmarks(bookmarks1, bookmarks2, bookmarks3),
+		Bookmarks:  bm.CombineBookmarks(bookmarks1, bookmarks2, bookmarks3),
 	})
 	defer session.Close(ctx)
 

--- a/neo4j/test-integration/summary_test.go
+++ b/neo4j/test-integration/summary_test.go
@@ -2,10 +2,12 @@ package test_integration
 
 import (
 	"context"
+	"testing"
+
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/test-integration/dbserver"
-	"testing"
 )
 
 func TestResultSummary(outer *testing.T) {
@@ -33,7 +35,7 @@ func TestResultSummary(outer *testing.T) {
 		}
 
 		inner.Run("does not include any database information", func(t *testing.T) {
-			session := driver.NewSession(ctx, neo4j.SessionConfig{Bookmarks: neo4j.BookmarksFromRawValues(bookmark)})
+			session := driver.NewSession(ctx, neo4j.SessionConfig{Bookmarks: bm.BookmarksFromRawValues(bookmark)})
 			defer assertCloses(ctx, t, session)
 			result, err := session.Run(ctx, "RETURN 42", noParams)
 			assertNil(t, err)
@@ -59,12 +61,12 @@ func TestResultSummary(outer *testing.T) {
 		assertNil(inner, err)
 		_, err = res.Consume(ctx) // consume result to obtain bookmark
 		assertNil(inner, err)
-		bookmarks := neo4j.BookmarksToRawValues(session.LastBookmarks())
+		bookmarks := bm.BookmarksToRawValues(session.LastBookmarks())
 		assertEquals(inner, len(bookmarks), 1)
 		bookmark = bookmarks[0]
 
 		defer func() {
-			session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "system", Bookmarks: neo4j.BookmarksFromRawValues(bookmark)})
+			session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "system", Bookmarks: bm.BookmarksFromRawValues(bookmark)})
 			defer assertCloses(ctx, inner, session)
 			res, err := session.Run(ctx, server.DropDatabaseQuery(extraDatabase), map[string]any{})
 			assertNil(inner, err)
@@ -74,7 +76,7 @@ func TestResultSummary(outer *testing.T) {
 		}()
 
 		inner.Run("includes the default database information", func(t *testing.T) {
-			session := driver.NewSession(ctx, neo4j.SessionConfig{Bookmarks: neo4j.BookmarksFromRawValues(bookmark)})
+			session := driver.NewSession(ctx, neo4j.SessionConfig{Bookmarks: bm.BookmarksFromRawValues(bookmark)})
 			defer assertCloses(ctx, t, session)
 			result, err := session.Run(ctx, "RETURN 42", noParams)
 			assertNil(t, err)
@@ -85,7 +87,7 @@ func TestResultSummary(outer *testing.T) {
 		})
 
 		inner.Run("includes the database information, based on session configuration", func(t *testing.T) {
-			session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: extraDatabase, Bookmarks: neo4j.BookmarksFromRawValues(bookmark)})
+			session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: extraDatabase, Bookmarks: bm.BookmarksFromRawValues(bookmark)})
 			defer assertCloses(ctx, t, session)
 			result, err := session.Run(ctx, "RETURN 42", noParams)
 			assertNil(t, err)

--- a/neo4j/transaction_helpers_test.go
+++ b/neo4j/transaction_helpers_test.go
@@ -22,9 +22,11 @@ package neo4j_test
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
-	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 	"testing"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 )
 
 func TestExecuteRead(outer *testing.T) {
@@ -81,7 +83,7 @@ type fakeSession struct {
 	neo4j.SessionWithContext
 }
 
-func (f *fakeSession) LastBookmarks() neo4j.Bookmarks {
+func (f *fakeSession) LastBookmarks() bm.Bookmarks {
 	panic("implement me")
 }
 

--- a/test-stress/testcontext.go
+++ b/test-stress/testcontext.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
 )
 
 // TestContext provides state data shared across tests
@@ -50,7 +51,7 @@ func NewTestContext(driver neo4j.DriverWithContext) *TestContext {
 		createdNodeCount:       0,
 	}
 
-	result.bookmarks.Store(neo4j.Bookmarks{})
+	result.bookmarks.Store(bm.Bookmarks{})
 
 	return result
 }
@@ -73,11 +74,11 @@ func (ctx *TestContext) addRead() {
 	atomic.AddInt32(&ctx.readNodeCount, 1)
 }
 
-func (ctx *TestContext) getBookmarks() neo4j.Bookmarks {
-	return ctx.bookmarks.Load().(neo4j.Bookmarks)
+func (ctx *TestContext) getBookmarks() bm.Bookmarks {
+	return ctx.bookmarks.Load().(bm.Bookmarks)
 }
 
-func (ctx *TestContext) setBookmarks(bookmarks neo4j.Bookmarks) {
+func (ctx *TestContext) setBookmarks(bookmarks bm.Bookmarks) {
 	ctx.bookmarks.Store(bookmarks)
 }
 

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -25,8 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 	"io"
 	"math"
 	"net/url"
@@ -34,6 +32,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	bm "github.com/neo4j/neo4j-go-driver/v5/neo4j/bookmarks"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/auth"
@@ -59,9 +61,9 @@ type backend struct {
 	resolvedBearerTokens            map[string]AuthTokenAndExpiration
 	id                              int // ID to use for next object created by frontend
 	wrLock                          sync.Mutex
-	suppliedBookmarks               map[string]neo4j.Bookmarks
+	suppliedBookmarks               map[string]bm.Bookmarks
 	consumedBookmarks               map[string]struct{}
-	bookmarkManagers                map[string]neo4j.BookmarkManager
+	bookmarkManagers                map[string]bm.BookmarkManager
 	timer                           *Timer
 }
 
@@ -133,8 +135,8 @@ func newBackend(rd *bufio.Reader, wr io.Writer) *backend {
 		resolvedBasicTokens:             make(map[string]AuthToken),
 		resolvedBearerTokens:            make(map[string]AuthTokenAndExpiration),
 		id:                              0,
-		bookmarkManagers:                make(map[string]neo4j.BookmarkManager),
-		suppliedBookmarks:               make(map[string]neo4j.Bookmarks),
+		bookmarkManagers:                make(map[string]bm.BookmarkManager),
+		suppliedBookmarks:               make(map[string]bm.Bookmarks),
 		consumedBookmarks:               make(map[string]struct{}),
 	}
 }
@@ -450,7 +452,7 @@ func (b *backend) handleRequest(req map[string]any) {
 	case "BookmarksSupplierCompleted":
 		requestId := data["requestId"].(string)
 		rawBookmarks := data["bookmarks"].([]any)
-		bookmarks := make(neo4j.Bookmarks, len(rawBookmarks))
+		bookmarks := make(bm.Bookmarks, len(rawBookmarks))
 		for i, bookmark := range rawBookmarks {
 			bookmarks[i] = bookmark.(string)
 		}
@@ -640,7 +642,7 @@ func (b *backend) handleRequest(req map[string]any) {
 			for i, x := range rawBookmarks {
 				bookmarks[i] = x.(string)
 			}
-			sessionConfig.Bookmarks = neo4j.BookmarksFromRawValues(bookmarks...)
+			sessionConfig.Bookmarks = bm.BookmarksFromRawValues(bookmarks...)
 		}
 		if data["database"] != nil {
 			sessionConfig.DatabaseName = data["database"].(string)
@@ -693,7 +695,7 @@ func (b *backend) handleRequest(req map[string]any) {
 
 	case "NewBookmarkManager":
 		bookmarkManagerId := b.nextId()
-		b.bookmarkManagers[bookmarkManagerId] = neo4j.NewBookmarkManager(
+		b.bookmarkManagers[bookmarkManagerId] = bm.NewBookmarkManager(
 			b.bookmarkManagerConfig(bookmarkManagerId, data))
 		b.writeResponse("BookmarkManager", map[string]any{
 			"id": bookmarkManagerId,
@@ -750,7 +752,7 @@ func (b *backend) handleRequest(req map[string]any) {
 
 	case "SessionLastBookmarks":
 		sessionState := b.sessionStates[data["sessionId"].(string)]
-		bookmarks := neo4j.BookmarksToRawValues(sessionState.session.LastBookmarks())
+		bookmarks := bm.BookmarksToRawValues(sessionState.session.LastBookmarks())
 		if bookmarks == nil {
 			bookmarks = []string{}
 		}
@@ -1585,13 +1587,13 @@ func patchNumbersInMap(dictionary map[string]any) error {
 }
 
 func (b *backend) bookmarkManagerConfig(bookmarkManagerId string,
-	config map[string]any) neo4j.BookmarkManagerConfig {
+	config map[string]any) bm.BookmarkManagerConfig {
 
-	var initialBookmarks neo4j.Bookmarks
+	var initialBookmarks bm.Bookmarks
 	if config["initialBookmarks"] != nil {
 		initialBookmarks = convertInitialBookmarks(config["initialBookmarks"].([]any))
 	}
-	result := neo4j.BookmarkManagerConfig{InitialBookmarks: initialBookmarks}
+	result := bm.BookmarkManagerConfig{InitialBookmarks: initialBookmarks}
 	supplierRegistered := config["bookmarksSupplierRegistered"]
 	if supplierRegistered != nil && supplierRegistered.(bool) {
 		result.BookmarkSupplier = b.supplyBookmarks(bookmarkManagerId)
@@ -1603,8 +1605,8 @@ func (b *backend) bookmarkManagerConfig(bookmarkManagerId string,
 	return result
 }
 
-func (b *backend) supplyBookmarks(bookmarkManagerId string) func(context.Context) (neo4j.Bookmarks, error) {
-	return func(ctx context.Context) (neo4j.Bookmarks, error) {
+func (b *backend) supplyBookmarks(bookmarkManagerId string) func(context.Context) (bm.Bookmarks, error) {
+	return func(ctx context.Context) (bm.Bookmarks, error) {
 		id := b.nextId()
 		msg := map[string]any{"id": id, "bookmarkManagerId": bookmarkManagerId}
 		b.writeResponse("BookmarksSupplierRequest", msg)
@@ -1613,8 +1615,8 @@ func (b *backend) supplyBookmarks(bookmarkManagerId string) func(context.Context
 	}
 }
 
-func (b *backend) consumeBookmarks(bookmarkManagerId string) func(context.Context, neo4j.Bookmarks) error {
-	return func(_ context.Context, bookmarks neo4j.Bookmarks) error {
+func (b *backend) consumeBookmarks(bookmarkManagerId string) func(context.Context, bm.Bookmarks) error {
+	return func(_ context.Context, bookmarks bm.Bookmarks) error {
 		id := b.nextId()
 		b.writeResponse("BookmarksConsumerRequest", map[string]any{
 			"id":                id,
@@ -1631,8 +1633,8 @@ func (b *backend) consumeBookmarks(bookmarkManagerId string) func(context.Contex
 	}
 }
 
-func convertInitialBookmarks(bookmarks []any) neo4j.Bookmarks {
-	result := make(neo4j.Bookmarks, len(bookmarks))
+func convertInitialBookmarks(bookmarks []any) bm.Bookmarks {
+	result := make(bm.Bookmarks, len(bookmarks))
 	for i, bookmark := range bookmarks {
 		result[i] = bookmark.(string)
 	}


### PR DESCRIPTION
- Relocated all bookmarks-related code to a new 'bookmarks' package.
- Updated references from 'neo4j.Bookmarks' to 'bm.Bookmarks' for clarity and to avoid conflicts.
- Adopted 'bm' as a package alias to resolve naming conflicts in functions, like in 'cleanupBookmarks(bookmarks bookmarks.Bookmarks)', to prevent ambiguity.
- Added Bookmarks aliases in the neo4j package to maintain backward compatibility.
- Renamed 'bookmarkManager' to 'DefaultBookmarkManager' for clearer representation and to avoid naming conflicts.

https://github.com/neo4j/neo4j-go-driver/discussions/433