### PR TITLE
Add  `ExecuteQueryWithAuthToken` configuration option

### DIFF
--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -672,6 +672,13 @@ func ExecuteQueryWithTransactionConfig(configurers ...func(*TransactionConfig)) 
 	}
 }
 
+// ExecuteQueryWithAuthToken configures DriverWithContext.ExecuteQuery to overwrite the AuthToken for the session.
+func ExecuteQueryWithAuthToken(auth AuthToken) ExecuteQueryConfigurationOption {
+	return func(configuration *ExecuteQueryConfiguration) {
+		configuration.Auth = &auth
+	}
+}
+
 // ExecuteQueryConfiguration holds all the possible configuration settings for DriverWithContext.ExecuteQuery
 type ExecuteQueryConfiguration struct {
 	Routing                RoutingControl
@@ -680,6 +687,7 @@ type ExecuteQueryConfiguration struct {
 	BookmarkManager        BookmarkManager
 	BoltLogger             log.BoltLogger
 	TransactionConfigurers []func(*TransactionConfig)
+	Auth                   *AuthToken
 }
 
 // RoutingControl specifies how the query executed by DriverWithContext.ExecuteQuery is to be routed
@@ -698,6 +706,7 @@ func (c *ExecuteQueryConfiguration) toSessionConfig() SessionConfig {
 		DatabaseName:     c.Database,
 		BookmarkManager:  c.BookmarkManager,
 		BoltLogger:       c.BoltLogger,
+		Auth:             c.Auth,
 	}
 }
 

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -604,8 +604,8 @@ func (b *backend) handleRequest(req map[string]any) {
 					config.TransactionConfigurers = append(config.TransactionConfigurers, neo4j.WithTxMetadata(b.toTxMetadata(executeQueryConfig)))
 				}
 				// Append Auth configuration if it exists
-				if executeQueryConfig["auth"] != nil {
-					token, err := getAuth(executeQueryConfig["auth"].(map[string]any)["data"].(map[string]any))
+				if executeQueryConfig["authorizationToken"] != nil {
+					token, err := getAuth(executeQueryConfig["authorizationToken"].(map[string]any)["data"].(map[string]any))
 					if err != nil {
 						b.writeError(err)
 						return

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1135,6 +1135,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"Feature:API:BookmarkManager",
 				"Feature:API:ConnectionAcquisitionTimeout",
 				"Feature:API:Driver.ExecuteQuery",
+				"Feature:API:Driver.ExecuteQuery:WithAuth",
 				"Feature:API:Driver:GetServerInfo",
 				"Feature:API:Driver.IsEncrypted",
 				"Feature:API:Driver:NotificationsConfig",

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -561,7 +561,6 @@ func (b *backend) handleRequest(req map[string]any) {
 		if rawConfig := data["config"]; rawConfig != nil {
 			executeQueryConfig := rawConfig.(map[string]any)
 			configurers = append(configurers, func(config *neo4j.ExecuteQueryConfiguration) {
-
 				config.BoltLogger = &streamLog{writeLine: b.writeLineLocked}
 
 				routing := executeQueryConfig["routing"]

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -603,8 +603,11 @@ func (b *backend) handleRequest(req map[string]any) {
 				}
 				// Append Auth configuration if it exists
 				if executeQueryConfig["auth"] != nil {
-					auth := executeQueryConfig["auth"].(map[string]any)
-					token := neo4j.BasicAuth(auth["principal"].(string), auth["credentials"].(string), "")
+					token, err := getAuth(executeQueryConfig["auth"].(map[string]any)["data"].(map[string]any))
+					if err != nil {
+						b.writeError(err)
+						return
+					}
 					config.Auth = &token
 				}
 			})

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -561,6 +561,9 @@ func (b *backend) handleRequest(req map[string]any) {
 		if rawConfig := data["config"]; rawConfig != nil {
 			executeQueryConfig := rawConfig.(map[string]any)
 			configurers = append(configurers, func(config *neo4j.ExecuteQueryConfiguration) {
+
+				config.BoltLogger = &streamLog{writeLine: b.writeLineLocked}
+
 				routing := executeQueryConfig["routing"]
 				if routing != nil {
 					switch routing {

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -600,6 +600,12 @@ func (b *backend) handleRequest(req map[string]any) {
 				if executeQueryConfig["txMeta"] != nil {
 					config.TransactionConfigurers = append(config.TransactionConfigurers, neo4j.WithTxMetadata(b.toTxMetadata(executeQueryConfig)))
 				}
+				// Append Auth configuration if it exists
+				if executeQueryConfig["auth"] != nil {
+					auth := executeQueryConfig["auth"].(map[string]any)
+					token := neo4j.BasicAuth(auth["principal"].(string), auth["credentials"].(string), "")
+					config.Auth = &token
+				}
 			})
 		}
 


### PR DESCRIPTION
```golang
result, err := neo4j.ExecuteQuery(ctx, driver, query, parameters,
    neo4j.ExecuteQueryWithAuthToken(neo4j.BasicAuth("neo4j", "password", "realm")),
)
```