### PR TITLE
Non-racing lock for driver pool

### DIFF
--- a/neo4j/driver_with_context_test.go
+++ b/neo4j/driver_with_context_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/racing"
 	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 	"net/url"
 	"sync"
@@ -415,7 +414,7 @@ func TestDriverExecuteQuery(outer *testing.T) {
 				},
 				delegate: &driverWithContext{
 					executeQueryBookmarkManager: defaultBookmarkManager,
-					mut:                         racing.NewMutex(),
+					mut:                         sync.Mutex{},
 				},
 			}
 
@@ -435,7 +434,7 @@ func TestDriverExecuteQuery(outer *testing.T) {
 				}
 			},
 			delegate: &driverWithContext{
-				mut: racing.NewMutex(),
+				mut: sync.Mutex{},
 			},
 		}
 

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -535,7 +535,7 @@ func (b *backend) handleRequest(req map[string]any) {
 	case "DriverClose":
 		driverId := data["driverId"].(string)
 		driver := b.drivers[driverId]
-		err := driver.Close(ctx)
+		driver.Close(ctx)
 		if err != nil {
 			b.writeError(err)
 			return
@@ -707,7 +707,7 @@ func (b *backend) handleRequest(req map[string]any) {
 	case "SessionClose":
 		sessionId := data["sessionId"].(string)
 		sessionState := b.sessionStates[sessionId]
-		err := sessionState.session.Close(ctx)
+		sessionState.session.Close(ctx)
 		if err != nil {
 			b.writeError(err)
 			return
@@ -805,7 +805,7 @@ func (b *backend) handleRequest(req map[string]any) {
 	case "TransactionClose":
 		txId := data["txId"].(string)
 		tx := b.explicitTransactions[txId]
-		err := tx.Close(ctx)
+		tx.Close(ctx)
 		if err != nil {
 			b.writeError(err)
 			return
@@ -910,7 +910,7 @@ func (b *backend) handleRequest(req map[string]any) {
 		})
 		result, err := session.Run(ctx, "RETURN 42", nil)
 		defer func() {
-			err = session.Close(ctx)
+			session.Close(ctx)
 			if err != nil {
 				b.writeError(fmt.Errorf("could not check multi DB support: %w", err))
 			}

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -532,7 +532,7 @@ func (b *backend) handleRequest(req map[string]any) {
 	case "DriverClose":
 		driverId := data["driverId"].(string)
 		driver := b.drivers[driverId]
-		driver.Close(ctx)
+		err := driver.Close(ctx)
 		if err != nil {
 			b.writeError(err)
 			return
@@ -711,7 +711,7 @@ func (b *backend) handleRequest(req map[string]any) {
 	case "SessionClose":
 		sessionId := data["sessionId"].(string)
 		sessionState := b.sessionStates[sessionId]
-		sessionState.session.Close(ctx)
+		err := sessionState.session.Close(ctx)
 		if err != nil {
 			b.writeError(err)
 			return
@@ -809,7 +809,7 @@ func (b *backend) handleRequest(req map[string]any) {
 	case "TransactionClose":
 		txId := data["txId"].(string)
 		tx := b.explicitTransactions[txId]
-		tx.Close(ctx)
+		err := tx.Close(ctx)
 		if err != nil {
 			b.writeError(err)
 			return
@@ -914,7 +914,7 @@ func (b *backend) handleRequest(req map[string]any) {
 		})
 		result, err := session.Run(ctx, "RETURN 42", nil)
 		defer func() {
-			session.Close(ctx)
+			err = session.Close(ctx)
 			if err != nil {
 				b.writeError(fmt.Errorf("could not check multi DB support: %w", err))
 			}


### PR DESCRIPTION
The mutex guarding the driver's pool attribute does not need to be held while doing IO. Therefore, we can use a standard (non-cancelable) mutex to guard it. This comes at the benefit of not needing a context for session creation. Session creation doesn't perform any I/O, so it shouldn't take long anyway. There's little to no gain in it accepting a context.