### PR TITLE
Hybrid Routing Spike

### DIFF
--- a/neo4j/directrouter.go
+++ b/neo4j/directrouter.go
@@ -28,6 +28,10 @@ type directRouter struct {
 	address string
 }
 
+func (r *directRouter) Address() string {
+	return r.address
+}
+
 func (r *directRouter) InvalidateWriter(string, string) {}
 
 func (r *directRouter) InvalidateReader(string, string) {}

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -312,6 +312,7 @@ type sessionRouter interface {
 	InvalidateWriter(db string, server string)
 	InvalidateReader(db string, server string)
 	InvalidateServer(server string)
+	Address() string
 }
 
 type driverWithContext struct {
@@ -671,7 +672,6 @@ func ExecuteQueryWithTransactionConfig(configurers ...func(*TransactionConfig)) 
 		configuration.TransactionConfigurers = configurers
 	}
 }
-
 
 // ExecuteQueryWithAuthToken configures neo4j.ExecuteQuery to overwrite the AuthToken for the session.
 func ExecuteQueryWithAuthToken(auth AuthToken) ExecuteQueryConfigurationOption {

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -47,6 +47,7 @@ type poolRouter interface {
 	InvalidateWriter(db string, server string)
 	InvalidateReader(db string, server string)
 	InvalidateServer(server string)
+	Address() string
 }
 
 type qitem struct {
@@ -178,6 +179,10 @@ func (p *Pool) anyHasCapacity(serverNames []string) bool {
 		}
 	}
 	return false
+}
+
+func (p *Pool) BorrowOptimistically(ctx context.Context, logger log.BoltLogger, auth *idb.ReAuthToken) (idb.Connection, error) {
+	return p.tryBorrow(ctx, p.router.Address(), logger, time.Hour, auth)
 }
 
 func (p *Pool) Borrow(

--- a/neo4j/internal/router/router.go
+++ b/neo4j/internal/router/router.go
@@ -81,6 +81,10 @@ func New(rootRouter string, getRouters func() []string, routerContext map[string
 	return r
 }
 
+func (r *Router) Address() string {
+	return r.rootRouter
+}
+
 func (r *Router) readTable(
 	ctx context.Context,
 	dbRouter *databaseRouter,


### PR DESCRIPTION
An initial spike of hybrid routing. 💀 ⚠️ DO NOT MERGE....LIKE SERIOUSLY

![hr-diagram](https://github.com/StephenCathcart/neo4j-go-driver/assets/1964033/d4962c85-20a0-4481-b541-a37ec92077a0)


A result of ExecuteQuery to a cluster (write query sent to a secondary):

```
2024-04-29 15:33:53.363   INFO  [pool 1] Created
2024-04-29 15:33:53.363   INFO  [router 1] Created {context: map[address:localhost:7687]}
2024-04-29 15:33:53.363   INFO  [driver 1] Created { target: localhost:7687 }
2024-04-29 15:33:53.363  DEBUG  [session 2] Created
2024-04-29 15:33:53.363  DEBUG  [session 2] connection acquisition timeout is 1m0s, resolved deadline is: 2024-04-29 15:34:53.363569 +0100 BST m=+60.000988609
2024-04-29 15:33:53.363   INFO  [pool 1] Connecting to localhost:7687
2024-04-29 15:33:53.366   BOLT  C: <MAGIC> 0X6060B017
2024-04-29 15:33:53.366   BOLT  C: <HANDSHAKE> 0X00040405 0X00020404 0X00000104 0X00000003
2024-04-29 15:33:53.418   BOLT  S: <HANDSHAKE> 0X00000405
2024-04-29 15:33:53.418   BOLT  C: HELLO {"bolt_agent":{"language":"Go/go1.20.3","platform":"darwin; amd64","product":"neo4j-go/5.20.0"},"routing":{"address":"localhost:7687"},"user_agent":"Go Driver/5.20.0"}
2024-04-29 15:33:53.418   BOLT  C: LOGON {"credentials":"<redacted>","principal":"neo4j","scheme":"basic"}
2024-04-29 15:33:53.446   BOLT  S: SUCCESS {"server":"Neo4j/5.19.0","connection_id":"bolt-0","hints":{"connection.recv_timeout_seconds":120}}
2024-04-29 15:33:53.473   BOLT  [bolt-0@localhost:7687] S: SUCCESS {}
2024-04-29 15:33:53.473   INFO  [bolt5 bolt-0@localhost:7687] Connected
2024-04-29 15:33:53.473   BOLT  [bolt-0@localhost:7687] C: BEGIN {"tx_metadata":{"key":"value"},"tx_timeout":30000}
2024-04-29 15:33:53.473   BOLT  [bolt-0@localhost:7687] C: RUN "CREATE (:User)" {} {}
2024-04-29 15:33:53.473   BOLT  [bolt-0@localhost:7687] C: PULL {"n":1000}
2024-04-29 15:33:53.554   BOLT  [bolt-0@localhost:7687] S: SUCCESS {}
2024-04-29 15:33:54.030   BOLT  [bolt-0@localhost:7687] S: SUCCESS {"t_first":475}
2024-04-29 15:33:54.037   BOLT  [bolt-0@localhost:7687] S: SUCCESS {"t_first":3,"db":"neo4j"}
2024-04-29 15:33:54.037   BOLT  [bolt-0@localhost:7687] C: COMMIT
2024-04-29 15:33:54.055   BOLT  [bolt-0@localhost:7687] S: SUCCESS 
2024-04-29 15:33:54.055  DEBUG  [pool 1] Returning connection to localhost:7687 {alive:true}
2024-04-29 15:33:54.055  DEBUG  [bolt5 bolt-0@localhost:7687] Resetting connection internal state
2024-04-29 15:33:54.055  DEBUG  [router 1] Cleaning up
2024-04-29 15:33:54.055  DEBUG  [session 2] Closed
2024-04-29 15:33:54.055   INFO  [pool 1] Closed
2024-04-29 15:33:54.055   INFO  [driver 1] Closed
```