### PR TITLE
Session is still usable after Close.

### DIFF
--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -676,6 +676,8 @@ func (s *sessionWithContext) Close(ctx context.Context) error {
 	}()
 	<-poolCleanUpChan
 	<-routerCleanUpChan
+	s.pool = nil
+	s.router = nil
 	return txErr
 }
 


### PR DESCRIPTION
The Session must not be usable after the caller closed it explicitly.

Following pattern just works at the moment

```
	session := driver.NewSession(ctx, sessionConfig)
        session.Close()

        session.ExecuteRead(...)
        // and keep using session with more operations...
```

This is because Closing session cleans up pool/router etc, but all the references are still preserved. 

As a good practice, the behavior should be fail-fast/fail-hard once you called `Close` on it