### PR TITLE
Add `ConnectionLivenessCheckTimeout` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ modules](https://go.dev/ref/mod) for dependency resolution.
 You can run unit tests as follows:
 
 ```shell
-go test -tags=internal_testkit -short ./...
+go test -tags internal_testkit,internal_time_mock -short ./...
 ```
 
 ### Integration and Benchmark Testing

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -13,11 +13,11 @@ fi
 echo "# pre-commit hook"
 printf '%-15s' "## staticcheck "
 cd "$(mktemp -d)" && go install honnef.co/go/tools/cmd/staticcheck@"${staticcheck_version}" && cd - > /dev/null
-"${GOBIN:-$(go env GOPATH)/bin}"/staticcheck -tags internal_testkit ./...
+"${GOBIN:-$(go env GOPATH)/bin}"/staticcheck -tags internal_testkit,internal_time_mock ./...
 echo "✅"
 
 printf '%-15s' "## go vet "
-go vet -tags internal_testkit ./...
+go vet -tags internal_testkit,internal_time_mock ./...
 echo "✅"
 
 printf '%-15s' "## go test "

--- a/neo4j/config.go
+++ b/neo4j/config.go
@@ -19,6 +19,7 @@ package neo4j
 
 import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 	"math"
 	"net/url"
@@ -41,6 +42,7 @@ func defaultConfig() *Config {
 		MaxConnectionPoolSize:           100,
 		MaxConnectionLifetime:           1 * time.Hour,
 		ConnectionAcquisitionTimeout:    1 * time.Minute,
+		ConnectionLivenessCheckTimeout:  pool.DefaultConnectionLivenessCheckTimeout,
 		SocketConnectTimeout:            5 * time.Second,
 		SocketKeepalive:                 true,
 		RootCAs:                         nil,
@@ -75,6 +77,11 @@ func validateAndNormaliseConfig(config *Config) error {
 	// Connection Acquisition Timeout
 	if config.ConnectionAcquisitionTimeout < 0 {
 		config.ConnectionAcquisitionTimeout = -1
+	}
+
+	// Connection Liveness Check Timeout
+	if config.ConnectionLivenessCheckTimeout < 0 {
+		return &UsageError{Message: "Connection liveness check timeout cannot be smaller than 0"}
 	}
 
 	// Socket Connect Timeout

--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -103,6 +103,21 @@ type Config struct {
 	//
 	// default: 1 * time.Minute
 	ConnectionAcquisitionTimeout time.Duration
+	// ConnectionLivenessCheckTimeout sets the timeout duration for idle connections in the pool.
+	// Connections idle longer than this timeout will be tested for liveliness before reuse. A low timeout value
+	// can increase network requests when acquiring a connection, impacting performance. Conversely, a high
+	// timeout may result in using connections that are no longer active, causing exceptions in your application.
+	// These exceptions typically resolve with a retry or using a driver API with automatic
+	// retries, assuming the database is operational.
+	//
+	// The parameter balances the likelihood of encountering connection issues against performance.
+	// Typically, adjustment of this parameter is not necessary.
+	//
+	// By default, no liveliness check is performed. A value of 0 ensures connections are always tested for
+	// validity, and negative values are not permitted.
+	//
+	// default: pool.DefaultConnectionLivenessCheckTimeout
+	ConnectionLivenessCheckTimeout time.Duration
 	// Connect timeout that will be set on underlying sockets. Values less than
 	// or equal to 0 results in no timeout being applied.
 	//

--- a/neo4j/config_test.go
+++ b/neo4j/config_test.go
@@ -99,6 +99,16 @@ func TestValidateAndNormaliseConfig(rt *testing.T) {
 		}
 	})
 
+	rt.Run("ConnectionLivenessCheckTimeout less than zero", func(t *testing.T) {
+		config := defaultConfig()
+
+		config.ConnectionLivenessCheckTimeout = -1 * time.Second
+		err := validateAndNormaliseConfig(config)
+		if err == nil {
+			t.Errorf("ConnectionLivenessCheckTimeout is less than 0 but never returned an error")
+		}
+	})
+
 	rt.Run("SocketConnectTimeout less than zero", func(t *testing.T) {
 		config := defaultConfig()
 

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -241,7 +241,16 @@ func NewDriverWithContext(target string, auth auth.TokenManager, configurers ...
 			}
 		}
 		// Let the router use the same log ID as the driver to simplify log reading.
-		d.router = router.New(address, routersResolver, routingContext, d.pool, d.log, d.logId, &d.now)
+		d.router = router.New(
+			address,
+			routersResolver,
+			routingContext,
+			d.pool,
+			d.config.ConnectionLivenessCheckTimeout,
+			d.log,
+			d.logId,
+			&d.now,
+		)
 	}
 
 	d.pool.SetRouter(d.router)

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -1,3 +1,5 @@
+// Package neo4j provides required functionality to connect and execute statements against a Neo4j Database.
+
 /*
  * Copyright (c) "Neo4j"
  * Neo4j Sweden AB [https://neo4j.com]
@@ -15,25 +17,22 @@
  * limitations under the License.
  */
 
-// Package neo4j provides required functionality to connect and execute statements against a Neo4j Database.
 package neo4j
 
 import (
 	"context"
 	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/auth"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/connector"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/racing"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 	"net/url"
 	"strings"
 	"sync"
-	"time"
-
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/connector"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router"
 )
 
 // AccessMode defines modes that routing driver decides to which cluster member
@@ -145,7 +144,7 @@ func NewDriverWithContext(target string, auth auth.TokenManager, configurers ...
 		return nil, err
 	}
 
-	d := driverWithContext{target: parsed, mut: racing.NewMutex(), now: time.Now, auth: auth}
+	d := driverWithContext{target: parsed, mut: racing.NewMutex(), auth: auth}
 
 	routing := true
 	d.connector.Network = "tcp"
@@ -220,10 +219,9 @@ func NewDriverWithContext(target string, auth auth.TokenManager, configurers ...
 	d.connector.Log = d.log
 	d.connector.RoutingContext = routingContext
 	d.connector.Config = d.config
-	d.connector.Now = &d.now
 
 	// Let the pool use the same log ID as the driver to simplify log reading.
-	d.pool = pool.New(d.config, d.connector.Connect, d.log, d.logId, &d.now)
+	d.pool = pool.New(d.config, d.connector.Connect, d.log, d.logId)
 
 	if !routing {
 		d.router = &directRouter{address: address}
@@ -249,7 +247,6 @@ func NewDriverWithContext(target string, auth auth.TokenManager, configurers ...
 			d.config.ConnectionLivenessCheckTimeout,
 			d.log,
 			d.logId,
-			&d.now,
 		)
 	}
 
@@ -333,7 +330,6 @@ type driverWithContext struct {
 	// this is *not* used by default by user-created session (see NewSession)
 	executeQueryBookmarkManager BookmarkManager
 	auth                        auth.TokenManager
-	now                         func() time.Time
 }
 
 func (d *driverWithContext) Target() url.URL {
@@ -369,7 +365,7 @@ func (d *driverWithContext) NewSession(ctx context.Context, config SessionConfig
 		return &erroredSessionWithContext{
 			err: &UsageError{Message: "Trying to create session on closed driver"}}
 	}
-	return newSessionWithContext(d.config, config, d.router, d.pool, d.log, reAuthToken, &d.now)
+	return newSessionWithContext(d.config, config, d.router, d.pool, d.log, reAuthToken)
 }
 
 func (d *driverWithContext) VerifyConnectivity(ctx context.Context) error {

--- a/neo4j/driver_with_context_testkit.go
+++ b/neo4j/driver_with_context_testkit.go
@@ -1,4 +1,4 @@
-//go:build internal_testkit
+//go:build internal_testkit && internal_time_mock
 
 /*
  * Copyright (c) "Neo4j"
@@ -25,21 +25,11 @@ import (
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router"
+	itime "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/time"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
-	"time"
 )
 
 type RoutingTable = idb.RoutingTable
-
-func SetTimer(d DriverWithContext, timer func() time.Time) {
-	driver := d.(*driverWithContext)
-	driver.now = timer
-}
-
-func ResetTime(d DriverWithContext) {
-	driver := d.(*driverWithContext)
-	driver.now = time.Now
-}
 
 func ForceRoutingTableUpdate(d DriverWithContext, database string, bookmarks []string, logger log.BoltLogger) error {
 	driver := d.(*driverWithContext)
@@ -70,3 +60,8 @@ func GetRoutingTable(d DriverWithContext, database string) (*RoutingTable, error
 	table := router.GetTable(database)
 	return table, nil
 }
+
+var Now = itime.Now
+var FreezeTime = itime.FreezeTime
+var TickTime = itime.TickTime
+var UnfreezeTime = itime.UnfreezeTime

--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -26,6 +26,7 @@ import (
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/telemetry"
+	itime "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/time"
 	"net"
 	"reflect"
 	"time"
@@ -95,18 +96,16 @@ type bolt3 struct {
 	authManager   auth.TokenManager
 	resetAuth     bool
 	errorListener ConnectionErrorListener
-	now           *func() time.Time
 }
 
 func NewBolt3(
 	serverName string,
 	conn net.Conn,
 	errorListener ConnectionErrorListener,
-	timer *func() time.Time,
 	logger log.Logger,
 	boltLog log.BoltLogger,
 ) *bolt3 {
-	now := (*timer)()
+	now := itime.Now()
 	b := &bolt3{
 		state:      bolt3_unauthorized,
 		conn:       conn,
@@ -123,7 +122,6 @@ func NewBolt3(
 		idleDate:      now,
 		log:           logger,
 		errorListener: errorListener,
-		now:           timer,
 	}
 	b.out = &outgoing{
 		chunker: newChunker(),
@@ -166,7 +164,7 @@ func (b *bolt3) receiveMsg(ctx context.Context) any {
 		b.state = bolt3_dead
 		return nil
 	}
-	b.idleDate = (*b.now)()
+	b.idleDate = itime.Now()
 	return msg
 }
 

--- a/neo4j/internal/bolt/bolt3_test.go
+++ b/neo4j/internal/bolt/bolt3_test.go
@@ -104,7 +104,6 @@ func TestBolt3(outer *testing.T) {
 		tcpConn, srv, cleanup := setupBolt3Pipe(t)
 		go serverJob(srv)
 
-		timer := time.Now
 		c, err := Connect(
 			context.Background(),
 			"serverName",
@@ -116,7 +115,6 @@ func TestBolt3(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -158,7 +156,6 @@ func TestBolt3(outer *testing.T) {
 			srv.waitForHello()
 			srv.rejectHelloUnauthorized()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -170,7 +167,6 @@ func TestBolt3(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNil(t, bolt)
 		AssertError(t, err)

--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -21,18 +21,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/auth"
-	iauth "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/auth"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/collections"
-	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/telemetry"
 	"net"
 	"reflect"
 	"time"
 
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/auth"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+	iauth "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/auth"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/collections"
+	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/packstream"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/telemetry"
+	itime "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/time"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
 
@@ -111,18 +112,16 @@ type bolt4 struct {
 	authManager   auth.TokenManager
 	resetAuth     bool
 	errorListener ConnectionErrorListener
-	now           *func() time.Time
 }
 
 func NewBolt4(
 	serverName string,
 	conn net.Conn,
 	errorListener ConnectionErrorListener,
-	timer *func() time.Time,
 	logger log.Logger,
 	boltLog log.BoltLogger,
 ) *bolt4 {
-	now := (*timer)()
+	now := itime.Now()
 	b := &bolt4{
 		state:         bolt4_unauthorized,
 		conn:          conn,
@@ -133,7 +132,6 @@ func NewBolt4(
 		streams:       openstreams{},
 		lastQid:       -1,
 		errorListener: errorListener,
-		now:           timer,
 	}
 	b.queue = newMessageQueue(
 		conn,
@@ -1135,7 +1133,7 @@ func (b *bolt4) expectedSuccessHandler(onSuccess func(*success)) responseHandler
 }
 
 func (b *bolt4) onNextMessage() {
-	b.idleDate = (*b.now)()
+	b.idleDate = itime.Now()
 }
 
 func (b *bolt4) onFailure(ctx context.Context, failure *db.Neo4jError) {

--- a/neo4j/internal/bolt/bolt4_test.go
+++ b/neo4j/internal/bolt/bolt4_test.go
@@ -108,7 +108,6 @@ func TestBolt4(outer *testing.T) {
 		tcpConn, srv, cleanup := setupBolt4Pipe(t)
 		go serverJob(srv)
 
-		timer := time.Now
 		c, err := Connect(context.Background(),
 			"serverName",
 			tcpConn,
@@ -119,7 +118,6 @@ func TestBolt4(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -221,7 +219,6 @@ func TestBolt4(outer *testing.T) {
 			}
 			srv.acceptHello()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -233,7 +230,6 @@ func TestBolt4(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNoError(t, err)
 		bolt.Close(context.Background())
@@ -252,7 +248,6 @@ func TestBolt4(outer *testing.T) {
 			}
 			srv.acceptHello()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -264,7 +259,6 @@ func TestBolt4(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNoError(t, err)
 		bolt.Close(context.Background())
@@ -284,7 +278,6 @@ func TestBolt4(outer *testing.T) {
 			}
 			srv.acceptHello()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -296,7 +289,6 @@ func TestBolt4(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNoError(t, err)
 		bolt.Close(context.Background())
@@ -312,7 +304,6 @@ func TestBolt4(outer *testing.T) {
 			srv.waitForHello()
 			srv.rejectHelloUnauthorized()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -324,7 +315,6 @@ func TestBolt4(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNil(t, bolt)
 		AssertError(t, err)

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -108,7 +108,6 @@ func TestBolt5(outer *testing.T) {
 		tcpConn, srv, cleanup := setupBolt5Pipe(t)
 		go serverJob(srv)
 
-		timer := time.Now
 		c, err := Connect(
 			context.Background(),
 			"serverName",
@@ -120,7 +119,6 @@ func TestBolt5(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -278,7 +276,6 @@ func TestBolt5(outer *testing.T) {
 			}
 			srv.acceptHello()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -290,7 +287,6 @@ func TestBolt5(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNoError(t, err)
 		bolt.Close(context.Background())
@@ -312,7 +308,6 @@ func TestBolt5(outer *testing.T) {
 			srv.waitForLogon()
 			srv.acceptLogon()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -324,7 +319,6 @@ func TestBolt5(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNoError(t, err)
 		bolt.Close(context.Background())
@@ -343,7 +337,6 @@ func TestBolt5(outer *testing.T) {
 			}
 			srv.acceptHello()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -355,7 +348,6 @@ func TestBolt5(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNoError(t, err)
 		bolt.Close(context.Background())
@@ -376,7 +368,6 @@ func TestBolt5(outer *testing.T) {
 			srv.waitForLogon()
 			srv.acceptLogon()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -388,7 +379,6 @@ func TestBolt5(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNoError(t, err)
 		bolt.Close(context.Background())
@@ -404,7 +394,6 @@ func TestBolt5(outer *testing.T) {
 			srv.waitForHello()
 			srv.rejectHelloUnauthorized()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -416,7 +405,6 @@ func TestBolt5(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNil(t, bolt)
 		AssertError(t, err)
@@ -441,7 +429,6 @@ func TestBolt5(outer *testing.T) {
 			srv.waitForLogon()
 			srv.rejectLogonWithoutAuthToken()
 		}()
-		timer := time.Now
 		bolt, err := Connect(
 			context.Background(),
 			"serverName",
@@ -453,7 +440,6 @@ func TestBolt5(outer *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertNil(t, bolt)
 		AssertError(t, err)

--- a/neo4j/internal/bolt/connect.go
+++ b/neo4j/internal/bolt/connect.go
@@ -21,12 +21,11 @@ package bolt
 import (
 	"context"
 	"fmt"
+	"net"
+
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/racing"
-	"net"
-	"time"
-
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
 
@@ -56,7 +55,7 @@ func Connect(ctx context.Context,
 	logger log.Logger,
 	boltLogger log.BoltLogger,
 	notificationConfig db.NotificationConfig,
-	timer *func() time.Time) (db.Connection, error) {
+) (db.Connection, error) {
 	// Perform Bolt handshake to negotiate version
 	// Send handshake to server
 	handshake := []byte{
@@ -93,11 +92,11 @@ func Connect(ctx context.Context,
 	var boltConn db.Connection
 	switch major {
 	case 3:
-		boltConn = NewBolt3(serverName, conn, errorListener, timer, logger, boltLogger)
+		boltConn = NewBolt3(serverName, conn, errorListener, logger, boltLogger)
 	case 4:
-		boltConn = NewBolt4(serverName, conn, errorListener, timer, logger, boltLogger)
+		boltConn = NewBolt4(serverName, conn, errorListener, logger, boltLogger)
 	case 5:
-		boltConn = NewBolt5(serverName, conn, errorListener, timer, logger, boltLogger)
+		boltConn = NewBolt5(serverName, conn, errorListener, logger, boltLogger)
 	case 0:
 		return nil, fmt.Errorf("server did not accept any of the requested Bolt versions (%#v)", versions)
 	default:

--- a/neo4j/internal/bolt/connect_test.go
+++ b/neo4j/internal/bolt/connect_test.go
@@ -19,11 +19,10 @@ package bolt
 
 import (
 	"context"
+	"testing"
+
 	iauth "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/auth"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
-	"testing"
-	"time"
-
 	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
@@ -54,7 +53,6 @@ func TestConnect(ot *testing.T) {
 			srv.closeConnection()
 		}()
 
-		timer := time.Now
 		_, err := Connect(
 			context.Background(),
 			"servername",
@@ -66,7 +64,6 @@ func TestConnect(ot *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertError(t, err)
 	})
@@ -82,7 +79,6 @@ func TestConnect(ot *testing.T) {
 			srv.acceptVersion(1, 0)
 		}()
 
-		timer := time.Now
 		boltconn, err := Connect(
 			context.Background(),
 			"servername",
@@ -94,7 +90,6 @@ func TestConnect(ot *testing.T) {
 			logger,
 			nil,
 			idb.NotificationConfig{},
-			&timer,
 		)
 		AssertError(t, err)
 		if boltconn != nil {

--- a/neo4j/internal/connector/connector.go
+++ b/neo4j/internal/connector/connector.go
@@ -22,14 +22,14 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"io"
 	"net"
 	"time"
 
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/bolt"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
 
@@ -41,7 +41,6 @@ type Connector struct {
 	Network          string
 	Config           *config.Config
 	SupplyConnection func(context.Context, string) (net.Conn, error)
-	Now              *func() time.Time
 }
 
 func (c Connector) Connect(
@@ -87,7 +86,6 @@ func (c Connector) Connect(
 			c.Log,
 			boltLogger,
 			notificationConfig,
-			c.Now,
 		)
 		if err != nil {
 			return nil, err
@@ -122,7 +120,6 @@ func (c Connector) Connect(
 		c.Log,
 		boltLogger,
 		notificationConfig,
-		c.Now,
 	)
 	if err != nil {
 		return nil, err

--- a/neo4j/internal/connector/connector_test.go
+++ b/neo4j/internal/connector/connector_test.go
@@ -19,15 +19,16 @@ package connector_test
 
 import (
 	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/connector"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
-	"io"
-	"net"
-	"testing"
-	"time"
 )
 
 type noopErrorListener struct{}
@@ -51,12 +52,10 @@ func TestConnect(outer *testing.T) {
 			server.acceptVersion(1, 0)
 		}()
 		connectionDelegate := &ConnDelegate{Delegate: clientConnection}
-		timer := time.Now
 		connector := &connector.Connector{
 			SupplyConnection: supplyThis(connectionDelegate),
 			SkipEncryption:   true,
 			Config:           &config.Config{},
-			Now:              &timer,
 		}
 
 		connection, err := connector.Connect(ctx, "irrelevant", nil, noopErrorListener{}, nil)
@@ -72,12 +71,10 @@ func TestConnect(outer *testing.T) {
 			server.failAcceptingVersion()
 		}()
 		connectionDelegate := &ConnDelegate{Delegate: clientConnection}
-		timer := time.Now
 		connector := &connector.Connector{
 			SupplyConnection: supplyThis(connectionDelegate),
 			SkipEncryption:   true,
 			Config:           &config.Config{},
-			Now:              &timer,
 		}
 
 		connection, err := connector.Connect(ctx, "irrelevant", nil, noopErrorListener{}, nil)

--- a/neo4j/internal/pool/server.go
+++ b/neo4j/internal/pool/server.go
@@ -20,10 +20,12 @@ package pool
 import (
 	"container/list"
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 	"sync/atomic"
 	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
+	itime "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/time"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
 
 // Represents a server with a number of connections that either is in use (borrowed) or
@@ -71,7 +73,7 @@ func (s *server) healthCheck(
 	boltLogger log.BoltLogger) (healthy bool, _ error) {
 
 	connection.SetBoltLogger(boltLogger)
-	if time.Since(connection.IdleDate()) > idlenessTimeout {
+	if itime.Since(connection.IdleDate()) > idlenessTimeout {
 		connection.ForceReset(ctx)
 		if !connection.IsAlive() {
 			return false, nil

--- a/neo4j/internal/pool/server.go
+++ b/neo4j/internal/pool/server.go
@@ -66,12 +66,12 @@ func (s *server) getIdle() db.Connection {
 func (s *server) healthCheck(
 	ctx context.Context,
 	connection db.Connection,
-	idlenessThreshold time.Duration,
+	idlenessTimeout time.Duration,
 	auth *db.ReAuthToken,
 	boltLogger log.BoltLogger) (healthy bool, _ error) {
 
 	connection.SetBoltLogger(boltLogger)
-	if time.Since(connection.IdleDate()) > idlenessThreshold {
+	if time.Since(connection.IdleDate()) > idlenessTimeout {
 		connection.ForceReset(ctx)
 		if !connection.IsAlive() {
 			return false, nil

--- a/neo4j/internal/pool/server_test.go
+++ b/neo4j/internal/pool/server_test.go
@@ -158,7 +158,7 @@ func TestServerPenalty(t *testing.T) {
 	// Get the connection from srv1 and return it, now srv1 should have higher penalty.
 	ctx := context.Background()
 	idle := srv1.getIdle()
-	_, _ = srv1.healthCheck(ctx, idle, DefaultLivenessCheckThreshold, nil, nil)
+	_, _ = srv1.healthCheck(ctx, idle, DefaultConnectionLivenessCheckTimeout, nil, nil)
 	testutil.AssertDeepEquals(t, idle, c11)
 	srv1.returnBusy(context.Background(), c11)
 	assertPenaltiesGreaterThan(srv1, srv2, now)
@@ -173,18 +173,18 @@ func TestServerPenalty(t *testing.T) {
 	assertPenaltiesGreaterThan(srv2, srv1, now)
 	// Get both idle connections from srv1
 	idle = srv1.getIdle()
-	_, _ = srv1.healthCheck(ctx, idle, DefaultLivenessCheckThreshold, nil, nil)
+	_, _ = srv1.healthCheck(ctx, idle, DefaultConnectionLivenessCheckTimeout, nil, nil)
 	idle = srv1.getIdle()
-	_, _ = srv1.healthCheck(ctx, idle, DefaultLivenessCheckThreshold, nil, nil)
+	_, _ = srv1.healthCheck(ctx, idle, DefaultConnectionLivenessCheckTimeout, nil, nil)
 	// Get one idle connection from srv2
 	idle = srv2.getIdle()
-	_, _ = srv2.healthCheck(ctx, idle, DefaultLivenessCheckThreshold, nil, nil)
+	_, _ = srv2.healthCheck(ctx, idle, DefaultConnectionLivenessCheckTimeout, nil, nil)
 	// Since more connections are in use on srv1, it should have higher penalty even though
 	// srv2 was last used
 	assertPenaltiesGreaterThan(srv1, srv2, now)
 	// Return the connections
 	idle = srv2.getIdle()
-	_, _ = srv2.healthCheck(ctx, idle, DefaultLivenessCheckThreshold, nil, nil)
+	_, _ = srv2.healthCheck(ctx, idle, DefaultConnectionLivenessCheckTimeout, nil, nil)
 	srv2.returnBusy(context.Background(), c21)
 	srv2.returnBusy(context.Background(), c22)
 	srv1.returnBusy(context.Background(), c11)
@@ -200,9 +200,9 @@ func TestServerPenalty(t *testing.T) {
 	testutil.AssertFalse(t, srv2.hasFailedConnect(now))
 	// Use srv2 to the max
 	idle = srv2.getIdle()
-	_, _ = srv2.healthCheck(ctx, idle, DefaultLivenessCheckThreshold, nil, nil)
+	_, _ = srv2.healthCheck(ctx, idle, DefaultConnectionLivenessCheckTimeout, nil, nil)
 	idle = srv2.getIdle()
-	_, _ = srv2.healthCheck(ctx, idle, DefaultLivenessCheckThreshold, nil, nil)
+	_, _ = srv2.healthCheck(ctx, idle, DefaultConnectionLivenessCheckTimeout, nil, nil)
 	// Even at this point we should prefer srv2
 	assertPenaltiesGreaterThan(srv1, srv2, now)
 

--- a/neo4j/internal/router/readtable.go
+++ b/neo4j/internal/router/readtable.go
@@ -19,10 +19,11 @@ package router
 
 import (
 	"context"
+	"time"
+
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
-	"time"
 )
 
 // Tries to read routing table from any of the specified routers using new or existing connection

--- a/neo4j/internal/router/readtable.go
+++ b/neo4j/internal/router/readtable.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
+	"time"
 )
 
 // Tries to read routing table from any of the specified routers using new or existing connection
@@ -32,6 +32,7 @@ func readTable(
 	connectionPool Pool,
 	routers []string,
 	routerContext map[string]string,
+	idlenessTimeout time.Duration,
 	bookmarks []string,
 	database,
 	impersonatedUser string,
@@ -46,7 +47,7 @@ func readTable(
 	// another db.
 	for _, router := range routers {
 		var conn db.Connection
-		if conn, err = connectionPool.Borrow(ctx, getStaticServer(router), true, boltLogger, pool.DefaultLivenessCheckThreshold, auth); err != nil {
+		if conn, err = connectionPool.Borrow(ctx, getStaticServer(router), true, boltLogger, idlenessTimeout, auth); err != nil {
 			// Check if failed due to context timing out
 			if ctx.Err() != nil {
 				return nil, wrapError(router, ctx.Err())

--- a/neo4j/internal/router/readtable_test.go
+++ b/neo4j/internal/router/readtable_test.go
@@ -23,6 +23,7 @@ import (
 	iauth "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/auth"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 	"testing"
 
@@ -180,6 +181,7 @@ func TestReadTableTable(ot *testing.T) {
 				c.pool,
 				c.routers,
 				nil,
+				pool.DefaultConnectionLivenessCheckTimeout,
 				nil,
 				"dbname",
 				"",

--- a/neo4j/internal/router/router_test.go
+++ b/neo4j/internal/router/router_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
+	"math"
 	"reflect"
 	"sync"
 	"testing"
@@ -56,7 +57,7 @@ func TestMultithreading(t *testing.T) {
 		n = n.Add(time.Duration(table.TimeToLive) * time.Second * 2)
 		return n
 	}
-	router := New("router", func() []string { return []string{} }, nil, pool, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
 
 	dbName := "dbname"
 	wg := sync.WaitGroup{}
@@ -108,7 +109,7 @@ func TestRespectsTimeToLiveAndInvalidate(t *testing.T) {
 	timer := func() time.Time {
 		return n
 	}
-	router := New("router", func() []string { return []string{} }, nil, pool, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
 	dbName := "dbname"
 
 	// First access should trigger initial table read
@@ -165,7 +166,7 @@ func TestUsesRootRouterWhenPreviousRoutersFails(t *testing.T) {
 	timer := func() time.Time {
 		return n
 	}
-	router := New("rootRouter", func() []string { return []string{} }, nil, pool, logger, "routerid", &timer)
+	router := New("rootRouter", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
 	dbName := "dbname"
 
 	// First access should trigger initial table read from root router
@@ -229,7 +230,7 @@ func TestUseGetRoutersHookWhenInitialRouterFails(t *testing.T) {
 	rootRouter := "rootRouter"
 	backupRouters := []string{"bup1", "bup2"}
 	timer := time.Now
-	router := New(rootRouter, func() []string { return backupRouters }, nil, pool, logger, "routerid", &timer)
+	router := New(rootRouter, func() []string { return backupRouters }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
 	dbName := "dbname"
 
 	// Trigger read of routing table
@@ -256,7 +257,7 @@ func TestWritersFailAfterNRetries(t *testing.T) {
 	}
 	numsleep := 0
 	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -294,7 +295,7 @@ func TestWritersRetriesWhenNoWriters(t *testing.T) {
 	}
 	numsleep := 0
 	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -333,7 +334,7 @@ func TestReadersRetriesWhenNoReaders(t *testing.T) {
 	}
 	numsleep := 0
 	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -367,7 +368,7 @@ func TestCleanUp(t *testing.T) {
 	}
 	now := time.Now()
 	timer := func() time.Time { return now }
-	router := New("router", func() []string { return []string{} }, nil, pool, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
 
 	ctx := context.Background()
 	if _, err := router.GetOrUpdateReaders(ctx, nilBookmarks, "db1", nil, nil); err != nil {

--- a/neo4j/internal/router/router_test.go
+++ b/neo4j/internal/router/router_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"errors"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
-	"math"
+	pool2 "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
 	"reflect"
 	"sync"
 	"testing"
@@ -57,7 +57,7 @@ func TestMultithreading(t *testing.T) {
 		n = n.Add(time.Duration(table.TimeToLive) * time.Second * 2)
 		return n
 	}
-	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
 
 	dbName := "dbname"
 	wg := sync.WaitGroup{}
@@ -109,7 +109,7 @@ func TestRespectsTimeToLiveAndInvalidate(t *testing.T) {
 	timer := func() time.Time {
 		return n
 	}
-	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
 	dbName := "dbname"
 
 	// First access should trigger initial table read
@@ -166,7 +166,7 @@ func TestUsesRootRouterWhenPreviousRoutersFails(t *testing.T) {
 	timer := func() time.Time {
 		return n
 	}
-	router := New("rootRouter", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
+	router := New("rootRouter", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
 	dbName := "dbname"
 
 	// First access should trigger initial table read from root router
@@ -230,7 +230,7 @@ func TestUseGetRoutersHookWhenInitialRouterFails(t *testing.T) {
 	rootRouter := "rootRouter"
 	backupRouters := []string{"bup1", "bup2"}
 	timer := time.Now
-	router := New(rootRouter, func() []string { return backupRouters }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
+	router := New(rootRouter, func() []string { return backupRouters }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
 	dbName := "dbname"
 
 	// Trigger read of routing table
@@ -257,7 +257,7 @@ func TestWritersFailAfterNRetries(t *testing.T) {
 	}
 	numsleep := 0
 	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -295,7 +295,7 @@ func TestWritersRetriesWhenNoWriters(t *testing.T) {
 	}
 	numsleep := 0
 	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -334,7 +334,7 @@ func TestReadersRetriesWhenNoReaders(t *testing.T) {
 	}
 	numsleep := 0
 	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -368,7 +368,7 @@ func TestCleanUp(t *testing.T) {
 	}
 	now := time.Now()
 	timer := func() time.Time { return now }
-	router := New("router", func() []string { return []string{} }, nil, pool, math.MaxInt64, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
 
 	ctx := context.Background()
 	if _, err := router.GetOrUpdateReaders(ctx, nilBookmarks, "db1", nil, nil); err != nil {

--- a/neo4j/internal/router/router_test.go
+++ b/neo4j/internal/router/router_test.go
@@ -1,3 +1,5 @@
+//go:build internal_time_mock
+
 /*
  * Copyright (c) "Neo4j"
  * Neo4j Sweden AB [https://neo4j.com]
@@ -21,14 +23,15 @@ package router
 import (
 	"context"
 	"errors"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
-	pool2 "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
+	pool2 "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
+	itime "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/time"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
 
@@ -37,7 +40,6 @@ var logger = &log.Void{}
 // Verifies that concurrent access works as expected relying on the race detector to
 // report suspicious behavior.
 func TestMultithreading(t *testing.T) {
-
 	// Set up a router that needs to read the routing table essentially on every access to
 	// stress threading a bit more.
 	num := 0
@@ -48,16 +50,14 @@ func TestMultithreading(t *testing.T) {
 			return &testutil.ConnFake{Table: table}, nil
 		},
 	}
-	n := time.Now()
-	mut := sync.Mutex{}
-	timer := func() time.Time {
+
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+	itime.ForceAddTicker(func(now *time.Time) {
 		// Need to lock here to make race detector happy
-		mut.Lock()
-		defer mut.Unlock()
-		n = n.Add(time.Duration(table.TimeToLive) * time.Second * 2)
-		return n
-	}
-	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
+		*now = now.Add(time.Duration(table.TimeToLive) * time.Second * 2)
+	})
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid")
 
 	dbName := "dbname"
 	wg := sync.WaitGroup{}
@@ -104,12 +104,9 @@ func TestRespectsTimeToLiveAndInvalidate(t *testing.T) {
 			return &testutil.ConnFake{Table: table}, nil
 		},
 	}
-	nzero := time.Now()
-	n := nzero
-	timer := func() time.Time {
-		return n
-	}
-	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid")
 	dbName := "dbname"
 
 	// First access should trigger initial table read
@@ -126,7 +123,7 @@ func TestRespectsTimeToLiveAndInvalidate(t *testing.T) {
 	assertNum(t, numfetch, 1, "Should not have have fetched")
 
 	// Third access with time passed table due should trigger fetch
-	n = n.Add(2 * time.Second)
+	itime.ForceTickTime(2 * time.Second)
 	if _, err := router.GetOrUpdateReaders(ctx, nilBookmarks, dbName, nil, nil); err != nil {
 		testutil.AssertNoError(t, err)
 	}
@@ -161,12 +158,9 @@ func TestUsesRootRouterWhenPreviousRoutersFails(t *testing.T) {
 			return conn, err
 		},
 	}
-	nzero := time.Now()
-	n := nzero
-	timer := func() time.Time {
-		return n
-	}
-	router := New("rootRouter", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+	router := New("rootRouter", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid")
 	dbName := "dbname"
 
 	// First access should trigger initial table read from root router
@@ -177,7 +171,7 @@ func TestUsesRootRouterWhenPreviousRoutersFails(t *testing.T) {
 		t.Errorf("Should have connected to root upon first router request")
 	}
 	// Next access should go to otherRouter
-	n = n.Add(2 * time.Second)
+	itime.ForceTickTime(2 * time.Second)
 	if _, err := router.GetOrUpdateReaders(context.Background(), nilBookmarks, dbName, nil, nil); err != nil {
 		testutil.AssertNoError(t, err)
 	}
@@ -204,7 +198,7 @@ func TestUsesRootRouterWhenPreviousRoutersFails(t *testing.T) {
 		requestedRoot = true
 		return &testutil.ConnFake{Table: &db.RoutingTable{TimeToLive: 1, Readers: []string{"aReader"}}}, nil
 	}
-	n = n.Add(2 * time.Second)
+	itime.ForceTickTime(2 * time.Second)
 	readers, err := router.GetOrUpdateReaders(context.Background(), nilBookmarks, dbName, nil, nil)
 	if err != nil {
 		t.Error(err)
@@ -229,8 +223,7 @@ func TestUseGetRoutersHookWhenInitialRouterFails(t *testing.T) {
 	}
 	rootRouter := "rootRouter"
 	backupRouters := []string{"bup1", "bup2"}
-	timer := time.Now
-	router := New(rootRouter, func() []string { return backupRouters }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
+	router := New(rootRouter, func() []string { return backupRouters }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid")
 	dbName := "dbname"
 
 	// Trigger read of routing table
@@ -256,8 +249,7 @@ func TestWritersFailAfterNRetries(t *testing.T) {
 		},
 	}
 	numsleep := 0
-	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid")
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -294,8 +286,7 @@ func TestWritersRetriesWhenNoWriters(t *testing.T) {
 		},
 	}
 	numsleep := 0
-	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid")
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -333,8 +324,7 @@ func TestReadersRetriesWhenNoReaders(t *testing.T) {
 		},
 	}
 	numsleep := 0
-	timer := time.Now
-	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid")
 	router.sleep = func(time.Duration) {
 		numsleep++
 	}
@@ -366,9 +356,9 @@ func TestCleanUp(t *testing.T) {
 			return &testutil.ConnFake{Table: table}, nil
 		},
 	}
-	now := time.Now()
-	timer := func() time.Time { return now }
-	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid", &timer)
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+	router := New("router", func() []string { return []string{} }, nil, pool, pool2.DefaultConnectionLivenessCheckTimeout, logger, "routerid")
 
 	ctx := context.Background()
 	if _, err := router.GetOrUpdateReaders(ctx, nilBookmarks, "db1", nil, nil); err != nil {
@@ -389,7 +379,7 @@ func TestCleanUp(t *testing.T) {
 		t.Fatal("Should not have removed routing tables")
 	}
 
-	timer = func() time.Time { return now.Add(1 * time.Minute) }
+	itime.ForceTickTime(1 * time.Minute)
 	router.CleanUp()
 	if len(router.dbRouters) != 0 {
 		t.Fatal("Should have cleaned up")

--- a/neo4j/internal/time/time.go
+++ b/neo4j/internal/time/time.go
@@ -1,4 +1,4 @@
-//go:build internal_testkit
+//go:build !internal_time_mock
 
 /*
  * Copyright (c) "Neo4j"
@@ -17,19 +17,9 @@
  * limitations under the License.
  */
 
-package auth
+package time
 
 import "time"
 
-func SetTimer(t TokenManager, timer func() time.Time) {
-	if t, ok := t.(*neo4jAuthTokenManager); ok {
-		t.now = &timer
-	}
-}
-
-func ResetTime(t TokenManager) {
-	if t, ok := t.(*neo4jAuthTokenManager); ok {
-		now := time.Now
-		t.now = &now
-	}
-}
+var Now = time.Now
+var Since = time.Since

--- a/neo4j/internal/time/time_mockable.go
+++ b/neo4j/internal/time/time_mockable.go
@@ -1,0 +1,130 @@
+//go:build internal_time_mock
+
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package time
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+type Ticker = func(*time.Time)
+
+var frozenNow *time.Time = nil
+var tickerRegistry []Ticker = nil
+var frozenNowMutex = &sync.Mutex{}
+
+func now() time.Time {
+	if frozenNow == nil {
+		return time.Now()
+	}
+	for _, ticker := range tickerRegistry {
+		ticker(frozenNow)
+	}
+	return *frozenNow
+}
+
+func Now() time.Time {
+	frozenNowMutex.Lock()
+	defer frozenNowMutex.Unlock()
+
+	return now()
+}
+
+func Since(t time.Time) time.Duration {
+	frozenNowMutex.Lock()
+	defer frozenNowMutex.Unlock()
+
+	if frozenNow == nil {
+		return time.Since(t)
+	}
+	return frozenNow.Sub(t)
+}
+
+func FreezeTime() error {
+	frozenNowMutex.Lock()
+	defer frozenNowMutex.Unlock()
+
+	if frozenNow != nil {
+		return errors.New("time already frozen")
+	}
+	now := now()
+	frozenNow = &now
+	return nil
+}
+
+func ForceFreezeTime() {
+	if err := FreezeTime(); err != nil {
+		panic(err)
+	}
+}
+
+func TickTime(d time.Duration) error {
+	frozenNowMutex.Lock()
+	defer frozenNowMutex.Unlock()
+
+	if frozenNow == nil {
+		return errors.New("time not frozen")
+	}
+	newNow := frozenNow.Add(d)
+	frozenNow = &newNow
+	return nil
+}
+
+func ForceTickTime(d time.Duration) {
+	if err := TickTime(d); err != nil {
+		panic(err)
+	}
+}
+
+func AddTicker(ticker Ticker) error {
+	frozenNowMutex.Lock()
+	defer frozenNowMutex.Unlock()
+
+	if frozenNow == nil {
+		return errors.New("time not frozen")
+	}
+	tickerRegistry = append(tickerRegistry, ticker)
+	return nil
+}
+
+func ForceAddTicker(ticker Ticker) {
+	if err := AddTicker(ticker); err != nil {
+		panic(err)
+	}
+}
+
+func UnfreezeTime() error {
+	frozenNowMutex.Lock()
+	defer frozenNowMutex.Unlock()
+
+	if frozenNow == nil {
+		return errors.New("time not frozen")
+	}
+	frozenNow = nil
+	tickerRegistry = nil
+	return nil
+}
+
+func ForceUnfreezeTime() {
+	if err := UnfreezeTime(); err != nil {
+		panic(err)
+	}
+}

--- a/neo4j/session_with_context_test.go
+++ b/neo4j/session_with_context_test.go
@@ -47,13 +47,12 @@ func TestSession(outer *testing.T) {
 		}
 	}
 
-	now := time.Now
 	createSession := func() (*RouterFake, *PoolFake, *sessionWithContext) {
 		conf := Config{MaxTransactionRetryTime: 3 * time.Millisecond, MaxConnectionPoolSize: 100}
 		router := RouterFake{}
 		pool := PoolFake{}
 		sessConfig := SessionConfig{AccessMode: AccessModeRead, BoltLogger: boltLogger}
-		sess := newSessionWithContext(&conf, sessConfig, &router, &pool, logger, nil, &now)
+		sess := newSessionWithContext(&conf, sessConfig, &router, &pool, logger, nil)
 		sess.throttleTime = time.Millisecond * 1
 		return &router, &pool, sess
 	}
@@ -62,7 +61,7 @@ func TestSession(outer *testing.T) {
 		conf := Config{MaxTransactionRetryTime: 3 * time.Millisecond}
 		router := RouterFake{}
 		pool := PoolFake{}
-		sess := newSessionWithContext(&conf, sessConfig, &router, &pool, logger, nil, &now)
+		sess := newSessionWithContext(&conf, sessConfig, &router, &pool, logger, nil)
 		sess.throttleTime = time.Millisecond * 1
 		return &router, &pool, sess
 	}

--- a/neo4j/test-integration/dbconn_test.go
+++ b/neo4j/test-integration/dbconn_test.go
@@ -78,7 +78,6 @@ func makeRawConnection(ctx context.Context, logger log.Logger, boltLogger log.Bo
 		},
 	}
 
-	timer := time.Now
 	boltConn, err := bolt.Connect(
 		context.Background(),
 		parsedUri.Host,
@@ -90,7 +89,6 @@ func makeRawConnection(ctx context.Context, logger log.Logger, boltLogger log.Bo
 		logger,
 		boltLogger,
 		idb.NotificationConfig{},
-		&timer,
 	)
 	if err != nil {
 		panic(err)

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1534,6 +1534,7 @@ func testSkips() map[string]string {
 		"stub.routing.test_routing_v*.RoutingV*.test_should_accept_routing_table_without_writers_and_then_rediscover":        "Driver retries to fetch a routing table up to 100 times if it's empty",
 		"stub.routing.test_routing_v*.RoutingV*.test_should_fail_on_routing_table_with_no_reader":                            "Driver retries to fetch a routing table up to 100 times if it's empty",
 		"stub.routing.test_routing_v*.RoutingV*.test_should_fail_discovery_when_router_fails_with_unknown_code":              "Unify: other drivers have a list of fast failing errors during discover: on anything else, the driver will try the next router",
+		"stub.routing.test_routing_v*.RoutingV*.test_should_drop_connections_failing_liveness_check":                         "Liveness check error handling is not (yet) unified: https://github.com/neo-technology/drivers-adr/pull/83",
 		"stub.*.test_0_timeout":                                  "Fixme: driver omits 0 as tx timeout value",
 		"stub.summary.test_summary.TestSummary.test_server_info": "pending unification: should the server address be pre or post DNS resolution?",
 	}

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -488,6 +488,9 @@ func (b *backend) handleRequest(req map[string]any) {
 			if data["connectionAcquisitionTimeoutMs"] != nil {
 				c.ConnectionAcquisitionTimeout = time.Millisecond * time.Duration(asInt64(data["connectionAcquisitionTimeoutMs"].(json.Number)))
 			}
+			if data["livenessCheckTimeoutMs"] != nil {
+				c.ConnectionLivenessCheckTimeout = time.Millisecond * time.Duration(asInt64(data["livenessCheckTimeoutMs"].(json.Number)))
+			}
 			if data["maxConnectionPoolSize"] != nil {
 				c.MaxConnectionPoolSize = asInt(data["maxConnectionPoolSize"].(json.Number))
 			}
@@ -1141,8 +1144,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"Feature:API:Driver.VerifyAuthentication",
 				"Feature:API:Driver.VerifyConnectivity",
 				//"Feature:API:Driver.SupportsSessionAuth",
-				// Go driver does not support LivenessCheckTimeout yet
-				//"Feature:API:Liveness.Check",
+				"Feature:API:Liveness.Check",
 				"Feature:API:Result.List",
 				"Feature:API:Result.Peek",
 				//"Feature:API:Result.Single",

--- a/testkit/backend.py
+++ b/testkit/backend.py
@@ -11,5 +11,10 @@ import sys
 
 if __name__ == "__main__":
     backend_path = os.path.join(".", "testkit-backend")
-    subprocess.check_call(["go", "run", "-tags", "internal_testkit", "-buildvcs=false", backend_path],
-                          stdout=sys.stdout, stderr=sys.stderr)
+    subprocess.check_call(
+        [
+            "go", "run", "-tags", "internal_testkit,internal_time_mock",
+            "-buildvcs=false", backend_path
+        ],
+        stdout=sys.stdout, stderr=sys.stderr
+    )

--- a/testkit/build.py
+++ b/testkit/build.py
@@ -21,7 +21,13 @@ if __name__ == "__main__":
     defaultEnv["GOFLAGS"] = "-buildvcs=false"
 
     print("Building for current target", flush=True)
-    run(["go", "build", "-tags", "internal_testkit", "-v", "./..."], env=defaultEnv)
+    run(
+        [
+            "go", "build", "-tags", "internal_testkit,internal_time_mock",
+            "-v", "./..."
+        ],
+        env=defaultEnv
+    )
 
     # Compile for 32 bits ARM to make sure it builds
     print("Building for 32 bits", flush=True)
@@ -32,13 +38,27 @@ if __name__ == "__main__":
     run(["go", "build", "./neo4j/..."], env=arm32Env)
 
     print("Vet sources", flush=True)
-    run(["go", "vet", "-tags", "internal_testkit", "./..."], env=defaultEnv)
+    run(
+        [
+            "go", "vet", "-tags", "internal_testkit,internal_time_mock",
+            "./..."
+        ],
+        env=defaultEnv
+    )
 
     print("Install staticcheck", flush=True)
-    run(["go", "install", "honnef.co/go/tools/cmd/staticcheck@v0.3.3"], env=defaultEnv)
+    run(["go", "install", "honnef.co/go/tools/cmd/staticcheck@v0.3.3"],
+        env=defaultEnv)
 
     print("Run staticcheck", flush=True)
     gopath = Path(
         subprocess.check_output(["go", "env", "GOPATH"]).decode("utf-8").strip()
     )
-    run([str(gopath / "bin" / "staticcheck"), "-tags", "internal_testkit", "./..."], env=defaultEnv)
+    run(
+        [
+            str(gopath / "bin" / "staticcheck"),
+            "-tags", "internal_testkit,internal_time_mock",
+            "./..."
+        ],
+        env=defaultEnv
+    )

--- a/testkit/unittests.py
+++ b/testkit/unittests.py
@@ -19,12 +19,16 @@ def run(args):
 if __name__ == "__main__":
     # Run explicit set of unit tests to avoid running integration tests
     # Specify -v -json to make TeamCity pickup the tests
-    cmd = ["go", "test"]
-    if os.environ.get("TEST_IN_TEAMCITY", False):
-        cmd = cmd + ["-v", "-json"]
-
     path = os.path.join(".", "neo4j", "...")
-    run(cmd + ["-buildvcs=false", "-short", path])
+
+    for extra_args in (
+        (), ("-tags", "internal_time_mock")
+    ):
+        cmd = ["go", "test", *extra_args]
+        if os.environ.get("TEST_IN_TEAMCITY", False):
+            cmd = cmd + ["-v", "-json"]
+
+        run(cmd + ["-buildvcs=false", "-short", path])
 
     # Repeat racing tests
     run(cmd + ["-buildvcs=false", "-race", "-count", "50",


### PR DESCRIPTION
This configuration defines the duration that the connection may be idle before needing to perform a liveness check on acquiring from the pool.

```golang
driver, err := neo4j.NewDriverWithContext("neo4j://localhost:7687", neo4j.BasicAuth("neo4j", "password", ""), func(config *neo4j.Config) {
    config.ConnectionLivenessCheckTimeout = 2 * time.Second
})
```

Check the API docs for more information.