### PR TITLE
Return error if operation is attempted on a closed session

### DIFF
--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -674,6 +674,11 @@ func (s *sessionWithContext) Run(ctx context.Context,
 }
 
 func (s *sessionWithContext) Close(ctx context.Context) error {
+	if s.closed {
+		// Safeguard against closing more than once
+		return nil
+	}
+
 	var txErr error
 	if s.explicitTx != nil {
 		txErr = s.explicitTx.Close(ctx)

--- a/neo4j/session_with_context_test.go
+++ b/neo4j/session_with_context_test.go
@@ -736,6 +736,38 @@ func TestSession(outer *testing.T) {
 			AssertErrorMessageContains(t, err, "cannot use this transaction")
 			AssertIntEqual(t, poolReturnsCalls, 1) // pool.Return must not be called again
 		})
+
+		ct.Run("Run returns error if session is closed", func(t *testing.T) {
+			_, _, sess := createSession()
+			sess.Close(context.Background())
+			_, err := sess.Run(context.Background(), "cypher", nil)
+			AssertErrorMessageContains(t, err, "Operation attempted on a closed session")
+		})
+
+		ct.Run("BeginTransaction returns error if session is closed", func(t *testing.T) {
+			_, _, sess := createSession()
+			sess.Close(context.Background())
+			_, err := sess.BeginTransaction(context.Background())
+			AssertErrorMessageContains(t, err, "Operation attempted on a closed session")
+		})
+
+		ct.Run("ExecuteRead returns error if session is closed", func(t *testing.T) {
+			_, _, sess := createSession()
+			sess.Close(context.Background())
+			_, err := sess.ExecuteRead(context.Background(), func(tx ManagedTransaction) (any, error) {
+				return nil, nil
+			})
+			AssertErrorMessageContains(t, err, "Operation attempted on a closed session")
+		})
+
+		ct.Run("ExecuteWrite returns error if session is closed", func(t *testing.T) {
+			_, _, sess := createSession()
+			sess.Close(context.Background())
+			_, err := sess.ExecuteWrite(context.Background(), func(tx ManagedTransaction) (any, error) {
+				return nil, nil
+			})
+			AssertErrorMessageContains(t, err, "Operation attempted on a closed session")
+		})
 	})
 
 }

--- a/neo4j/session_with_context_test.go
+++ b/neo4j/session_with_context_test.go
@@ -768,6 +768,14 @@ func TestSession(outer *testing.T) {
 			})
 			AssertErrorMessageContains(t, err, "Operation attempted on a closed session")
 		})
+
+		ct.Run("Session returns nil if closed multiple times", func(t *testing.T) {
+			_, _, sess := createSession()
+			err := sess.Close(context.Background())
+			AssertNoError(t, err)
+			err = sess.Close(context.Background())
+			AssertNoError(t, err)
+		})
 	})
 
 }


### PR DESCRIPTION
A session is still usable even after closing it explicitly:

```go
session := driver.NewSession(ctx, sessionConfig)
session.Close()
// These all still work
session.Run(...)
session.BeginTransaction(...)
session.ExecuteRead(...)
session.ExecuteWrite(...)
```

We now return a new UsageError when an operation is attempted on a closed session.

Fixes issue: https://github.com/neo4j/neo4j-go-driver/issues/569 raised by @oleriajm