### PR TITLE
Clarify `FetchAll` behavior inline docs

### DIFF
--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -168,10 +168,10 @@ type Config struct {
 	// FetchSize defines how many records to pull from server in each batch.
 	// From Bolt protocol v4 (Neo4j 4+) records can be fetched in batches as
 	// compared to fetching all in previous versions.
+	// If the underlying protocol does not support FetchSize, it is ignored.
 	//
 	// If FetchSize is set to `FetchDefault`, the driver decides the appropriate size.
-	// If set to a positive value that size is used (if the underlying protocol supports it);
-	// otherwise it is ignored.
+	// If set to a positive value that size is used; negative values behaves as `FetchAll` (see below).
 	//
 	// To turn off fetching in batches and always fetch everything, set FetchSize to `FetchAll`.
 	// A limited FetchSize ensures the client is not overflown with records,

--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -169,14 +169,13 @@ type Config struct {
 	// From Bolt protocol v4 (Neo4j 4+) records can be fetched in batches as
 	// compared to fetching all in previous versions.
 	//
-	// If FetchSize is set to FetchDefault, the driver decides the appropriate
+	// If FetchSize is set to `FetchDefault`, the driver decides the appropriate
 	// size. If set to a positive value that size is used if the underlying
 	// protocol supports it otherwise it is ignored.
 	//
 	// To turn off fetching in batches and always fetch everything, set
-	// FetchSize to FetchAll.
-	// If a single large result is to be retrieved, this is the most performant
-	// setting.
+	// FetchSize to `FetchAll`.
+	// `FetchAll` is the most performant setting for results consisting of a single large record.
 	FetchSize int
 	// NotificationsMinSeverity defines the minimum severity level of notifications the server should send.
 	// By default, the server's settings are used.

--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -169,13 +169,13 @@ type Config struct {
 	// From Bolt protocol v4 (Neo4j 4+) records can be fetched in batches as
 	// compared to fetching all in previous versions.
 	//
-	// If FetchSize is set to `FetchDefault`, the driver decides the appropriate
-	// size. If set to a positive value that size is used if the underlying
-	// protocol supports it otherwise it is ignored.
+	// If FetchSize is set to `FetchDefault`, the driver decides the appropriate size.
+	// If set to a positive value that size is used (if the underlying protocol supports it);
+	// otherwise it is ignored.
 	//
-	// To turn off fetching in batches and always fetch everything, set
-	// FetchSize to `FetchAll`.
-	// `FetchAll` is the most performant setting for results consisting of a single large record.
+	// To turn off fetching in batches and always fetch everything, set FetchSize to `FetchAll`.
+	// A limited FetchSize ensures the client is not overflown with records,
+	// and allows to bound memory usage.
 	FetchSize int
 	// NotificationsMinSeverity defines the minimum severity level of notifications the server should send.
 	// By default, the server's settings are used.

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -121,12 +121,12 @@ type SessionConfig struct {
 	//		For older Bolt protocol versions, the behavior is the same as described for the bolt schemes above.
 	DatabaseName string
 	// FetchSize defines how many records to pull from server in each batch.
-	// From Bolt protocol v4 (Neo4j 4+), records can be fetched in batches as
+	// From Bolt protocol v4 (Neo4j 4+) records can be fetched in batches as
 	// compared to fetching all in previous versions.
+	// If the underlying protocol does not support FetchSize, it is ignored.
 	//
 	// If FetchSize is set to `FetchDefault`, the driver decides the appropriate size.
-	// If set to a positive value that size is used (if the underlying protocol supports it);
-	// otherwise it is ignored.
+	// If set to a positive value that size is used; negative values behaves as `FetchAll` (see below).
 	//
 	// To turn off fetching in batches and always fetch everything, set FetchSize to `FetchAll`.
 	// A limited FetchSize ensures the client is not overflown with records,

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -121,14 +121,16 @@ type SessionConfig struct {
 	//		For older Bolt protocol versions, the behavior is the same as described for the bolt schemes above.
 	DatabaseName string
 	// FetchSize defines how many records to pull from server in each batch.
-	// From Bolt protocol v4 (Neo4j 4+) records can be fetched in batches as compared to fetching
-	// all in previous versions.
+	// From Bolt protocol v4 (Neo4j 4+), records can be fetched in batches as
+	// compared to fetching all in previous versions.
 	//
-	// If FetchSize is set to `FetchDefault`, the driver decides the appropriate size. If set to a positive value
-	// that size is used if the underlying protocol supports it otherwise it is ignored.
+	// If FetchSize is set to `FetchDefault`, the driver decides the appropriate size.
+	// If set to a positive value that size is used (if the underlying protocol supports it);
+	// otherwise it is ignored.
 	//
 	// To turn off fetching in batches and always fetch everything, set FetchSize to `FetchAll`.
-	// `FetchAll` is the most performant setting for results consisting of a single large record.
+	// A limited FetchSize ensures the client is not overflown with records,
+	// and allows to bound memory usage.
 	FetchSize int
 	// Logging target the session will send its Bolt message traces
 	//

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -124,11 +124,11 @@ type SessionConfig struct {
 	// From Bolt protocol v4 (Neo4j 4+) records can be fetched in batches as compared to fetching
 	// all in previous versions.
 	//
-	// If FetchSize is set to FetchDefault, the driver decides the appropriate size. If set to a positive value
+	// If FetchSize is set to `FetchDefault`, the driver decides the appropriate size. If set to a positive value
 	// that size is used if the underlying protocol supports it otherwise it is ignored.
 	//
-	// To turn off fetching in batches and always fetch everything, set FetchSize to FetchAll.
-	// If a single large result is to be retrieved this is the most performant setting.
+	// To turn off fetching in batches and always fetch everything, set FetchSize to `FetchAll`.
+	// `FetchAll` is the most performant setting for results consisting of a single large record.
 	FetchSize int
 	// Logging target the session will send its Bolt message traces
 	//


### PR DESCRIPTION
"single large result" is ambiguous, as it refer both to a session used to fetch _one result_ with many records, or  to a session used to fetch many results, each with a single record.