### PR TITLE
Clean up logging packaging

### DIFF
--- a/neo4j/consolelogger.go
+++ b/neo4j/consolelogger.go
@@ -23,28 +23,40 @@ import (
 
 // LogLevel is the type that default logging implementations use for available
 // log levels
-type LogLevel int
+//
+// Deprecated: use log.Level instead.
+type LogLevel = log.Level
 
 const (
 	// ERROR is the level that error messages are written
-	ERROR LogLevel = 1
+	//
+	// Deprecated: use log.ERROR instead.
+	ERROR = log.ERROR
 	// WARNING is the level that warning messages are written
-	WARNING = 2
+	//
+	// Deprecated: use log.WARNING instead.
+	WARNING = log.WARNING
 	// INFO is the level that info messages are written
-	INFO = 3
+	//
+	// Deprecated: use log.INFO instead.
+	INFO = log.INFO
 	// DEBUG is the level that debug messages are written
-	DEBUG = 4
+	//
+	// Deprecated: use log.DEBUG instead.
+	DEBUG = log.DEBUG
 )
 
-func ConsoleLogger(level LogLevel) *log.Console {
+// Deprecated: use log.ToConsole() instead.
+func ConsoleLogger(level log.Level) *log.Console {
 	return &log.Console{
-		Errors: level >= ERROR,
-		Warns:  level >= WARNING,
-		Infos:  level >= INFO,
-		Debugs: level >= DEBUG,
+		Errors: level >= log.ERROR,
+		Warns:  level >= log.WARNING,
+		Infos:  level >= log.INFO,
+		Debugs: level >= log.DEBUG,
 	}
 }
 
+// Deprecated: use log.BoltToConsole() instead.
 func ConsoleBoltLogger() *log.ConsoleBoltLogger {
 	return &log.ConsoleBoltLogger{}
 }

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -207,7 +207,7 @@ func NewDriverWithContext(target string, auth auth.TokenManager, configurers ...
 	d.log = d.config.Log
 	if d.log == nil {
 		// Default to void logger
-		d.log = &log.Void{}
+		d.log = log.ToVoid()
 	}
 	d.logId = log.NewId()
 

--- a/neo4j/internal/bolt/connect_test.go
+++ b/neo4j/internal/bolt/connect_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
 
-var logger = &log.Void{}
+var logger = log.ToVoid()
 
 func TestConnect(ot *testing.T) {
 	// TODO: Test connect timeout

--- a/neo4j/internal/pool/pool_test.go
+++ b/neo4j/internal/pool/pool_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
 
-var logger = &log.Void{}
+var logger = log.ToVoid()
 var ctx = context.Background()
 var reAuthToken = &idb.ReAuthToken{FromSession: false, Manager: iauth.Token{Tokens: map[string]any{"scheme": "none"}}}
 

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -144,7 +144,7 @@ func TestState(outer *testing.T) {
 	for i, testCase := range testCases {
 		outer.Run(i, func(t *testing.T) {
 			state := State{
-				Log:                     &log.Void{},
+				Log:                     log.ToVoid(),
 				LogName:                 "TEST",
 				LogId:                   "State",
 				Sleep:                   func(time.Duration) {},

--- a/neo4j/internal/router/router_test.go
+++ b/neo4j/internal/router/router_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
 
-var logger = &log.Void{}
+var logger = log.ToVoid()
 
 // Verifies that concurrent access works as expected relying on the race detector to
 // report suspicious behavior.

--- a/neo4j/log/bolt_logger.go
+++ b/neo4j/log/bolt_logger.go
@@ -28,18 +28,18 @@ type BoltLogger interface {
 	LogServerMessage(context string, msg string, args ...any)
 }
 
-type ConsoleBoltLogger struct {
+type consoleBoltLogger struct {
 }
 
-func (cbl *ConsoleBoltLogger) LogClientMessage(id, msg string, args ...any) {
+func (cbl *consoleBoltLogger) LogClientMessage(id, msg string, args ...any) {
 	cbl.logBoltMessage("C", id, msg, args)
 }
 
-func (cbl *ConsoleBoltLogger) LogServerMessage(id, msg string, args ...any) {
+func (cbl *consoleBoltLogger) LogServerMessage(id, msg string, args ...any) {
 	cbl.logBoltMessage("S", id, msg, args)
 }
 
-func (cbl *ConsoleBoltLogger) logBoltMessage(src, id string, msg string, args []any) {
+func (cbl *consoleBoltLogger) logBoltMessage(src, id string, msg string, args []any) {
 	_, _ = fmt.Fprintf(os.Stdout, "%s   BOLT  %s%s: %s\n", time.Now().Format(timeFormat), formatId(id), src, fmt.Sprintf(msg, args...))
 }
 
@@ -48,4 +48,12 @@ func formatId(id string) string {
 		return ""
 	}
 	return fmt.Sprintf("[%s] ", id)
+}
+
+// Deprecated: use log.BoltToConsole() instead.
+type ConsoleBoltLogger = consoleBoltLogger
+
+// BoltToConsole returns a BoltLogger implementation that writes to stdout.
+func BoltToConsole() BoltLogger {
+	return &consoleBoltLogger{}
 }

--- a/neo4j/log/console.go
+++ b/neo4j/log/console.go
@@ -23,9 +23,7 @@ import (
 	"time"
 )
 
-// Console is a simple logger that logs to stdout/console.
-// Turn the different log levels on/off as wished, all are off by default.
-type Console struct {
+type console struct {
 	Errors bool
 	Infos  bool
 	Warns  bool
@@ -34,7 +32,7 @@ type Console struct {
 
 const timeFormat = "2006-01-02 15:04:05.000"
 
-func (l *Console) Error(name, id string, err error) {
+func (l *console) Error(name, id string, err error) {
 	if !l.Errors {
 		return
 	}
@@ -42,7 +40,7 @@ func (l *Console) Error(name, id string, err error) {
 	fmt.Fprintf(os.Stderr, "%s  ERROR  [%s %s] %s\n", now.Format(timeFormat), name, id, err.Error())
 }
 
-func (l *Console) Infof(name, id string, msg string, args ...any) {
+func (l *console) Infof(name, id string, msg string, args ...any) {
 	if !l.Infos {
 		return
 	}
@@ -50,7 +48,7 @@ func (l *Console) Infof(name, id string, msg string, args ...any) {
 	fmt.Fprintf(os.Stdout, "%s   INFO  [%s %s] %s\n", now.Format(timeFormat), name, id, fmt.Sprintf(msg, args...))
 }
 
-func (l *Console) Warnf(name, id string, msg string, args ...any) {
+func (l *console) Warnf(name, id string, msg string, args ...any) {
 	if !l.Warns {
 		return
 	}
@@ -58,10 +56,28 @@ func (l *Console) Warnf(name, id string, msg string, args ...any) {
 	fmt.Fprintf(os.Stdout, "%s   WARN  [%s %s] %s\n", now.Format(timeFormat), name, id, fmt.Sprintf(msg, args...))
 }
 
-func (l *Console) Debugf(name, id string, msg string, args ...any) {
+func (l *console) Debugf(name, id string, msg string, args ...any) {
 	if !l.Debugs {
 		return
 	}
 	now := time.Now()
 	fmt.Fprintf(os.Stdout, "%s  DEBUG  [%s %s] %s\n", now.Format(timeFormat), name, id, fmt.Sprintf(msg, args...))
+}
+
+// Console is a simple logger that logs to stdout/console.
+// Turn the different log levels on/off as wished, all are off by default.
+//
+// Deprecated: use log.ToConsole() instead.
+type Console = console
+
+// ToConsole returns a simple logger that logs to stdout/console.
+//
+// level is the minimum log level that will be logged.
+func ToConsole(level Level) Logger {
+	return &console{
+		Errors: level >= ERROR,
+		Warns:  level >= WARNING,
+		Infos:  level >= INFO,
+		Debugs: level >= DEBUG,
+	}
 }

--- a/neo4j/log/level.go
+++ b/neo4j/log/level.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package log
+
+// Level is the type that default logging implementations use for available
+// log levels
+type Level int
+
+const (
+	// ERROR is the level that error messages are written
+	ERROR Level = 1
+	// WARNING is the level that warning messages are written
+	WARNING = 2
+	// INFO is the level that info messages are written
+	INFO = 3
+	// DEBUG is the level that debug messages are written
+	DEBUG = 4
+)

--- a/neo4j/log/void.go
+++ b/neo4j/log/void.go
@@ -18,16 +18,26 @@
 package log
 
 // Logger implementation that throws away all log events.
-type Void struct{}
+type void struct{}
 
-func (l Void) Error(name, id string, err error) {
+func (l void) Error(name, id string, err error) {
 }
 
-func (l Void) Infof(name, id string, msg string, args ...any) {
+func (l void) Infof(name, id, msg string, args ...any) {
 }
 
-func (l Void) Warnf(name, id string, msg string, args ...any) {
+func (l void) Warnf(name, id, msg string, args ...any) {
 }
 
-func (l Void) Debugf(name, id string, msg string, args ...any) {
+func (l void) Debugf(name, id, msg string, args ...any) {
+}
+
+// Void is a Logger implementation that throws away all log events.
+//
+// Deprecated: use log.ToVoid() instead.
+type Void = void
+
+// ToVoid returns a Logger implementation that throws away all log events.
+func ToVoid() Logger {
+	return void{}
 }

--- a/neo4j/session_with_context_test.go
+++ b/neo4j/session_with_context_test.go
@@ -38,7 +38,7 @@ type transactionFunc func(context.Context, ManagedTransactionWork, ...func(*Tran
 type transactionFuncApi func(session SessionWithContext) transactionFunc
 
 func TestSession(outer *testing.T) {
-	var logger log.Logger = &log.Void{}
+	var logger = log.ToVoid()
 	var boltLogger log.BoltLogger = nil
 
 	assertCleanSessionState := func(t *testing.T, sess *sessionWithContext) {

--- a/neo4j/test-integration/dbconn_test.go
+++ b/neo4j/test-integration/dbconn_test.go
@@ -98,7 +98,7 @@ func makeRawConnection(ctx context.Context, logger log.Logger, boltLogger log.Bo
 
 func BenchmarkQuery(b *testing.B) {
 	ctx := context.Background()
-	_, conn := makeRawConnection(ctx, &log.Console{Debugs: true, Errors: true, Infos: true, Warns: true}, nil)
+	_, conn := makeRawConnection(ctx, log.ToConsole(log.DEBUG), nil)
 	defer conn.Close(context.Background())
 	params := map[string]any{
 		"one": 1,
@@ -124,7 +124,7 @@ func TestConnectionConformance(outer *testing.T) {
 		outer.Skip()
 	}
 	ctx := context.Background()
-	server, boltConn := makeRawConnection(ctx, &log.Console{Errors: true, Infos: true, Warns: true, Debugs: true}, nil)
+	server, boltConn := makeRawConnection(ctx, log.ToConsole(log.DEBUG), nil)
 	defer boltConn.Close(context.Background())
 
 	randInt := func() int64 {

--- a/neo4j/test-integration/session_test.go
+++ b/neo4j/test-integration/session_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 	"testing"
 	"time"
 
@@ -46,7 +47,7 @@ func TestSession(outer *testing.T) {
 		)
 
 		driver = server.Driver(func(c *config.Config) {
-			c.Log = neo4j.ConsoleLogger(neo4j.DEBUG)
+			c.Log = log.ToConsole(log.DEBUG)
 		})
 		assertNotNil(inner, driver)
 

--- a/neo4j/test-integration/summary_test.go
+++ b/neo4j/test-integration/summary_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/test-integration/dbserver"
 	"testing"
 )
@@ -40,7 +41,7 @@ func TestResultSummary(outer *testing.T) {
 
 	server = dbserver.GetDbServer(ctx)
 	driver = server.Driver(func(config *config.Config) {
-		config.Log = neo4j.ConsoleLogger(neo4j.DEBUG)
+		config.Log = log.ToConsole(log.DEBUG)
 	})
 	assertNotNil(outer, driver)
 
@@ -70,7 +71,7 @@ func TestResultSummary(outer *testing.T) {
 			inner.Skip("Multi-tenancy is a Neo4j 4+ feature")
 		}
 
-		session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "system", BoltLogger: neo4j.ConsoleBoltLogger()})
+		session := driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: "system", BoltLogger: log.BoltToConsole()})
 		defer assertCloses(ctx, inner, session)
 		res, err := session.Run(ctx, server.CreateDatabaseQuery(extraDatabase), map[string]any{})
 		assertNil(inner, err)

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/config"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 	"io"
 	"math"
@@ -910,7 +911,7 @@ func (b *backend) handleRequest(req map[string]any) {
 	case "CheckMultiDBSupport":
 		driver := b.drivers[data["driverId"].(string)]
 		session := driver.NewSession(ctx, neo4j.SessionConfig{
-			BoltLogger: neo4j.ConsoleBoltLogger(),
+			BoltLogger: log.BoltToConsole(),
 		})
 		result, err := session.Run(ctx, "RETURN 42", nil)
 		defer func() {


### PR DESCRIPTION
 * Move everything logging related into `log` package. Deprecations are now in place, new alternatives exist.
 * Made structs implementing Logger private so they need to be created via factory methods.

Closes #472