### PR TITLE
Add `GqlStatusObject` support as notifications to `ResultSummary`

### DIFF
--- a/neo4j/config.go
+++ b/neo4j/config.go
@@ -37,20 +37,21 @@ type ServerAddress = config.ServerAddress
 
 func defaultConfig() *Config {
 	return &Config{
-		AddressResolver:                 nil,
-		MaxTransactionRetryTime:         30 * time.Second,
-		MaxConnectionPoolSize:           100,
-		MaxConnectionLifetime:           1 * time.Hour,
-		ConnectionAcquisitionTimeout:    1 * time.Minute,
-		ConnectionLivenessCheckTimeout:  pool.DefaultConnectionLivenessCheckTimeout,
-		SocketConnectTimeout:            5 * time.Second,
-		SocketKeepalive:                 true,
-		RootCAs:                         nil,
-		UserAgent:                       UserAgent,
-		FetchSize:                       FetchDefault,
-		NotificationsMinSeverity:        notifications.DefaultLevel,
-		NotificationsDisabledCategories: notifications.NotificationDisabledCategories{},
-		TelemetryDisabled:               false,
+		AddressResolver:                      nil,
+		MaxTransactionRetryTime:              30 * time.Second,
+		MaxConnectionPoolSize:                100,
+		MaxConnectionLifetime:                1 * time.Hour,
+		ConnectionAcquisitionTimeout:         1 * time.Minute,
+		ConnectionLivenessCheckTimeout:       pool.DefaultConnectionLivenessCheckTimeout,
+		SocketConnectTimeout:                 5 * time.Second,
+		SocketKeepalive:                      true,
+		RootCAs:                              nil,
+		UserAgent:                            UserAgent,
+		FetchSize:                            FetchDefault,
+		NotificationsMinSeverity:             notifications.DefaultLevel,
+		NotificationsDisabledCategories:      notifications.NotificationDisabledCategories{},
+		NotificationsDisabledClassifications: notifications.NotificationDisabledClassifications{},
+		TelemetryDisabled:                    false,
 	}
 }
 
@@ -87,6 +88,12 @@ func validateAndNormaliseConfig(config *Config) error {
 	// Socket Connect Timeout
 	if config.SocketConnectTimeout < 0 {
 		config.SocketConnectTimeout = 0
+	}
+
+	// Check notifications have not been configured with both categories and classifications.
+	if len(config.NotificationsDisabledCategories.DisabledCategories()) > 0 &&
+		len(config.NotificationsDisabledClassifications.DisabledClassifications()) > 0 {
+		return &UsageError{Message: "Notifications cannot be disabled for both categories and classifications at the same time."}
 	}
 
 	return nil

--- a/neo4j/config.go
+++ b/neo4j/config.go
@@ -38,23 +38,22 @@ type ServerAddress = config.ServerAddress
 
 func defaultConfig() *Config {
 	return &Config{
-		AddressResolver:                nil,
-		MaxTransactionRetryTime:        30 * time.Second,
-		MaxConnectionPoolSize:          100,
-		MaxConnectionLifetime:          1 * time.Hour,
-		ConnectionAcquisitionTimeout:   1 * time.Minute,
-		ConnectionLivenessCheckTimeout: pool.DefaultConnectionLivenessCheckTimeout,
-		SocketConnectTimeout:           5 * time.Second,
-		SocketKeepalive:                true,
-		RootCAs:                        nil,
-		UserAgent:                      UserAgent,
-		FetchSize:                      FetchDefault,
-		NotificationsMinSeverity:       notifications.DefaultLevel,
-		//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
+		AddressResolver:                      nil,
+		MaxTransactionRetryTime:              30 * time.Second,
+		MaxConnectionPoolSize:                100,
+		MaxConnectionLifetime:                1 * time.Hour,
+		ConnectionAcquisitionTimeout:         1 * time.Minute,
+		ConnectionLivenessCheckTimeout:       pool.DefaultConnectionLivenessCheckTimeout,
+		SocketConnectTimeout:                 5 * time.Second,
+		SocketKeepalive:                      true,
+		RootCAs:                              nil,
+		UserAgent:                            UserAgent,
+		FetchSize:                            FetchDefault,
+		NotificationsMinSeverity:             notifications.DefaultLevel,
 		NotificationsDisabledCategories:      notifications.NotificationDisabledCategories{},
 		NotificationsDisabledClassifications: notifications.NotificationDisabledClassifications{},
 		TelemetryDisabled:                    false,
-		ReadBufferSize:                  bolt.DefaultReadBufferSize,
+		ReadBufferSize:                       bolt.DefaultReadBufferSize,
 	}
 }
 
@@ -94,7 +93,6 @@ func validateAndNormaliseConfig(config *Config) error {
 	}
 
 	// Check notifications have not been configured with both categories and classifications.
-	//lint:ignore SA1019 NotificationsDisabledCategories and DisabledCategories are supported at least until 6.0
 	if len(config.NotificationsDisabledCategories.DisabledCategories()) > 0 &&
 		len(config.NotificationsDisabledClassifications.DisabledClassifications()) > 0 {
 		return &UsageError{Message: "Notifications cannot be disabled for both categories and classifications at the same time."}

--- a/neo4j/config.go
+++ b/neo4j/config.go
@@ -37,18 +37,19 @@ type ServerAddress = config.ServerAddress
 
 func defaultConfig() *Config {
 	return &Config{
-		AddressResolver:                      nil,
-		MaxTransactionRetryTime:              30 * time.Second,
-		MaxConnectionPoolSize:                100,
-		MaxConnectionLifetime:                1 * time.Hour,
-		ConnectionAcquisitionTimeout:         1 * time.Minute,
-		ConnectionLivenessCheckTimeout:       pool.DefaultConnectionLivenessCheckTimeout,
-		SocketConnectTimeout:                 5 * time.Second,
-		SocketKeepalive:                      true,
-		RootCAs:                              nil,
-		UserAgent:                            UserAgent,
-		FetchSize:                            FetchDefault,
-		NotificationsMinSeverity:             notifications.DefaultLevel,
+		AddressResolver:                nil,
+		MaxTransactionRetryTime:        30 * time.Second,
+		MaxConnectionPoolSize:          100,
+		MaxConnectionLifetime:          1 * time.Hour,
+		ConnectionAcquisitionTimeout:   1 * time.Minute,
+		ConnectionLivenessCheckTimeout: pool.DefaultConnectionLivenessCheckTimeout,
+		SocketConnectTimeout:           5 * time.Second,
+		SocketKeepalive:                true,
+		RootCAs:                        nil,
+		UserAgent:                      UserAgent,
+		FetchSize:                      FetchDefault,
+		NotificationsMinSeverity:       notifications.DefaultLevel,
+		//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
 		NotificationsDisabledCategories:      notifications.NotificationDisabledCategories{},
 		NotificationsDisabledClassifications: notifications.NotificationDisabledClassifications{},
 		TelemetryDisabled:                    false,
@@ -91,6 +92,7 @@ func validateAndNormaliseConfig(config *Config) error {
 	}
 
 	// Check notifications have not been configured with both categories and classifications.
+	//lint:ignore SA1019 NotificationsDisabledCategories and DisabledCategories are supported at least until 6.0
 	if len(config.NotificationsDisabledCategories.DisabledCategories()) > 0 &&
 		len(config.NotificationsDisabledClassifications.DisabledClassifications()) > 0 {
 		return &UsageError{Message: "Notifications cannot be disabled for both categories and classifications at the same time."}

--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -182,10 +182,18 @@ type Config struct {
 	// By default, the server's settings are used.
 	// Disabling severities allows the server to skip analysis for those, which can speed up query execution.
 	NotificationsMinSeverity notifications.NotificationMinimumSeverityLevel
+	// Deprecated: please use NotificationsDisabledClassifications. This will be removed in 6.0.
+	//
 	// NotificationsDisabledCategories defines the categories of notifications the server should not send.
 	// By default, the server's settings are used.
 	// Disabling categories allows the server to skip analysis for those, which can speed up query execution.
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
+	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
+	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.
+	//
+	// NotificationsDisabledClassifications is part of the GQL compliant notifications preview feature
+	// (see README on what it means in terms of support and compatibility guarantees)
+	NotificationsDisabledClassifications notifications.NotificationDisabledClassifications
 	// By default, if the server requests it, the driver will automatically transmit anonymous usage
 	// statistics to the server it is connected to.
 	//

--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -182,13 +182,9 @@ type Config struct {
 	// By default, the server's settings are used.
 	// Disabling severities allows the server to skip analysis for those, which can speed up query execution.
 	NotificationsMinSeverity notifications.NotificationMinimumSeverityLevel
-	// Deprecated: please use NotificationsDisabledClassifications. This will be removed in 6.0.
-	//
 	// NotificationsDisabledCategories defines the categories of notifications the server should not send.
 	// By default, the server's settings are used.
 	// Disabling categories allows the server to skip analysis for those, which can speed up query execution.
-	//
-	//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
 	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
 	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.

--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -187,6 +187,8 @@ type Config struct {
 	// NotificationsDisabledCategories defines the categories of notifications the server should not send.
 	// By default, the server's settings are used.
 	// Disabling categories allows the server to skip analysis for those, which can speed up query execution.
+	//
+	//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
 	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
 	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.

--- a/neo4j/config_test.go
+++ b/neo4j/config_test.go
@@ -18,6 +18,7 @@
 package neo4j
 
 import (
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 	"math"
 	"testing"
 	"time"
@@ -119,6 +120,18 @@ func TestValidateAndNormaliseConfig(rt *testing.T) {
 		}
 		if config.SocketConnectTimeout != 0*time.Nanosecond {
 			t.Errorf("SocketConnectTimeout should be set to (0 * time.Nanosecond) when negative")
+		}
+	})
+
+	rt.Run("Configure both NotificationsDisabledCategories and NotificationsDisabledCategories", func(t *testing.T) {
+		config := defaultConfig()
+
+		config.NotificationsDisabledCategories = notifications.DisableCategories(notifications.Deprecation)
+		config.NotificationsDisabledClassifications = notifications.DisableClassifications(notifications.Deprecation)
+
+		err := validateAndNormaliseConfig(config)
+		if err == nil {
+			t.Errorf("NotificationsDisabledCategories and NotificationsDisabledCategories are configured but no error returned")
 		}
 	})
 }

--- a/neo4j/config_test.go
+++ b/neo4j/config_test.go
@@ -126,7 +126,6 @@ func TestValidateAndNormaliseConfig(rt *testing.T) {
 	rt.Run("Configure both NotificationsDisabledCategories and NotificationsDisabledCategories", func(t *testing.T) {
 		config := defaultConfig()
 
-		//lint:ignore SA1019 NotificationsDisabledCategories and DisableCategories are supported at least until 6.0
 		config.NotificationsDisabledCategories = notifications.DisableCategories(notifications.Deprecation)
 		config.NotificationsDisabledClassifications = notifications.DisableClassifications(notifications.Deprecation)
 

--- a/neo4j/config_test.go
+++ b/neo4j/config_test.go
@@ -126,6 +126,7 @@ func TestValidateAndNormaliseConfig(rt *testing.T) {
 	rt.Run("Configure both NotificationsDisabledCategories and NotificationsDisabledCategories", func(t *testing.T) {
 		config := defaultConfig()
 
+		//lint:ignore SA1019 NotificationsDisabledCategories and DisableCategories are supported at least until 6.0
 		config.NotificationsDisabledCategories = notifications.DisableCategories(notifications.Deprecation)
 		config.NotificationsDisabledClassifications = notifications.DisableClassifications(notifications.Deprecation)
 

--- a/neo4j/db/summary.go
+++ b/neo4j/db/summary.go
@@ -90,6 +90,8 @@ type ProfiledPlan struct {
 	Time              int64
 }
 
+// StreamSummary is part of the GQL compliant notifications preview feature
+// (see README on what it means in terms of support and compatibility guarantees)
 type StreamSummary struct {
 	HadRecord bool
 	HadKey    bool
@@ -104,18 +106,51 @@ type Notification struct {
 	Category    string
 }
 
+// GqlStatusObject represents a GqlStatusObject generated when executing a statement.
+// A GqlStatusObject can be visualized in a client pinpointing problems or other information about the statement.
+// Contrary to failures or errors, GqlStatusObjects do not affect the execution of the statement.
+//
+// GqlStatusObject is part of the GQL compliant notifications preview feature
+// (see README on what it means in terms of support and compatibility guarantees)
 type GqlStatusObject struct {
 	// Deprecated: for backward compatibility with Notification.Code only.
 	Code string
 	// Deprecated: for backward compatibility with Notification.Title only.
-	Title             string
-	GqlStatus         string
+	Title string
+	// GqlStatus returns the GQLSTATUS.
+	// The following GQLSTATUS codes denote codes that the driver will use for
+	// polyfilling (when connected to an old, non-GQL-aware server). Further, they may be used by servers
+	// during the transition-phase to GQLSTATUS-awareness.
+	//   - "01N42" (warning - unknown warning)
+	//   - "02N42" (no data - unknown subcondition)
+	//   - "03N42" (informational - unknown notification)
+	//   - "05N42" (general processing exception - unknown error)
+	//
+	// This means these codes are not guaranteed to be stable and may change in future versions.
+	GqlStatus string
+	// StatusDescription returns a description of the status.
 	StatusDescription string
-	Position          *InputPosition
-	Classification    string
-	Severity          string
-	DiagnosticRecord  map[string]any
-	IsNotification    bool
+	// Position returns the position in the statement where this status points to.
+	// Not all statuses have a unique position to point to and in that case the position would be set to nil.
+	//
+	// Only Notifications (see IsNotification) have a meaningful position.
+	Position *InputPosition
+	// Classification returns the mapped Classification of this status.
+	// If the Classification is not a known value, Classification returns notifications.UnknownClassification.
+	//
+	// Only Notifications (see IsNotification) have a meaningful classification.
+	Classification string
+	// Severity returns the mapped Severity of this status.
+	// If the Severity is not a known value, Severity returns notifications.UnknownSeverity.
+	//
+	// Only Notifications (see IsNotification) have a meaningful severity.
+	Severity string
+	// DiagnosticRecord returns further information about the status for diagnostic purposes.
+	DiagnosticRecord map[string]any
+	// IsNotification returns true if this status is a Notification.
+	//
+	// Only some statuses are Notifications.
+	IsNotification bool
 }
 
 // InputPosition contains information about a specific position in a statement

--- a/neo4j/db/summary.go
+++ b/neo4j/db/summary.go
@@ -99,6 +99,20 @@ type Notification struct {
 	Category    string
 }
 
+type GqlStatusObject struct {
+	// Deprecated: for backward compatibility with Notification.Code only.
+	Code string
+	// Deprecated: for backward compatibility with Notification.Title only.
+	Title             string
+	GqlStatus         string
+	StatusDescription string
+	Position          *InputPosition
+	Classification    string
+	Severity          string
+	DiagnosticRecord  map[string]any
+	IsNotification    bool
+}
+
 // InputPosition contains information about a specific position in a statement
 type InputPosition struct {
 	// Offset contains the character offset referred to by this position; offset numbers start at 0.
@@ -127,6 +141,7 @@ type Summary struct {
 	Plan                  *Plan
 	ProfiledPlan          *ProfiledPlan
 	Notifications         []Notification
+	GqlStatusObjects      []GqlStatusObject
 	Database              string
 	ContainsSystemUpdates *bool
 	ContainsUpdates       *bool

--- a/neo4j/db/summary.go
+++ b/neo4j/db/summary.go
@@ -117,6 +117,8 @@ type GqlStatusObject struct {
 	Code string
 	// Deprecated: for backward compatibility with Notification.Title only.
 	Title string
+	// Deprecated: for backward compatibility with Notification.Description only.
+	Description string
 	// GqlStatus returns the GQLSTATUS.
 	// The following GQLSTATUS codes denote codes that the driver will use for
 	// polyfilling (when connected to an old, non-GQL-aware server). Further, they may be used by servers

--- a/neo4j/db/summary.go
+++ b/neo4j/db/summary.go
@@ -90,6 +90,11 @@ type ProfiledPlan struct {
 	Time              int64
 }
 
+type StreamSummary struct {
+	HadRecord bool
+	HadKey    bool
+}
+
 type Notification struct {
 	Code        string
 	Title       string
@@ -145,4 +150,5 @@ type Summary struct {
 	Database              string
 	ContainsSystemUpdates *bool
 	ContainsUpdates       *bool
+	StreamSummary         StreamSummary
 }

--- a/neo4j/driver_with_context_test.go
+++ b/neo4j/driver_with_context_test.go
@@ -743,6 +743,10 @@ func (sum *fakeSummary) Notifications() []Notification {
 	panic("implement me")
 }
 
+func (sum *fakeSummary) GqlStatusObjects() []GqlStatusObject {
+	panic("implement me")
+}
+
 func (sum *fakeSummary) ResultAvailableAfter() time.Duration {
 	return sum.resultAvailableAfter
 }

--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -652,6 +652,7 @@ func (b *bolt3) receiveNext(ctx context.Context) (*db.Record, *db.Summary, error
 		sum.Minor = b.minor
 		sum.ServerName = b.serverName
 		sum.TFirst = b.currStream.tfirst
+		sum.StreamSummary = b.currStream.ToSummary()
 		b.currStream.sum = sum
 		b.currStream = nil
 		return nil, sum, nil

--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -625,6 +625,7 @@ func (b *bolt3) receiveNext(ctx context.Context) (*db.Record, *db.Summary, error
 	switch message := res.(type) {
 	case *db.Record:
 		message.Keys = b.currStream.keys
+		b.currStream.hadRecord = true
 		return message, nil, nil
 	case *success:
 		// End of stream, parse summary

--- a/neo4j/internal/bolt/bolt3_test.go
+++ b/neo4j/internal/bolt/bolt3_test.go
@@ -1000,4 +1000,70 @@ func TestBolt3(outer *testing.T) {
 			}
 		})
 	}
+
+	outer.Run("StreamSummary tests", func(t *testing.T) {
+		// Test where both HadRecord and HadKey are false - omitted result
+		t.Run("StreamSummary omitted result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt3server) {
+				srv.accept(3)
+				// Simulate a run that returns no keys and no records
+				srv.waitForRun()
+				srv.send(msgSuccess, map[string]any{"fields": []any{}})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertFalse(t, summary.StreamSummary.HadRecord)
+			AssertFalse(t, summary.StreamSummary.HadKey)
+		})
+
+		// Test where both HadRecord and HadKey are true - success result
+		t.Run("StreamSummary success result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt3server) {
+				srv.accept(3)
+				// Simulate a run that returns keys and records
+				srv.waitForRun()
+				srv.send(msgSuccess, map[string]any{"fields": []any{"name"}})
+				srv.send(msgRecord, []any{"John Doe"})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertTrue(t, summary.StreamSummary.HadRecord)
+			AssertTrue(t, summary.StreamSummary.HadKey)
+		})
+
+		// Test where HadRecord is false but HadKey is true - no data result
+		t.Run("StreamSummary no data result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt3server) {
+				srv.accept(3)
+				// Simulate a run that returns keys but no records
+				srv.waitForRun()
+				srv.send(msgSuccess, map[string]any{"fields": []any{"name"}})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertFalse(t, summary.StreamSummary.HadRecord)
+			AssertTrue(t, summary.StreamSummary.HadKey)
+		})
+	})
 }

--- a/neo4j/internal/bolt/bolt3_test.go
+++ b/neo4j/internal/bolt/bolt3_test.go
@@ -201,7 +201,6 @@ func TestBolt3(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
-			//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -221,7 +220,6 @@ func TestBolt3(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
-					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -229,14 +227,12 @@ func TestBolt3(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
-					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
-					//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,

--- a/neo4j/internal/bolt/bolt3_test.go
+++ b/neo4j/internal/bolt/bolt3_test.go
@@ -199,6 +199,7 @@ func TestBolt3(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -218,6 +219,7 @@ func TestBolt3(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -225,12 +227,14 @@ func TestBolt3(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,

--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -1034,6 +1034,9 @@ func (b *bolt4) discardResponseHandler(stream *stream) responseHandler {
 func (b *bolt4) pullResponseHandler(stream *stream) responseHandler {
 	return responseHandler{
 		onRecord: func(record *db.Record) {
+			if record != nil {
+				stream.hadRecord = true
+			}
 			if stream.discarding {
 				stream.emptyRecords()
 			} else {
@@ -1181,6 +1184,7 @@ func (b *bolt4) extractSummary(success *success, stream *stream) *db.Summary {
 	summary.Minor = b.minor
 	summary.ServerName = b.serverName
 	summary.TFirst = stream.tfirst
+	summary.StreamSummary = stream.ToSummary()
 	return summary
 }
 

--- a/neo4j/internal/bolt/bolt4_test.go
+++ b/neo4j/internal/bolt/bolt4_test.go
@@ -420,7 +420,6 @@ func TestBolt4(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
-			//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -440,7 +439,6 @@ func TestBolt4(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
-					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -448,14 +446,12 @@ func TestBolt4(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
-					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
-					//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,

--- a/neo4j/internal/bolt/bolt4_test.go
+++ b/neo4j/internal/bolt/bolt4_test.go
@@ -415,6 +415,7 @@ func TestBolt4(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -434,6 +435,7 @@ func TestBolt4(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -441,12 +443,14 @@ func TestBolt4(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,

--- a/neo4j/internal/bolt/bolt4_test.go
+++ b/neo4j/internal/bolt/bolt4_test.go
@@ -1579,4 +1579,70 @@ func TestBolt4(outer *testing.T) {
 			}
 		})
 	}
+
+	outer.Run("StreamSummary tests", func(t *testing.T) {
+		// Test where both HadRecord and HadKey are false - omitted result
+		t.Run("StreamSummary omitted result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt4server) {
+				srv.accept(4)
+				// Simulate a run that returns no keys and no records
+				srv.waitForRun(nil)
+				srv.send(msgSuccess, map[string]any{"fields": []any{}})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertFalse(t, summary.StreamSummary.HadRecord)
+			AssertFalse(t, summary.StreamSummary.HadKey)
+		})
+
+		// Test where both HadRecord and HadKey are true - success result
+		t.Run("StreamSummary success result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt4server) {
+				srv.accept(4)
+				// Simulate a run that returns keys and records
+				srv.waitForRun(nil)
+				srv.send(msgSuccess, map[string]any{"fields": []any{"name"}})
+				srv.send(msgRecord, []any{"John Doe"})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertTrue(t, summary.StreamSummary.HadRecord)
+			AssertTrue(t, summary.StreamSummary.HadKey)
+		})
+
+		// Test where HadRecord is false but HadKey is true - no data result
+		t.Run("StreamSummary no data result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt4server) {
+				srv.accept(4)
+				// Simulate a run that returns keys but no records
+				srv.waitForRun(nil)
+				srv.send(msgSuccess, map[string]any{"fields": []any{"name"}})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertFalse(t, summary.StreamSummary.HadRecord)
+			AssertTrue(t, summary.StreamSummary.HadKey)
+		})
+	})
 }

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -1052,6 +1052,9 @@ func (b *bolt5) discardResponseHandler(stream *stream) responseHandler {
 func (b *bolt5) pullResponseHandler(stream *stream) responseHandler {
 	return responseHandler{
 		onRecord: func(record *db.Record) {
+			if record != nil {
+				stream.hadRecord = true
+			}
 			if stream.discarding {
 				stream.emptyRecords()
 			} else {
@@ -1190,5 +1193,6 @@ func (b *bolt5) extractSummary(success *success, stream *stream) *db.Summary {
 	summary.Minor = b.minor
 	summary.ServerName = b.serverName
 	summary.TFirst = stream.tfirst
+	summary.StreamSummary = stream.ToSummary()
 	return summary
 }

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -60,7 +60,7 @@ type internalTx5 struct {
 	notificationConfig idb.NotificationConfig
 }
 
-func (i *internalTx5) toMeta(logger log.Logger, logId string, minor int) map[string]any {
+func (i *internalTx5) toMeta(logger log.Logger, logId string, version db.ProtocolVersion) map[string]any {
 	if i == nil {
 		return nil
 	}
@@ -88,7 +88,7 @@ func (i *internalTx5) toMeta(logger log.Logger, logId string, minor int) map[str
 	if i.impersonatedUser != "" {
 		meta["imp_user"] = i.impersonatedUser
 	}
-	i.notificationConfig.ToMeta(meta, minor)
+	i.notificationConfig.ToMeta(meta, version)
 	return meta
 }
 
@@ -270,7 +270,7 @@ func (b *bolt5) Connect(
 	if err := checkNotificationFiltering(notificationConfig, b); err != nil {
 		return err
 	}
-	notificationConfig.ToMeta(hello, b.minor)
+	notificationConfig.ToMeta(hello, b.Version())
 	b.queue.appendHello(hello, b.helloResponseHandler())
 	if b.minor > 0 {
 		b.queue.appendLogon(token.Tokens, b.logonResponseHandler())
@@ -322,7 +322,7 @@ func (b *bolt5) TxBegin(
 		notificationConfig: txConfig.NotificationConfig,
 	}
 
-	b.queue.appendBegin(tx.toMeta(b.log, b.logId, b.minor), b.beginResponseHandler())
+	b.queue.appendBegin(tx.toMeta(b.log, b.logId, b.Version()), b.beginResponseHandler())
 	if syncMessages {
 		if b.queue.send(ctx); b.err != nil {
 			return 0, b.err
@@ -561,7 +561,8 @@ func (b *bolt5) run(ctx context.Context, cypher string, params map[string]any, r
 
 	fetchSize := b.normalizeFetchSize(rawFetchSize)
 	stream := &stream{fetchSize: fetchSize}
-	b.queue.appendRun(cypher, params, tx.toMeta(b.log, b.logId, b.minor), b.runResponseHandler(stream))
+	b.Version()
+	b.queue.appendRun(cypher, params, tx.toMeta(b.log, b.logId, b.Version()), b.runResponseHandler(stream))
 	b.queue.appendPullN(fetchSize, b.pullResponseHandler(stream))
 	if b.queue.send(ctx); b.err != nil {
 		return nil, b.err

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -1921,7 +1921,8 @@ func TestBolt5(outer *testing.T) {
 		outer.Run(test.description, func(t *testing.T) {
 			tx := internalTx5{timeout: test.input}
 
-			actual, ok := tx.toMeta(logger, "")["tx_timeout"]
+			minor := 0
+			actual, ok := tx.toMeta(logger, "", minor)["tx_timeout"]
 			if test.omitted {
 				if ok {
 					t.Errorf("tx_timeout was present but should be omitted")

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -1945,4 +1945,70 @@ func TestBolt5(outer *testing.T) {
 			}
 		})
 	}
+
+	outer.Run("StreamSummary tests", func(t *testing.T) {
+		// Test where both HadRecord and HadKey are false - omitted result
+		t.Run("StreamSummary omitted result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt5server) {
+				srv.accept(5)
+				// Simulate a run that returns no keys and no records
+				srv.waitForRun(nil)
+				srv.send(msgSuccess, map[string]any{"fields": []any{}})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertFalse(t, summary.StreamSummary.HadRecord)
+			AssertFalse(t, summary.StreamSummary.HadKey)
+		})
+
+		// Test where both HadRecord and HadKey are true - success result
+		t.Run("StreamSummary success result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt5server) {
+				srv.accept(5)
+				// Simulate a run that returns keys and records
+				srv.waitForRun(nil)
+				srv.send(msgSuccess, map[string]any{"fields": []any{"name"}})
+				srv.send(msgRecord, []any{"John Doe"})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertTrue(t, summary.StreamSummary.HadRecord)
+			AssertTrue(t, summary.StreamSummary.HadKey)
+		})
+
+		// Test where HadRecord is false but HadKey is true - no data result
+		t.Run("StreamSummary no data result", func(t *testing.T) {
+			bolt, cleanup := connectToServer(t, func(srv *bolt5server) {
+				srv.accept(5)
+				// Simulate a run that returns keys but no records
+				srv.waitForRun(nil)
+				srv.send(msgSuccess, map[string]any{"fields": []any{"name"}})
+				srv.send(msgSuccess, map[string]any{})
+			})
+			defer cleanup()
+			defer bolt.Close(context.Background())
+
+			stream, _ := bolt.Run(context.Background(), idb.Command{Cypher: "MATCH (n) RETURN n"}, idb.TxConfig{Mode: idb.ReadMode})
+			summary, err := bolt.Consume(context.Background(), stream)
+			AssertNoError(t, err)
+
+			// Validate StreamSummary fields
+			AssertFalse(t, summary.StreamSummary.HadRecord)
+			AssertTrue(t, summary.StreamSummary.HadKey)
+		})
+	})
 }

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -563,9 +563,8 @@ func TestBolt5(outer *testing.T) {
 	outer.Run("with notifications", func(inner *testing.T) {
 		warningSev := "WARNING"
 		type testCase struct {
-			description string
-			MinSev      notifications.NotificationMinimumSeverityLevel
-			//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
+			description     string
+			MinSev          notifications.NotificationMinimumSeverityLevel
 			DisCats         notifications.NotificationDisabledCategories
 			ExpectedMinSev  *string
 			ExpectDisCats   bool
@@ -586,17 +585,15 @@ func TestBolt5(outer *testing.T) {
 					Method:         s,
 				},
 				testCase{
-					description: "disabled categories",
-					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
+					description:     "disabled categories",
 					DisCats:         notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{"UNSUPPORTED", "GENERIC"},
 					Method:          s,
 				},
 				testCase{
-					description: "warning minimum severity and disabled categories",
-					MinSev:      notifications.WarningLevel,
-					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
+					description:     "warning minimum severity and disabled categories",
+					MinSev:          notifications.WarningLevel,
 					DisCats:         notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{"UNSUPPORTED", "GENERIC"},
@@ -604,8 +601,7 @@ func TestBolt5(outer *testing.T) {
 					Method:          s,
 				},
 				testCase{
-					description: "disable no categories",
-					//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
+					description:     "disable no categories",
 					DisCats:         notifications.DisableNoCategories(),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{},
@@ -672,7 +668,6 @@ func TestBolt5(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
-			//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -692,7 +687,6 @@ func TestBolt5(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
-					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -700,14 +694,12 @@ func TestBolt5(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
-					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
-					//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,
@@ -1937,9 +1929,8 @@ func TestBolt5(outer *testing.T) {
 	for _, test := range txTimeoutTestCases {
 		outer.Run(test.description, func(t *testing.T) {
 			tx := internalTx5{timeout: test.input}
-
-			minor := 0
-			actual, ok := tx.toMeta(logger, "", minor)["tx_timeout"]
+			version := db.ProtocolVersion{Major: 5, Minor: 0}
+			actual, ok := tx.toMeta(logger, "", version)["tx_timeout"]
 			if test.omitted {
 				if ok {
 					t.Errorf("tx_timeout was present but should be omitted")

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -556,8 +556,9 @@ func TestBolt5(outer *testing.T) {
 	outer.Run("with notifications", func(inner *testing.T) {
 		warningSev := "WARNING"
 		type testCase struct {
-			description     string
-			MinSev          notifications.NotificationMinimumSeverityLevel
+			description string
+			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
 			DisCats         notifications.NotificationDisabledCategories
 			ExpectedMinSev  *string
 			ExpectDisCats   bool
@@ -578,15 +579,17 @@ func TestBolt5(outer *testing.T) {
 					Method:         s,
 				},
 				testCase{
-					description:     "disabled categories",
+					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:         notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{"UNSUPPORTED", "GENERIC"},
 					Method:          s,
 				},
 				testCase{
-					description:     "warning minimum severity and disabled categories",
-					MinSev:          notifications.WarningLevel,
+					description: "warning minimum severity and disabled categories",
+					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:         notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{"UNSUPPORTED", "GENERIC"},
@@ -594,7 +597,8 @@ func TestBolt5(outer *testing.T) {
 					Method:          s,
 				},
 				testCase{
-					description:     "disable no categories",
+					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 					DisCats:         notifications.DisableNoCategories(),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{},
@@ -661,6 +665,7 @@ func TestBolt5(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -680,6 +685,7 @@ func TestBolt5(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -687,12 +693,14 @@ func TestBolt5(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported at least until 6.0
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,

--- a/neo4j/internal/bolt/connect.go
+++ b/neo4j/internal/bolt/connect.go
@@ -37,7 +37,7 @@ type protocolVersion struct {
 
 // Supported versions in priority order
 var versions = [4]protocolVersion{
-	{major: 5, minor: 5, back: 5},
+	{major: 5, minor: 6, back: 6},
 	{major: 4, minor: 4, back: 2},
 	{major: 4, minor: 1},
 	{major: 3, minor: 0},

--- a/neo4j/internal/bolt/connect.go
+++ b/neo4j/internal/bolt/connect.go
@@ -37,7 +37,7 @@ type protocolVersion struct {
 
 // Supported versions in priority order
 var versions = [4]protocolVersion{
-	{major: 5, minor: 4, back: 4},
+	{major: 5, minor: 5, back: 5},
 	{major: 4, minor: 4, back: 2},
 	{major: 4, minor: 1},
 	{major: 3, minor: 0},

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -1035,6 +1035,12 @@ func parseGqlStatusObject(m map[string]any) db.GqlStatusObject {
 		g.Title = title
 	}
 
+	// Backward compatibility support for older Notification API.
+	if description, ok := m["description"].(string); ok {
+		//lint:ignore SA1019 Description is supported at least until 6.0
+		g.Description = description
+	}
+
 	// Initialize the default diagnostic record
 	diagnosticRecord := newDefaultDiagnosticRecord()
 

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -54,6 +54,7 @@ type success struct {
 	num                uint32
 	configurationHints map[string]any
 	patches            []string
+	streamSummary      db.StreamSummary
 }
 
 func (s *success) String() string {
@@ -83,6 +84,7 @@ func (s *success) summary() *db.Summary {
 		Database:              s.db,
 		ContainsSystemUpdates: extractBoolPointer(s.counters, containsSystemUpdatesKey),
 		ContainsUpdates:       extractBoolPointer(s.counters, containsUpdatesKey),
+		StreamSummary:         s.streamSummary,
 	}
 }
 

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -79,6 +79,7 @@ func (s *success) summary() *db.Summary {
 		Plan:                  s.plan,
 		ProfiledPlan:          s.profile,
 		Notifications:         s.notifications,
+		GqlStatusObjects:      s.statuses,
 		Database:              s.db,
 		ContainsSystemUpdates: extractBoolPointer(s.counters, containsSystemUpdatesKey),
 		ContainsUpdates:       extractBoolPointer(s.counters, containsUpdatesKey),

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -1005,6 +1005,14 @@ func parseNotification(m map[string]any) db.Notification {
 	return n
 }
 
+func newDefaultDiagnosticRecord() map[string]any {
+	return map[string]any{
+		"OPERATION":      "",
+		"OPERATION_CODE": "0",
+		"CURRENT_SCHEMA": "/",
+	}
+}
+
 func parseGqlStatusObject(m map[string]any) db.GqlStatusObject {
 	g := db.GqlStatusObject{}
 	g.GqlStatus = m["gql_status"].(string)
@@ -1024,11 +1032,7 @@ func parseGqlStatusObject(m map[string]any) db.GqlStatusObject {
 	}
 
 	// Initialize the default diagnostic record
-	diagnosticRecord := map[string]any{
-		"OPERATION":      "",
-		"OPERATION_CODE": "0",
-		"CURRENT_SCHEMA": "/",
-	}
+	diagnosticRecord := newDefaultDiagnosticRecord()
 
 	// Merge the diagnostic record from the map m
 	if dr, ok := m["diagnostic_record"].(map[string]any); ok {

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -1012,12 +1012,14 @@ func parseGqlStatusObject(m map[string]any) db.GqlStatusObject {
 
 	// Backward compatibility support for deprecated Notification API.
 	if code, found := m["neo4j_code"].(string); found {
+		//lint:ignore SA1019 Code is supported at least until 6.0
 		g.Code = code
 		g.IsNotification = true
 	}
 
 	// Backward compatibility support for deprecated Notification API.
 	if title, found := m["title"].(string); found {
+		//lint:ignore SA1019 Title is supported at least until 6.0
 		g.Title = title
 	}
 

--- a/neo4j/internal/bolt/hydrator_test.go
+++ b/neo4j/internal/bolt/hydrator_test.go
@@ -329,15 +329,17 @@ func TestHydrator(outer *testing.T) {
 				packer.String("sys")
 				packer.String("statuses") // Array
 				packer.ArrayHeader(2)
-				packer.MapHeader(5) // GqlStatusObject map
+				packer.MapHeader(6) // GqlStatusObject map
 				packer.String("gql_status")
 				packer.String("g1")
 				packer.String("status_description")
-				packer.String("d1")
+				packer.String("sd1")
 				packer.String("neo4j_code")
 				packer.String("n1")
 				packer.String("title")
 				packer.String("t1")
+				packer.String("description")
+				packer.String("d1")
 				packer.String("diagnostic_record") // Array
 				packer.MapHeader(3)                // Diagnostic Record map
 				packer.String("_severity")
@@ -356,15 +358,16 @@ func TestHydrator(outer *testing.T) {
 				packer.String("gql_status")
 				packer.String("g2")
 				packer.String("status_description")
-				packer.String("d2")
+				packer.String("sd2")
 			},
 			x: &success{tlast: -1, tfirst: -1, bookmark: "bm", db: "sys", qid: -1, num: 4,
 				statuses: []db.GqlStatusObject{
 					{
 						Code:              "n1",
 						Title:             "t1",
+						Description:       "d1",
 						GqlStatus:         "g1",
-						StatusDescription: "d1",
+						StatusDescription: "sd1",
 						Position:          &db.InputPosition{Offset: 1, Line: 2, Column: 3},
 						Classification:    "c1",
 						Severity:          "s1",
@@ -373,7 +376,7 @@ func TestHydrator(outer *testing.T) {
 					},
 					{
 						GqlStatus:         "g2",
-						StatusDescription: "d2",
+						StatusDescription: "sd2",
 						DiagnosticRecord:  newDefaultDiagnosticRecord(),
 						IsNotification:    false,
 					},

--- a/neo4j/internal/bolt/notifications.go
+++ b/neo4j/internal/bolt/notifications.go
@@ -28,7 +28,8 @@ func checkNotificationFiltering(
 	bolt idb.Connection,
 ) error {
 	if notificationConfig.MinSev == notifications.DefaultLevel &&
-		!notificationConfig.DisCats.DisablesNone() && len(notificationConfig.DisCats.DisabledCategories()) == 0 {
+		!notificationConfig.DisCats.DisablesNone() && len(notificationConfig.DisCats.DisabledCategories()) == 0 &&
+		!notificationConfig.DisClas.DisablesNone() && len(notificationConfig.DisClas.DisabledClassifications()) == 0 {
 		return nil
 	}
 	version := bolt.Version()

--- a/neo4j/internal/bolt/notifications.go
+++ b/neo4j/internal/bolt/notifications.go
@@ -28,6 +28,7 @@ func checkNotificationFiltering(
 	bolt idb.Connection,
 ) error {
 	if notificationConfig.MinSev == notifications.DefaultLevel &&
+		//lint:ignore SA1019 DisablesNone and DisabledCategories are supported at least until 6.0
 		!notificationConfig.DisCats.DisablesNone() && len(notificationConfig.DisCats.DisabledCategories()) == 0 &&
 		!notificationConfig.DisClas.DisablesNone() && len(notificationConfig.DisClas.DisabledClassifications()) == 0 {
 		return nil

--- a/neo4j/internal/bolt/notifications.go
+++ b/neo4j/internal/bolt/notifications.go
@@ -28,7 +28,6 @@ func checkNotificationFiltering(
 	bolt idb.Connection,
 ) error {
 	if notificationConfig.MinSev == notifications.DefaultLevel &&
-		//lint:ignore SA1019 DisablesNone and DisabledCategories are supported at least until 6.0
 		!notificationConfig.DisCats.DisablesNone() && len(notificationConfig.DisCats.DisabledCategories()) == 0 &&
 		!notificationConfig.DisClas.DisablesNone() && len(notificationConfig.DisClas.DisabledClassifications()) == 0 {
 		return nil

--- a/neo4j/internal/bolt/stream.go
+++ b/neo4j/internal/bolt/stream.go
@@ -38,6 +38,7 @@ type stream struct {
 	endOfBatch bool
 	discarding bool
 	tfirst     int64 // Time that server started streaming
+	hadRecord  bool
 }
 
 // Acts on buffered data, first return value indicates if buffering
@@ -75,6 +76,13 @@ func (s *stream) Err() error {
 
 func (s *stream) push(rec *db.Record) {
 	s.fifo.PushBack(rec)
+}
+
+func (s *stream) ToSummary() db.StreamSummary {
+	return db.StreamSummary{
+		HadRecord: s.hadRecord,
+		HadKey:    len(s.keys) > 0,
+	}
 }
 
 // Only need to keep track of current stream. Client keeps track of other

--- a/neo4j/internal/connector/connector.go
+++ b/neo4j/internal/connector/connector.go
@@ -69,7 +69,8 @@ func (c Connector) Connect(
 	}()
 
 	notificationConfig := db.NotificationConfig{
-		MinSev:  c.Config.NotificationsMinSeverity,
+		MinSev: c.Config.NotificationsMinSeverity,
+		//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
 		DisCats: c.Config.NotificationsDisabledCategories,
 		DisClas: c.Config.NotificationsDisabledClassifications,
 	}

--- a/neo4j/internal/connector/connector.go
+++ b/neo4j/internal/connector/connector.go
@@ -71,6 +71,7 @@ func (c Connector) Connect(
 	notificationConfig := db.NotificationConfig{
 		MinSev:  c.Config.NotificationsMinSeverity,
 		DisCats: c.Config.NotificationsDisabledCategories,
+		DisClas: c.Config.NotificationsDisabledClassifications,
 	}
 
 	// TLS not requested

--- a/neo4j/internal/connector/connector.go
+++ b/neo4j/internal/connector/connector.go
@@ -69,8 +69,7 @@ func (c Connector) Connect(
 	}()
 
 	notificationConfig := db.NotificationConfig{
-		MinSev: c.Config.NotificationsMinSeverity,
-		//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
+		MinSev:  c.Config.NotificationsMinSeverity,
 		DisCats: c.Config.NotificationsDisabledCategories,
 		DisClas: c.Config.NotificationsDisabledClassifications,
 	}

--- a/neo4j/internal/db/connection.go
+++ b/neo4j/internal/db/connection.go
@@ -59,7 +59,8 @@ type TxConfig struct {
 }
 
 type NotificationConfig struct {
-	MinSev  notifications.NotificationMinimumSeverityLevel
+	MinSev notifications.NotificationMinimumSeverityLevel
+	//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
 	DisCats notifications.NotificationDisabledCategories
 	DisClas notifications.NotificationDisabledClassifications
 }
@@ -73,11 +74,13 @@ func (n *NotificationConfig) ToMeta(meta map[string]any, minor int) {
 	if minor >= 5 {
 		disabledKey = "notifications_disabled_classifications"
 	}
-
+	//lint:ignore SA1019 DisablesNone is supported at least until 6.0
 	if n.DisCats.DisablesNone() || n.DisClas.DisablesNone() {
 		meta[disabledKey] = make([]string, 0)
 	} else {
+		//lint:ignore SA1019 DisabledCategories is supported at least until 6.0
 		if len(n.DisCats.DisabledCategories()) > 0 {
+			//lint:ignore SA1019 DisabledCategories is supported at least until 6.0
 			meta[disabledKey] = n.DisCats.DisabledCategories()
 		}
 		if len(n.DisClas.DisabledClassifications()) > 0 {

--- a/neo4j/internal/db/connection.go
+++ b/neo4j/internal/db/connection.go
@@ -59,28 +59,24 @@ type TxConfig struct {
 }
 
 type NotificationConfig struct {
-	MinSev notifications.NotificationMinimumSeverityLevel
-	//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
+	MinSev  notifications.NotificationMinimumSeverityLevel
 	DisCats notifications.NotificationDisabledCategories
 	DisClas notifications.NotificationDisabledClassifications
 }
 
-func (n *NotificationConfig) ToMeta(meta map[string]any, minor int) {
+func (n *NotificationConfig) ToMeta(meta map[string]any, version db.ProtocolVersion) {
 	if n.MinSev != notifications.DefaultLevel {
 		meta["notifications_minimum_severity"] = string(n.MinSev)
 	}
 
 	disabledKey := "notifications_disabled_categories"
-	if minor >= 5 {
+	if version.Minor >= 5 {
 		disabledKey = "notifications_disabled_classifications"
 	}
-	//lint:ignore SA1019 DisablesNone is supported at least until 6.0
 	if n.DisCats.DisablesNone() || n.DisClas.DisablesNone() {
 		meta[disabledKey] = make([]string, 0)
 	} else {
-		//lint:ignore SA1019 DisabledCategories is supported at least until 6.0
 		if len(n.DisCats.DisabledCategories()) > 0 {
-			//lint:ignore SA1019 DisabledCategories is supported at least until 6.0
 			meta[disabledKey] = n.DisCats.DisabledCategories()
 		}
 		if len(n.DisClas.DisabledClassifications()) > 0 {

--- a/neo4j/internal/db/connection.go
+++ b/neo4j/internal/db/connection.go
@@ -61,22 +61,27 @@ type TxConfig struct {
 type NotificationConfig struct {
 	MinSev  notifications.NotificationMinimumSeverityLevel
 	DisCats notifications.NotificationDisabledCategories
+	DisClas notifications.NotificationDisabledClassifications
 }
 
-func (n *NotificationConfig) ToMeta(meta map[string]any) {
+func (n *NotificationConfig) ToMeta(meta map[string]any, minor int) {
 	if n.MinSev != notifications.DefaultLevel {
 		meta["notifications_minimum_severity"] = string(n.MinSev)
 	}
-	if n.DisCats.DisablesNone() {
-		meta["notifications_disabled_categories"] = make([]string, 0)
+
+	disabledKey := "notifications_disabled_categories"
+	if minor >= 5 {
+		disabledKey = "notifications_disabled_classifications"
+	}
+
+	if n.DisCats.DisablesNone() || n.DisClas.DisablesNone() {
+		meta[disabledKey] = make([]string, 0)
 	} else {
-		notiDisCatsSlice := n.DisCats.DisabledCategories()
-		if len(notiDisCatsSlice) != 0 {
-			notiDisCatsStrSlice := make([]string, len(notiDisCatsSlice))
-			for i, v := range notiDisCatsSlice {
-				notiDisCatsStrSlice[i] = string(v)
-			}
-			meta["notifications_disabled_categories"] = notiDisCatsSlice
+		if len(n.DisCats.DisabledCategories()) > 0 {
+			meta[disabledKey] = n.DisCats.DisabledCategories()
+		}
+		if len(n.DisClas.DisabledClassifications()) > 0 {
+			meta[disabledKey] = n.DisClas.DisabledClassifications()
 		}
 	}
 }

--- a/neo4j/internal/notifications/notifications.go
+++ b/neo4j/internal/notifications/notifications.go
@@ -1,0 +1,124 @@
+package notifications
+
+import (
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
+)
+
+func newDefaultDiagnosticRecord() map[string]any {
+	return map[string]any{
+		"OPERATION":      "",
+		"OPERATION_CODE": "0",
+		"CURRENT_SCHEMA": "/",
+	}
+}
+
+func newSuccessGqlStatusObject() *db.GqlStatusObject {
+	return &db.GqlStatusObject{
+		GqlStatus:         "00000",
+		StatusDescription: "note: successful completion",
+		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+	}
+}
+
+func newNoDataGqlStatusObject() *db.GqlStatusObject {
+	return &db.GqlStatusObject{
+		GqlStatus:         "02000",
+		StatusDescription: "note: no data",
+		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+	}
+}
+
+func newOmittedResultGqlStatusObject() *db.GqlStatusObject {
+	return &db.GqlStatusObject{
+		GqlStatus:         "00001",
+		StatusDescription: "note: successful completion - omitted result",
+		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+	}
+}
+
+func newUnknownWarningResultGqlStatusObject() *db.GqlStatusObject {
+	return &db.GqlStatusObject{
+		GqlStatus:         "01N42",
+		StatusDescription: "warn: unknown warning",
+		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+	}
+}
+
+func newUnknownInformationResultGqlStatusObject() *db.GqlStatusObject {
+	return &db.GqlStatusObject{
+		GqlStatus:         "03N42",
+		StatusDescription: "info: unknown notification",
+		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+	}
+}
+
+// ToNotification returns a db.Notification that corresponds to the given db.GqlStatusObject.
+// It maps fields from the status to their respective notification fields.
+func ToNotification(gqlStatusObject db.GqlStatusObject) *db.Notification {
+	return &db.Notification{
+		//lint:ignore SA1019 Code is supported at least until 6.0
+		Code: gqlStatusObject.Code,
+		//lint:ignore SA1019 Title is supported at least until 6.0
+		Title:       gqlStatusObject.Title,
+		Description: gqlStatusObject.StatusDescription,
+		Position:    gqlStatusObject.Position,
+		Severity:    gqlStatusObject.Severity,
+		Category:    gqlStatusObject.Classification,
+	}
+}
+
+// ToGqlStatusObject returns a db.GqlStatusObject that corresponds to the given db.Notification.
+// It maps fields from the notification to their respective status fields.
+func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
+	var defaultStatus *db.GqlStatusObject
+	if notification.Severity == string(notifications.Warning) {
+		defaultStatus = newUnknownWarningResultGqlStatusObject()
+	} else {
+		defaultStatus = newUnknownInformationResultGqlStatusObject()
+	}
+
+	statusDescription := notification.Description
+	if statusDescription == "" {
+		statusDescription = defaultStatus.StatusDescription
+	}
+
+	diagnosticRecord := newDefaultDiagnosticRecord()
+
+	if notification.Position != nil {
+		diagnosticRecord["_position"] = map[string]any{
+			"offset": notification.Position.Offset,
+			"line":   notification.Position.Line,
+			"column": notification.Position.Column,
+		}
+	}
+	if notification.Severity != "" {
+		diagnosticRecord["_severity"] = notification.Severity
+	}
+	if notification.Category != "" {
+		diagnosticRecord["_classification"] = notification.Category
+	}
+
+	return &db.GqlStatusObject{
+		Code:              notification.Code,
+		Title:             notification.Title,
+		GqlStatus:         defaultStatus.GqlStatus,
+		StatusDescription: statusDescription,
+		Position:          notification.Position,
+		Classification:    notification.Category,
+		Severity:          notification.Severity,
+		DiagnosticRecord:  diagnosticRecord,
+		IsNotification:    true,
+	}
+}
+
+// ToGqlStatusObjectFromSummary creates a new db.GqlStatusObject based on the context of the db.StreamSummary.
+func ToGqlStatusObjectFromSummary(summary db.StreamSummary) *db.GqlStatusObject {
+	if summary.HadRecord {
+		return newSuccessGqlStatusObject()
+	} else if summary.HadKey {
+		return newNoDataGqlStatusObject()
+	} else {
+		return newOmittedResultGqlStatusObject()
+	}
+}

--- a/neo4j/internal/notifications/notifications.go
+++ b/neo4j/internal/notifications/notifications.go
@@ -60,8 +60,9 @@ func ToNotification(gqlStatusObject db.GqlStatusObject) *db.Notification {
 		//lint:ignore SA1019 Code is supported at least until 6.0
 		Code: gqlStatusObject.Code,
 		//lint:ignore SA1019 Title is supported at least until 6.0
-		Title:       gqlStatusObject.Title,
-		Description: gqlStatusObject.StatusDescription,
+		Title: gqlStatusObject.Title,
+		//lint:ignore SA1019 Description is supported at least until 6.0
+		Description: gqlStatusObject.Description,
 		Position:    gqlStatusObject.Position,
 		Severity:    gqlStatusObject.Severity,
 		Category:    gqlStatusObject.Classification,
@@ -102,6 +103,7 @@ func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
 	return &db.GqlStatusObject{
 		Code:              notification.Code,
 		Title:             notification.Title,
+		Description:       notification.Description,
 		GqlStatus:         defaultStatus.GqlStatus,
 		StatusDescription: statusDescription,
 		Position:          notification.Position,

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -26,9 +26,8 @@ type NotificationCategory string
 
 // NotificationClassification is part of the GQL compliant notifications preview feature
 // (see README on what it means in terms of support and compatibility guarantees)
-type NotificationClassification string
+type NotificationClassification = NotificationCategory
 
-// TODO do these need deprecated individually?
 const (
 	Hint         NotificationCategory = "HINT"
 	Unrecognized NotificationCategory = "UNRECOGNIZED"
@@ -40,20 +39,26 @@ const (
 	Security NotificationCategory = "SECURITY"
 	// Topology requires server version 5.14 or newer.
 	Topology NotificationCategory = "TOPOLOGY"
+	Unknown  NotificationCategory = "UNKNOWN"
 )
 
+type NotificationSeverity string
+
 const (
-	HintClassification         NotificationClassification = "HINT"
-	UnrecognizedClassification NotificationClassification = "UNRECOGNIZED"
-	UnsupportedClassification  NotificationClassification = "UNSUPPORTED"
-	PerformanceClassification  NotificationClassification = "PERFORMANCE"
-	DeprecationClassification  NotificationClassification = "DEPRECATION"
-	GenericClassification      NotificationClassification = "GENERIC"
-	// SecurityClassification requires server version 5.14 or newer.
-	SecurityClassification NotificationClassification = "SECURITY"
-	// TopologyClassification requires server version 5.14 or newer.
-	TopologyClassification NotificationClassification = "TOPOLOGY"
-	UnknownClassification  NotificationClassification = "UNKNOWN"
+	Warning         NotificationSeverity = "WARNING"
+	Information     NotificationSeverity = "INFORMATION"
+	UnknownSeverity NotificationSeverity = "UNKNOWN"
+)
+
+// NotificationMinimumSeverityLevel defines the minimum severity level of notifications the server should send.
+// Can be used for NotificationsMinSeverity of config.Config and config.SessionConfig.
+type NotificationMinimumSeverityLevel string
+
+const (
+	DefaultLevel     NotificationMinimumSeverityLevel = ""
+	DisabledLevel    NotificationMinimumSeverityLevel = "OFF"
+	WarningLevel     NotificationMinimumSeverityLevel = "WARNING"
+	InformationLevel NotificationMinimumSeverityLevel = "INFORMATION"
 )
 
 // Deprecated: please use notifications.NotificationDisabledClassifications. This will be removed in 6.0.
@@ -118,17 +123,6 @@ func (n *NotificationDisabledCategories) DisabledCategories() []NotificationCate
 func (n *NotificationDisabledClassifications) DisabledClassifications() []NotificationClassification {
 	return n.classifications
 }
-
-// NotificationMinimumSeverityLevel defines the minimum severity level of notifications the server should send.
-// Can be used for NotificationsMinSeverity of config.Config and config.SessionConfig.
-type NotificationMinimumSeverityLevel string
-
-const (
-	DefaultLevel     NotificationMinimumSeverityLevel = ""
-	DisabledLevel    NotificationMinimumSeverityLevel = "OFF"
-	WarningLevel     NotificationMinimumSeverityLevel = "WARNING"
-	InformationLevel NotificationMinimumSeverityLevel = "INFORMATION"
-)
 
 // ToNotification returns a db.Notification that corresponds to the given db.GqlStatusObject.
 // It maps fields from the status to their respective notification fields.

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -191,7 +191,7 @@ func newUnknownInformationResultGqlStatusObject() *db.GqlStatusObject {
 // It maps fields from the notification to their respective status fields.
 func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
 	var defaultStatus *db.GqlStatusObject
-	if notification.Severity == string(WarningLevel) {
+	if notification.Severity == string(Warning) {
 		defaultStatus = newUnknownWarningResultGqlStatusObject()
 	} else {
 		defaultStatus = newUnknownInformationResultGqlStatusObject()

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -128,7 +128,9 @@ func (n *NotificationDisabledClassifications) DisabledClassifications() []Notifi
 // It maps fields from the status to their respective notification fields.
 func ToNotification(gqlStatusObject db.GqlStatusObject) *db.Notification {
 	return &db.Notification{
-		Code:        gqlStatusObject.Code,
+		//lint:ignore SA1019 Code is supported at least until 6.0
+		Code: gqlStatusObject.Code,
+		//lint:ignore SA1019 Title is supported at least until 6.0
 		Title:       gqlStatusObject.Title,
 		Description: gqlStatusObject.StatusDescription,
 		Position:    gqlStatusObject.Position,

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -202,8 +202,12 @@ func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
 	if notification.Position != nil {
 		diagnosticRecord["_position"] = notification.Position
 	}
-	diagnosticRecord["_classification"] = notification.Category
-	diagnosticRecord["_severity"] = notification.Severity
+	if notification.Severity != "" {
+		diagnosticRecord["_severity"] = notification.Severity
+	}
+	if notification.Category != "" {
+		diagnosticRecord["_classification"] = notification.Category
+	}
 
 	return &db.GqlStatusObject{
 		Code:              notification.Code,

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -17,11 +17,6 @@
 
 package notifications
 
-import (
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
-)
-
-// Deprecated: please use NotificationClassification. This will be removed in 6.0.
 type NotificationCategory string
 
 // NotificationClassification is part of the GQL compliant notifications preview feature
@@ -61,19 +56,18 @@ const (
 	InformationLevel NotificationMinimumSeverityLevel = "INFORMATION"
 )
 
-// Deprecated: please use notifications.NotificationDisabledClassifications. This will be removed in 6.0.
 type NotificationDisabledCategories struct {
 	categories []NotificationCategory
 	none       bool
 }
 
+// NotificationDisabledClassifications is part of the GQL compliant notifications preview feature
+// (see README on what it means in terms of support and compatibility guarantees)
 type NotificationDisabledClassifications struct {
 	classifications []NotificationClassification
 	none            bool
 }
 
-// Deprecated: please use DisableClassifications. This will be removed in 6.0.
-//
 // DisableCategories creates a NotificationDisabledCategories that disables the given categories.
 // Can be used for NotificationsDisabledCategories of config.Config and config.SessionConfig.
 func DisableCategories(value ...NotificationCategory) NotificationDisabledCategories {
@@ -82,12 +76,13 @@ func DisableCategories(value ...NotificationCategory) NotificationDisabledCatego
 
 // DisableClassifications creates a NotificationDisabledClassifications that disables the given classifications.
 // Can be used for NotificationsDisabledClassifications of config.Config and config.SessionConfig.
+//
+// DisableClassifications is part of the GQL compliant notifications preview feature
+// (see README on what it means in terms of support and compatibility guarantees)
 func DisableClassifications(value ...NotificationClassification) NotificationDisabledClassifications {
 	return NotificationDisabledClassifications{value, false}
 }
 
-// Deprecated: please use DisableNoClassifications. This will be removed in 6.0.
-//
 // DisableNoCategories creates a NotificationDisabledCategories that enables all categories.
 // Can be used for NotificationsDisabledCategories of neo4j.Config and neo4j.SessionConfig.
 func DisableNoCategories() NotificationDisabledCategories {
@@ -96,144 +91,35 @@ func DisableNoCategories() NotificationDisabledCategories {
 
 // DisableNoClassifications creates a NotificationDisabledClassifications that enables all classifications.
 // Can be used for NotificationsDisabledClassifications of neo4j.Config and neo4j.SessionConfig.
+//
+// DisableNoClassifications is part of the GQL compliant notifications preview feature
+// (see README on what it means in terms of support and compatibility guarantees)
 func DisableNoClassifications() NotificationDisabledClassifications {
 	return NotificationDisabledClassifications{nil, true}
 }
 
-// Deprecated: please use NotificationDisabledClassifications.DisablesNone. This will be removed in 6.0.
-//
 // DisablesNone returns true if all categories are enabled.
 func (n *NotificationDisabledCategories) DisablesNone() bool {
 	return n.none
 }
 
 // DisablesNone returns true if all classifications are enabled.
+//
+// DisablesNone is part of the GQL compliant notifications preview feature
+// (see README on what it means in terms of support and compatibility guarantees)
 func (n *NotificationDisabledClassifications) DisablesNone() bool {
 	return n.none
 }
 
-// Deprecated: please use NotificationDisabledClassifications.DisabledClassifications. This will be removed in 6.0.
-//
 // DisabledCategories returns the categories that are disabled.
 func (n *NotificationDisabledCategories) DisabledCategories() []NotificationCategory {
 	return n.categories
 }
 
 // DisabledClassifications returns the classifications that are disabled.
+//
+// DisabledClassifications is part of the GQL compliant notifications preview feature
+// (see README on what it means in terms of support and compatibility guarantees)
 func (n *NotificationDisabledClassifications) DisabledClassifications() []NotificationClassification {
 	return n.classifications
-}
-
-// ToNotification returns a db.Notification that corresponds to the given db.GqlStatusObject.
-// It maps fields from the status to their respective notification fields.
-func ToNotification(gqlStatusObject db.GqlStatusObject) *db.Notification {
-	return &db.Notification{
-		//lint:ignore SA1019 Code is supported at least until 6.0
-		Code: gqlStatusObject.Code,
-		//lint:ignore SA1019 Title is supported at least until 6.0
-		Title:       gqlStatusObject.Title,
-		Description: gqlStatusObject.StatusDescription,
-		Position:    gqlStatusObject.Position,
-		Severity:    gqlStatusObject.Severity,
-		Category:    gqlStatusObject.Classification,
-	}
-}
-
-func newDefaultDiagnosticRecord() map[string]any {
-	return map[string]any{
-		"OPERATION":      "",
-		"OPERATION_CODE": "0",
-		"CURRENT_SCHEMA": "/",
-	}
-}
-
-func newSuccessGqlStatusObject() *db.GqlStatusObject {
-	return &db.GqlStatusObject{
-		GqlStatus:         "00000",
-		StatusDescription: "note: successful completion",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
-	}
-}
-
-func newNoDataGqlStatusObject() *db.GqlStatusObject {
-	return &db.GqlStatusObject{
-		GqlStatus:         "02000",
-		StatusDescription: "note: no data",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
-	}
-}
-
-func newOmittedResultGqlStatusObject() *db.GqlStatusObject {
-	return &db.GqlStatusObject{
-		GqlStatus:         "00001",
-		StatusDescription: "note: successful completion - omitted result",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
-	}
-}
-
-func newUnknownWarningResultGqlStatusObject() *db.GqlStatusObject {
-	return &db.GqlStatusObject{
-		GqlStatus:         "01N42",
-		StatusDescription: "warn: unknown warning",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
-	}
-}
-
-func newUnknownInformationResultGqlStatusObject() *db.GqlStatusObject {
-	return &db.GqlStatusObject{
-		GqlStatus:         "03N42",
-		StatusDescription: "info: unknown notification",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
-	}
-}
-
-// ToGqlStatusObject returns a db.GqlStatusObject that corresponds to the given db.Notification.
-// It maps fields from the notification to their respective status fields.
-func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
-	var defaultStatus *db.GqlStatusObject
-	if notification.Severity == string(Warning) {
-		defaultStatus = newUnknownWarningResultGqlStatusObject()
-	} else {
-		defaultStatus = newUnknownInformationResultGqlStatusObject()
-	}
-
-	statusDescription := notification.Description
-	if statusDescription == "" {
-		statusDescription = defaultStatus.StatusDescription
-	}
-
-	diagnosticRecord := newDefaultDiagnosticRecord()
-
-	if notification.Position != nil {
-		diagnosticRecord["_position"] = notification.Position
-	}
-	if notification.Severity != "" {
-		diagnosticRecord["_severity"] = notification.Severity
-	}
-	if notification.Category != "" {
-		diagnosticRecord["_classification"] = notification.Category
-	}
-
-	return &db.GqlStatusObject{
-		Code:              notification.Code,
-		Title:             notification.Title,
-		GqlStatus:         defaultStatus.GqlStatus,
-		StatusDescription: statusDescription,
-		Position:          notification.Position,
-		Classification:    notification.Category,
-		Severity:          notification.Severity,
-		DiagnosticRecord:  diagnosticRecord,
-		IsNotification:    true,
-	}
-}
-
-// ToGqlStatusObjectFromSummary creates a new db.GqlStatusObject based on the context of the db.StreamSummary.
-func ToGqlStatusObjectFromSummary(summary db.StreamSummary) *db.GqlStatusObject {
-	if summary.HadRecord {
-		return newSuccessGqlStatusObject()
-	} else if summary.HadKey {
-		return newNoDataGqlStatusObject()
-	} else {
-		return newOmittedResultGqlStatusObject()
-	}
 }

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -75,7 +75,7 @@ type NotificationDisabledClassifications struct {
 // Deprecated: please use DisableClassifications. This will be removed in 6.0.
 //
 // DisableCategories creates a NotificationDisabledCategories that disables the given categories.
-// Can be used for NotificationDisabledClassifications of config.Config and config.SessionConfig.
+// Can be used for NotificationsDisabledCategories of config.Config and config.SessionConfig.
 func DisableCategories(value ...NotificationCategory) NotificationDisabledCategories {
 	return NotificationDisabledCategories{value, false}
 }
@@ -107,7 +107,7 @@ func (n *NotificationDisabledCategories) DisablesNone() bool {
 	return n.none
 }
 
-// DisablesNone returns true if all categories are enabled.
+// DisablesNone returns true if all classifications are enabled.
 func (n *NotificationDisabledClassifications) DisablesNone() bool {
 	return n.none
 }

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -17,8 +17,18 @@
 
 package notifications
 
+import (
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+)
+
+// Deprecated: please use NotificationClassification. This will be removed in 6.0.
 type NotificationCategory string
 
+// NotificationClassification is part of the GQL compliant notifications preview feature
+// (see README on what it means in terms of support and compatibility guarantees)
+type NotificationClassification string
+
+// TODO do these need deprecated individually?
 const (
 	Hint         NotificationCategory = "HINT"
 	Unrecognized NotificationCategory = "UNRECOGNIZED"
@@ -32,31 +42,81 @@ const (
 	Topology NotificationCategory = "TOPOLOGY"
 )
 
+const (
+	HintClassification         NotificationClassification = "HINT"
+	UnrecognizedClassification NotificationClassification = "UNRECOGNIZED"
+	UnsupportedClassification  NotificationClassification = "UNSUPPORTED"
+	PerformanceClassification  NotificationClassification = "PERFORMANCE"
+	DeprecationClassification  NotificationClassification = "DEPRECATION"
+	GenericClassification      NotificationClassification = "GENERIC"
+	// SecurityClassification requires server version 5.14 or newer.
+	SecurityClassification NotificationClassification = "SECURITY"
+	// TopologyClassification requires server version 5.14 or newer.
+	TopologyClassification NotificationClassification = "TOPOLOGY"
+	UnknownClassification  NotificationClassification = "UNKNOWN"
+)
+
+// Deprecated: please use notifications.NotificationDisabledClassifications. This will be removed in 6.0.
 type NotificationDisabledCategories struct {
 	categories []NotificationCategory
 	none       bool
 }
 
+type NotificationDisabledClassifications struct {
+	classifications []NotificationClassification
+	none            bool
+}
+
+// Deprecated: please use DisableClassifications. This will be removed in 6.0.
+//
 // DisableCategories creates a NotificationDisabledCategories that disables the given categories.
-// Can be used for NotificationsDisabledCategories of config.Config and config.SessionConfig.
+// Can be used for NotificationDisabledClassifications of config.Config and config.SessionConfig.
 func DisableCategories(value ...NotificationCategory) NotificationDisabledCategories {
 	return NotificationDisabledCategories{value, false}
 }
 
+// DisableClassifications creates a NotificationDisabledClassifications that disables the given classifications.
+// Can be used for NotificationsDisabledClassifications of config.Config and config.SessionConfig.
+func DisableClassifications(value ...NotificationClassification) NotificationDisabledClassifications {
+	return NotificationDisabledClassifications{value, false}
+}
+
+// Deprecated: please use DisableNoClassifications. This will be removed in 6.0.
+//
 // DisableNoCategories creates a NotificationDisabledCategories that enables all categories.
 // Can be used for NotificationsDisabledCategories of neo4j.Config and neo4j.SessionConfig.
 func DisableNoCategories() NotificationDisabledCategories {
 	return NotificationDisabledCategories{nil, true}
 }
 
+// DisableNoClassifications creates a NotificationDisabledClassifications that enables all classifications.
+// Can be used for NotificationsDisabledClassifications of neo4j.Config and neo4j.SessionConfig.
+func DisableNoClassifications() NotificationDisabledClassifications {
+	return NotificationDisabledClassifications{nil, true}
+}
+
+// Deprecated: please use NotificationDisabledClassifications.DisablesNone. This will be removed in 6.0.
+//
 // DisablesNone returns true if all categories are enabled.
 func (n *NotificationDisabledCategories) DisablesNone() bool {
 	return n.none
 }
 
+// DisablesNone returns true if all categories are enabled.
+func (n *NotificationDisabledClassifications) DisablesNone() bool {
+	return n.none
+}
+
+// Deprecated: please use NotificationDisabledClassifications.DisabledClassifications. This will be removed in 6.0.
+//
 // DisabledCategories returns the categories that are disabled.
 func (n *NotificationDisabledCategories) DisabledCategories() []NotificationCategory {
 	return n.categories
+}
+
+// DisabledClassifications returns the classifications that are disabled.
+func (n *NotificationDisabledClassifications) DisabledClassifications() []NotificationClassification {
+	return n.classifications
 }
 
 // NotificationMinimumSeverityLevel defines the minimum severity level of notifications the server should send.
@@ -69,3 +129,102 @@ const (
 	WarningLevel     NotificationMinimumSeverityLevel = "WARNING"
 	InformationLevel NotificationMinimumSeverityLevel = "INFORMATION"
 )
+
+// ToNotification returns a db.Notification that corresponds to the given db.GqlStatusObject.
+// It maps fields from the status to their respective notification fields.
+func ToNotification(gqlStatusObject db.GqlStatusObject) *db.Notification {
+	return &db.Notification{
+		Code:        gqlStatusObject.Code,
+		Title:       gqlStatusObject.Title,
+		Description: gqlStatusObject.StatusDescription,
+		Position:    gqlStatusObject.Position,
+		Severity:    gqlStatusObject.Severity,
+		Category:    gqlStatusObject.Classification,
+	}
+}
+
+var (
+	defaultDiagnosticRecord = map[string]any{
+		"OPERATION":      "",
+		"OPERATION_CODE": "0",
+		"CURRENT_SCHEMA": "/",
+	}
+
+	successGqlStatusObject = &db.GqlStatusObject{
+		GqlStatus:         "00000",
+		StatusDescription: "note: successful completion",
+		DiagnosticRecord:  defaultDiagnosticRecord,
+	}
+
+	noDataGqlStatusObject = &db.GqlStatusObject{
+		GqlStatus:         "02000",
+		StatusDescription: "note: no data",
+		DiagnosticRecord:  defaultDiagnosticRecord,
+	}
+
+	noDataUnknownGqlStatusObject = &db.GqlStatusObject{
+		GqlStatus:         "02N42",
+		StatusDescription: "note: no data - unknown subcondition",
+		DiagnosticRecord:  defaultDiagnosticRecord,
+	}
+
+	omittedResultGqlStatusObject = &db.GqlStatusObject{
+		GqlStatus:         "00001",
+		StatusDescription: "note: successful completion - omitted result",
+		DiagnosticRecord:  defaultDiagnosticRecord,
+	}
+
+	unknownWarningResultGqlStatusObject = &db.GqlStatusObject{
+		GqlStatus:         "01N42",
+		StatusDescription: "warn: unknown warning",
+		DiagnosticRecord:  defaultDiagnosticRecord,
+	}
+
+	unknownInformationResultGqlStatusObject = &db.GqlStatusObject{
+		GqlStatus:         "03N42",
+		StatusDescription: "info: unknown notification",
+		DiagnosticRecord:  defaultDiagnosticRecord,
+	}
+)
+
+// ToGqlStatusObject returns a db.GqlStatusObject that corresponds to the given db.Notification.
+// It maps fields from the notification to their respective status fields.
+func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
+	defaultStatus := unknownInformationResultGqlStatusObject
+	if notification.Severity == string(WarningLevel) {
+		defaultStatus = unknownWarningResultGqlStatusObject
+	}
+
+	statusDescription := notification.Description
+	if statusDescription == "" {
+		statusDescription = defaultStatus.StatusDescription
+	}
+
+	diagnosticRecord := map[string]any{}
+	for k, v := range defaultDiagnosticRecord {
+		diagnosticRecord[k] = v
+	}
+
+	if notification.Position != nil {
+		diagnosticRecord["_position"] = notification.Position
+	}
+	diagnosticRecord["_classification"] = notification.Category
+	diagnosticRecord["_severity"] = notification.Severity
+
+	return &db.GqlStatusObject{
+		Code:              notification.Code,
+		Title:             notification.Title,
+		GqlStatus:         defaultStatus.GqlStatus,
+		StatusDescription: statusDescription,
+		Position:          notification.Position,
+		Classification:    notification.Category,
+		Severity:          notification.Severity,
+		DiagnosticRecord:  diagnosticRecord,
+		IsNotification:    true,
+	}
+}
+
+func ToGqlStatusObjectFromSummary(summary *db.Summary) *db.GqlStatusObject {
+	// TODO return successGqlStatusObject, noDataGqlStatusObject, noDataUnknownGqlStatusObject or omittedResultGqlStatusObject
+	return successGqlStatusObject
+}

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -190,9 +190,11 @@ func newUnknownInformationResultGqlStatusObject() *db.GqlStatusObject {
 // ToGqlStatusObject returns a db.GqlStatusObject that corresponds to the given db.Notification.
 // It maps fields from the notification to their respective status fields.
 func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
-	defaultStatus := newUnknownInformationResultGqlStatusObject()
+	var defaultStatus *db.GqlStatusObject
 	if notification.Severity == string(WarningLevel) {
 		defaultStatus = newUnknownWarningResultGqlStatusObject()
+	} else {
+		defaultStatus = newUnknownInformationResultGqlStatusObject()
 	}
 
 	statusDescription := notification.Description

--- a/neo4j/notifications_examples_test.go
+++ b/neo4j/notifications_examples_test.go
@@ -28,7 +28,6 @@ func ExampleConfig_disableNoCategories() {
 	ctx := context.Background()
 	driver, err := NewDriverWithContext(getUrl(), getAuth(), func(config *Config) {
 		// makes the server return all notification categories
-		//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
 		config.NotificationsDisabledCategories = notifications.DisableNoCategories()
 	})
 	handleError(err)
@@ -53,7 +52,6 @@ func ExampleSessionConfig_disableNoCategories() {
 	session := driver.NewSession(ctx, SessionConfig{
 		// makes the server return all notification categories
 		// this overrides the driver level configuration of the same name
-		//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 		NotificationsDisabledCategories: notifications.DisableNoCategories(),
 	})
 
@@ -74,7 +72,6 @@ func ExampleConfig_disableSomeCategories() {
 	ctx := context.Background()
 	driver, err := NewDriverWithContext(getUrl(), getAuth(), func(config *Config) {
 		// makes the server return all notification categories but deprecations
-		//lint:ignore SA1019 NotificationsDisabledCategories and DisableCategories are supported at least until 6.0
 		config.NotificationsDisabledCategories = notifications.DisableCategories(notifications.Deprecation)
 	})
 	handleError(err)
@@ -100,7 +97,6 @@ func ExampleSessionConfig_disableSomeCategories() {
 	session := driver.NewSession(ctx, SessionConfig{
 		// makes the server return all notification categories but deprecations
 		// this overrides the driver level configuration of the same name
-		//lint:ignore SA1019 NotificationsDisabledCategories and DisableCategories are supported at least until 6.0
 		NotificationsDisabledCategories: notifications.DisableCategories(notifications.Deprecation),
 	})
 

--- a/neo4j/notifications_examples_test.go
+++ b/neo4j/notifications_examples_test.go
@@ -28,6 +28,7 @@ func ExampleConfig_disableNoCategories() {
 	ctx := context.Background()
 	driver, err := NewDriverWithContext(getUrl(), getAuth(), func(config *Config) {
 		// makes the server return all notification categories
+		//lint:ignore SA1019 NotificationsDisabledCategories is supported at least until 6.0
 		config.NotificationsDisabledCategories = notifications.DisableNoCategories()
 	})
 	handleError(err)
@@ -52,6 +53,7 @@ func ExampleSessionConfig_disableNoCategories() {
 	session := driver.NewSession(ctx, SessionConfig{
 		// makes the server return all notification categories
 		// this overrides the driver level configuration of the same name
+		//lint:ignore SA1019 DisableNoCategories is supported at least until 6.0
 		NotificationsDisabledCategories: notifications.DisableNoCategories(),
 	})
 
@@ -72,6 +74,7 @@ func ExampleConfig_disableSomeCategories() {
 	ctx := context.Background()
 	driver, err := NewDriverWithContext(getUrl(), getAuth(), func(config *Config) {
 		// makes the server return all notification categories but deprecations
+		//lint:ignore SA1019 NotificationsDisabledCategories and DisableCategories are supported at least until 6.0
 		config.NotificationsDisabledCategories = notifications.DisableCategories(notifications.Deprecation)
 	})
 	handleError(err)
@@ -97,6 +100,7 @@ func ExampleSessionConfig_disableSomeCategories() {
 	session := driver.NewSession(ctx, SessionConfig{
 		// makes the server return all notification categories but deprecations
 		// this overrides the driver level configuration of the same name
+		//lint:ignore SA1019 NotificationsDisabledCategories and DisableCategories are supported at least until 6.0
 		NotificationsDisabledCategories: notifications.DisableCategories(notifications.Deprecation),
 	})
 

--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -614,7 +614,6 @@ func (s *resultSummary) Notifications() []Notification {
 			status := s.sum.GqlStatusObjects[i]
 			if status.IsNotification {
 				n = append(n, &notification{notification: notifications.ToNotification(status)})
-
 			}
 		}
 		return n

--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -634,7 +634,7 @@ func (s *resultSummary) GqlStatusObjects() []GqlStatusObject {
 			g = append(g, &gqlStatusObject{gqlStatusObject: notifications.ToGqlStatusObject(s.sum.Notifications[i])})
 		}
 		// Append client generated polyfill status
-		g = append(g, &gqlStatusObject{gqlStatusObject: notifications.ToGqlStatusObjectFromSummary(s.sum)})
+		g = append(g, &gqlStatusObject{gqlStatusObject: notifications.ToGqlStatusObjectFromSummary(s.sum.StreamSummary)})
 		// Sort by GqlStatus weight
 		sort.Slice(g, func(i, j int) bool {
 			return calculateGqlStatusWeight(g[i]) < calculateGqlStatusWeight(g[j])
@@ -642,7 +642,7 @@ func (s *resultSummary) GqlStatusObjects() []GqlStatusObject {
 		return g
 	}
 	// If both s.sum.GqlStatusObjects and s.sum.Notifications are nil
-	return []GqlStatusObject{&gqlStatusObject{gqlStatusObject: notifications.ToGqlStatusObjectFromSummary(s.sum)}}
+	return []GqlStatusObject{&gqlStatusObject{gqlStatusObject: notifications.ToGqlStatusObjectFromSummary(s.sum.StreamSummary)}}
 }
 
 func calculateGqlStatusWeight(gqlStatusObject GqlStatusObject) int {

--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -247,13 +247,13 @@ type Notification interface {
 	// In that case, Category returns UnknownCategory while RawCategory returns the raw string
 	RawCategory() string
 	// SeverityLevel returns the mapped security level of this notification.
-	// If the severity level is not a known value, SeverityLevel returns UnknownSeverity
+	// If the severity level is not a known value, SeverityLevel returns notifications.UnknownSeverity
 	// Call RawSeverityLevel to get access to the raw string value
-	SeverityLevel() NotificationSeverity
+	SeverityLevel() notifications.NotificationSeverity
 	// Category returns the mapped category of this notification.
 	// If the category is not a known value, Category returns UnknownCategory
 	// Call RawCategory to get access to the raw string value
-	Category() NotificationCategory
+	Category() notifications.NotificationCategory
 }
 
 // GqlStatusObject represents a GqlStatusObject generated when executing a statement.
@@ -293,11 +293,11 @@ type GqlStatusObject interface {
 	// Only Notifications (see IsNotification) have a meaningful classification.
 	RawClassification() string
 	// Severity returns the mapped Severity of this status.
-	// If the Severity is not a known value, Severity returns UnknownSeverity. // TODO should this be notifications.UnknownSeverity?
+	// If the Severity is not a known value, Severity returns notifications.UnknownSeverity.
 	// Call RawSeverity to get access to the raw string value
 	//
 	// Only Notifications (see IsNotification) have a meaningful severity.
-	Severity() NotificationSeverity // TODO should this be or notifications.NotificationSeverity in the notification package?
+	Severity() notifications.NotificationSeverity
 	// RawSeverity returns the unmapped Severity level of this status.
 	// This is useful when the driver cannot interpret the Severity returned by the server
 	//
@@ -325,28 +325,40 @@ type InputPosition interface {
 	Column() int
 }
 
-type NotificationSeverity string
+// Deprecated: please use notifications.NotificationSeverity directly. This will be removed in 6.0.
+type NotificationSeverity = notifications.NotificationSeverity
 
 const (
-	Warning         NotificationSeverity = "WARNING"
-	Information     NotificationSeverity = "INFORMATION"
-	UnknownSeverity NotificationSeverity = "UNKNOWN"
+	// Deprecated: please use notifications.Warning directly. This will be removed in 6.0.
+	Warning NotificationSeverity = notifications.Warning
+	// Deprecated: please use notifications.Information directly. This will be removed in 6.0.
+	Information NotificationSeverity = notifications.Information
+	// Deprecated: please use notifications.UnknownSeverity directly. This will be removed in 6.0.
+	UnknownSeverity NotificationSeverity = notifications.UnknownSeverity
 )
 
 // Deprecated: please use notifications.NotificationCategory directly. This will be removed in 6.0.
-type NotificationCategory notifications.NotificationCategory // TODO is this ok to do from string?
+type NotificationCategory = notifications.NotificationCategory
 
-// TODO do these need deprecated individually to their notification.x equivalent?
 const (
-	Hint            NotificationCategory = "HINT"
-	Unrecognized    NotificationCategory = "UNRECOGNIZED"
-	Unsupported     NotificationCategory = "UNSUPPORTED"
-	Performance     NotificationCategory = "PERFORMANCE"
-	Deprecation     NotificationCategory = "DEPRECATION"
-	Generic         NotificationCategory = "GENERIC"
-	Security        NotificationCategory = "SECURITY"
-	Topology        NotificationCategory = "TOPOLOGY"
-	UnknownCategory NotificationCategory = "UNKNOWN"
+	// Deprecated: please use notifications.Hint directly. This will be removed in 6.0.
+	Hint NotificationCategory = notifications.Hint
+	// Deprecated: please use notifications.Unrecognized directly. This will be removed in 6.0.
+	Unrecognized NotificationCategory = notifications.Unrecognized
+	// Deprecated: please use notifications.Unsupported directly. This will be removed in 6.0.
+	Unsupported NotificationCategory = notifications.Unsupported
+	// Deprecated: please use notifications.Performance directly. This will be removed in 6.0.
+	Performance NotificationCategory = notifications.Performance
+	// Deprecated: please use notifications.Deprecation directly. This will be removed in 6.0.
+	Deprecation NotificationCategory = notifications.Deprecation
+	// Deprecated: please use notifications.Generic directly. This will be removed in 6.0.
+	Generic NotificationCategory = notifications.Generic
+	// Deprecated: please use notifications.Security directly. This will be removed in 6.0.
+	Security NotificationCategory = notifications.Security
+	// Deprecated: please use notifications.Topology directly. This will be removed in 6.0.
+	Topology NotificationCategory = notifications.Topology
+	// Deprecated: please use notifications.Unknown directly. This will be removed in 6.0.
+	UnknownCategory NotificationCategory = notifications.Unknown
 )
 
 type resultSummary struct {
@@ -672,7 +684,7 @@ func (n *notification) RawSeverityLevel() string {
 	return n.notification.Severity
 }
 
-func (n *notification) SeverityLevel() NotificationSeverity {
+func (n *notification) SeverityLevel() notifications.NotificationSeverity {
 	switch n.notification.Severity {
 	case "WARNING":
 		return Warning
@@ -687,7 +699,7 @@ func (n *notification) RawCategory() string {
 	return n.notification.Category
 }
 
-func (n *notification) Category() NotificationCategory {
+func (n *notification) Category() notifications.NotificationCategory {
 	switch n.notification.Category {
 	case "HINT":
 		return Hint
@@ -763,23 +775,23 @@ func (g *gqlStatusObject) Line() int {
 func (g *gqlStatusObject) Classification() notifications.NotificationClassification {
 	switch g.gqlStatusObject.Classification {
 	case "HINT":
-		return notifications.HintClassification
+		return notifications.Hint
 	case "UNRECOGNIZED":
-		return notifications.UnrecognizedClassification
+		return notifications.Unrecognized
 	case "UNSUPPORTED":
-		return notifications.UnsupportedClassification
+		return notifications.Unsupported
 	case "PERFORMANCE":
-		return notifications.PerformanceClassification
+		return notifications.Performance
 	case "DEPRECATION":
-		return notifications.DeprecationClassification
+		return notifications.Deprecation
 	case "SECURITY":
-		return notifications.SecurityClassification
+		return notifications.Security
 	case "TOPOLOGY":
-		return notifications.TopologyClassification
+		return notifications.Topology
 	case "GENERIC":
-		return notifications.GenericClassification
+		return notifications.Generic
 	default:
-		return notifications.UnknownClassification
+		return notifications.Unknown
 	}
 }
 
@@ -787,7 +799,7 @@ func (g *gqlStatusObject) RawClassification() string {
 	return g.gqlStatusObject.Classification
 }
 
-func (g *gqlStatusObject) Severity() NotificationSeverity {
+func (g *gqlStatusObject) Severity() notifications.NotificationSeverity {
 	switch g.gqlStatusObject.Severity {
 	case "WARNING":
 		return Warning

--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -253,6 +253,7 @@ type Notification interface {
 	// Category returns the mapped category of this notification.
 	// If the category is not a known value, Category returns UnknownCategory
 	// Call RawCategory to get access to the raw string value
+	//lint:ignore SA1019 NotificationCategory is supported at least until 6.0
 	Category() notifications.NotificationCategory
 }
 
@@ -338,6 +339,8 @@ const (
 )
 
 // Deprecated: please use notifications.NotificationCategory directly. This will be removed in 6.0.
+//
+//lint:ignore SA1019 NotificationCategory is supported at least until 6.0
 type NotificationCategory = notifications.NotificationCategory
 
 const (
@@ -700,6 +703,7 @@ func (n *notification) RawCategory() string {
 	return n.notification.Category
 }
 
+//lint:ignore SA1019 NotificationCategory is supported at least until 6.0
 func (n *notification) Category() notifications.NotificationCategory {
 	switch n.notification.Category {
 	case "HINT":

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -158,14 +158,10 @@ type SessionConfig struct {
 	// Else, this option overrides the driver's settings.
 	// Disabling severities allows the server to skip analysis for those, which can speed up query execution.
 	NotificationsMinSeverity notifications.NotificationMinimumSeverityLevel
-	// Deprecated: please use NotificationsDisabledClassifications. This will be removed in 6.0.
-	//
 	// NotificationsDisabledCategories defines the categories of notifications the server should not send.
 	// By default, the driver's settings are used.
 	// Else, this option overrides the driver's settings.
 	// Disabling categories allows the server to skip analysis for those, which can speed up query execution.
-	//
-	//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
 	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
 	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -164,6 +164,8 @@ type SessionConfig struct {
 	// By default, the driver's settings are used.
 	// Else, this option overrides the driver's settings.
 	// Disabling categories allows the server to skip analysis for those, which can speed up query execution.
+	//
+	//lint:ignore SA1019 NotificationDisabledCategories is supported at least until 6.0
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
 	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
 	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -158,11 +158,19 @@ type SessionConfig struct {
 	// Else, this option overrides the driver's settings.
 	// Disabling severities allows the server to skip analysis for those, which can speed up query execution.
 	NotificationsMinSeverity notifications.NotificationMinimumSeverityLevel
+	// Deprecated: please use NotificationsDisabledClassifications. This will be removed in 6.0.
+	//
 	// NotificationsDisabledCategories defines the categories of notifications the server should not send.
 	// By default, the driver's settings are used.
 	// Else, this option overrides the driver's settings.
 	// Disabling categories allows the server to skip analysis for those, which can speed up query execution.
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
+	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
+	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.
+	//
+	// NotificationsDisabledClassifications is part of the GQL compliant notifications preview feature
+	// (see README on what it means in terms of support and compatibility guarantees)
+	NotificationsDisabledClassifications notifications.NotificationDisabledClassifications
 	// Auth is used to overwrite the authentication information for the session.
 	// This requires the server to support re-authentication on the protocol level.
 	// `nil` will make the driver use the authentication information from the driver configuration.
@@ -329,6 +337,7 @@ func (s *sessionWithContext) BeginTransaction(ctx context.Context, configurers .
 			NotificationConfig: idb.NotificationConfig{
 				MinSev:  s.config.NotificationsMinSeverity,
 				DisCats: s.config.NotificationsDisabledCategories,
+				DisClas: s.config.NotificationsDisabledClassifications,
 			},
 		}, true)
 	if err != nil {
@@ -482,6 +491,7 @@ func (s *sessionWithContext) executeTransactionFunction(
 			NotificationConfig: idb.NotificationConfig{
 				MinSev:  s.config.NotificationsMinSeverity,
 				DisCats: s.config.NotificationsDisabledCategories,
+				DisClas: s.config.NotificationsDisabledClassifications,
 			},
 		},
 		blockingTxBegin)
@@ -648,6 +658,7 @@ func (s *sessionWithContext) Run(ctx context.Context,
 			NotificationConfig: idb.NotificationConfig{
 				MinSev:  s.config.NotificationsMinSeverity,
 				DisCats: s.config.NotificationsDisabledCategories,
+				DisClas: s.config.NotificationsDisabledClassifications,
 			},
 		},
 	)

--- a/testkit-backend/2cypher.go
+++ b/testkit-backend/2cypher.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"time"
 
@@ -201,7 +202,17 @@ func nativeToCypher(v any) map[string]any {
 				"z":      x.Z,
 			},
 		}
+	case *db.InputPosition:
+		if x != nil {
+			return valueResponse("CypherMap", map[string]any{
+				"column": nativeToCypher(int64(x.Column)),
+				"line":   nativeToCypher(int64(x.Line)),
+				"offset": nativeToCypher(int64(x.Offset)),
+			})
+		}
+		return nil
 	}
+
 	panic(fmt.Sprintf("Don't know how to patch %T", v))
 }
 

--- a/testkit-backend/2cypher.go
+++ b/testkit-backend/2cypher.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/dbtype"
 	"time"
 
@@ -32,6 +31,8 @@ func nativeToCypher(v any) map[string]any {
 		return map[string]any{"name": "CypherNull", "data": nil}
 	}
 	switch x := v.(type) {
+	case int:
+		return valueResponse("CypherInt", x)
 	case int64:
 		return valueResponse("CypherInt", x)
 	case string:
@@ -202,15 +203,6 @@ func nativeToCypher(v any) map[string]any {
 				"z":      x.Z,
 			},
 		}
-	case *db.InputPosition:
-		if x != nil {
-			return valueResponse("CypherMap", map[string]any{
-				"column": nativeToCypher(int64(x.Column)),
-				"line":   nativeToCypher(int64(x.Line)),
-				"offset": nativeToCypher(int64(x.Offset)),
-			})
-		}
-		return nil
 	}
 
 	panic(fmt.Sprintf("Don't know how to patch %T", v))

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -569,11 +569,9 @@ func (b *backend) handleRequest(req map[string]any) {
 			if data["notificationsDisabledCategories"] != nil {
 				notiDisCats := data["notificationsDisabledCategories"].([]any)
 				if len(notiDisCats) == 0 {
-					//lint:ignore SA1019 NotificationsDisabledCategories and DisableNoCategories are supported at least until 6.0
 					c.NotificationsDisabledCategories = notifications.DisableNoCategories()
 				} else {
 					cats := convertSlice(notiDisCats, anyToNotificationCategory)
-					//lint:ignore SA1019 NotificationsDisabledCategories and DisableNoCategories are supported at least until 6.0
 					c.NotificationsDisabledCategories = notifications.DisableCategories(cats...)
 				}
 			}
@@ -780,11 +778,9 @@ func (b *backend) handleRequest(req map[string]any) {
 		if data["notificationsDisabledCategories"] != nil {
 			notiDisCats := data["notificationsDisabledCategories"].([]any)
 			if len(notiDisCats) == 0 {
-				//lint:ignore SA1019 NotificationsDisabledCategories and DisableNoCategories are supported at least until 6.0
 				sessionConfig.NotificationsDisabledCategories = notifications.DisableNoCategories()
 			} else {
 				cats := convertSlice(notiDisCats, anyToNotificationCategory)
-				//lint:ignore SA1019 NotificationsDisabledCategories and DisableNoCategories are supported at least until 6.0
 				sessionConfig.NotificationsDisabledCategories = notifications.DisableCategories(cats...)
 			}
 		}
@@ -1448,7 +1444,7 @@ func serializeRecord(record *neo4j.Record) map[string]any {
 
 func serializeNotifications(slice []neo4j.Notification, version db.ProtocolVersion) []map[string]any {
 	if slice == nil {
-		if version.Minor >= 5 {
+		if version.Major == 4 && version.Minor >= 5 {
 			return []map[string]any{}
 		}
 		return nil
@@ -1481,12 +1477,6 @@ func serializeNotifications(slice []neo4j.Notification, version db.ProtocolVersi
 }
 
 func serializeGqlStatusObjects(slice []neo4j.GqlStatusObject) []map[string]any {
-	if slice == nil {
-		return []map[string]any{}
-	}
-	if len(slice) == 0 {
-		return []map[string]any{}
-	}
 	var res []map[string]any
 	for i, status := range slice {
 		res = append(res, map[string]any{
@@ -1549,7 +1539,6 @@ func serializeSummary(summary neo4j.ResultSummary) map[string]any {
 			"text":       summary.Query().Text(),
 			"parameters": serializeParameters(summary.Query().Parameters()),
 		},
-		//lint:ignore SA1019 Notifications is supported at least until 6.0
 		"notifications":    serializeNotifications(summary.Notifications(), protocolVersion),
 		"gqlStatusObjects": serializeGqlStatusObjects(summary.GqlStatusObjects()),
 		"plan":             serializePlan(summary.Plan()),
@@ -1780,9 +1769,7 @@ func convertInitialBookmarks(bookmarks []any) neo4j.Bookmarks {
 	return result
 }
 
-//lint:ignore SA1019 NotificationCategory is supported at least until 6.0
 func anyToNotificationCategory(v any) notifications.NotificationCategory {
-	//lint:ignore SA1019 NotificationCategory is supported at least until 6.0
 	return notifications.NotificationCategory(v.(string))
 }
 

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -569,9 +569,11 @@ func (b *backend) handleRequest(req map[string]any) {
 			if data["notificationsDisabledCategories"] != nil {
 				notiDisCats := data["notificationsDisabledCategories"].([]any)
 				if len(notiDisCats) == 0 {
+					//lint:ignore SA1019 NotificationsDisabledCategories and DisableNoCategories are supported at least until 6.0
 					c.NotificationsDisabledCategories = notifications.DisableNoCategories()
 				} else {
 					cats := convertSlice(notiDisCats, anyToNotificationCategory)
+					//lint:ignore SA1019 NotificationsDisabledCategories and DisableNoCategories are supported at least until 6.0
 					c.NotificationsDisabledCategories = notifications.DisableCategories(cats...)
 				}
 			}
@@ -778,9 +780,11 @@ func (b *backend) handleRequest(req map[string]any) {
 		if data["notificationsDisabledCategories"] != nil {
 			notiDisCats := data["notificationsDisabledCategories"].([]any)
 			if len(notiDisCats) == 0 {
+				//lint:ignore SA1019 NotificationsDisabledCategories and DisableNoCategories are supported at least until 6.0
 				sessionConfig.NotificationsDisabledCategories = notifications.DisableNoCategories()
 			} else {
 				cats := convertSlice(notiDisCats, anyToNotificationCategory)
+				//lint:ignore SA1019 NotificationsDisabledCategories and DisableNoCategories are supported at least until 6.0
 				sessionConfig.NotificationsDisabledCategories = notifications.DisableCategories(cats...)
 			}
 		}
@@ -1545,6 +1549,7 @@ func serializeSummary(summary neo4j.ResultSummary) map[string]any {
 			"text":       summary.Query().Text(),
 			"parameters": serializeParameters(summary.Query().Parameters()),
 		},
+		//lint:ignore SA1019 Notifications is supported at least until 6.0
 		"notifications":    serializeNotifications(summary.Notifications(), protocolVersion),
 		"gqlStatusObjects": serializeGqlStatusObjects(summary.GqlStatusObjects()),
 		"plan":             serializePlan(summary.Plan()),
@@ -1775,7 +1780,9 @@ func convertInitialBookmarks(bookmarks []any) neo4j.Bookmarks {
 	return result
 }
 
+//lint:ignore SA1019 NotificationCategory is supported at least until 6.0
 func anyToNotificationCategory(v any) notifications.NotificationCategory {
+	//lint:ignore SA1019 NotificationCategory is supported at least until 6.0
 	return notifications.NotificationCategory(v.(string))
 }
 

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1442,8 +1442,11 @@ func serializeRecord(record *neo4j.Record) map[string]any {
 	return data
 }
 
-func serializeNotifications(slice []neo4j.Notification) []map[string]any {
+func serializeNotifications(slice []neo4j.Notification, version db.ProtocolVersion) []map[string]any {
 	if slice == nil {
+		if version.Minor >= 5 {
+			return []map[string]any{}
+		}
 		return nil
 	}
 	if len(slice) == 0 {
@@ -1542,7 +1545,7 @@ func serializeSummary(summary neo4j.ResultSummary) map[string]any {
 			"text":       summary.Query().Text(),
 			"parameters": serializeParameters(summary.Query().Parameters()),
 		},
-		"notifications":    serializeNotifications(summary.Notifications()),
+		"notifications":    serializeNotifications(summary.Notifications(), protocolVersion),
 		"gqlStatusObjects": serializeGqlStatusObjects(summary.GqlStatusObjects()),
 		"plan":             serializePlan(summary.Plan()),
 		"profile":          serializeProfile(summary.Profile()),

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1262,6 +1262,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"Feature:Bolt:5.3",
 				"Feature:Bolt:5.4",
 				"Feature:Bolt:5.5",
+				"Feature:Bolt:5.6",
 				"Feature:Bolt:Patch:UTC",
 				"Feature:Impersonation",
 				//"Feature:TLS:1.1",

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1444,7 +1444,7 @@ func serializeRecord(record *neo4j.Record) map[string]any {
 
 func serializeNotifications(slice []neo4j.Notification, version db.ProtocolVersion) []map[string]any {
 	if slice == nil {
-		if version.Major == 4 && version.Minor >= 5 {
+		if version.Major == 5 && version.Minor >= 5 {
 			return []map[string]any{}
 		}
 		return nil


### PR DESCRIPTION
⚠️  This API is released as preview.

Introduces GQL-compliant status objects to the `ResultSummary`.

`GqlStatusObject` is a GQL-compliant `Notification` object and status of query execution, this new object includes `GqlStatus` and `StatusDescription`.

`ResultSummary.GqlStatusObjects()` always contains at least 1 status representing the `Success`, `No Data` or `Omitted Result`.

The GqlStatusObjects will be presented in the following order:

* A “no data” (`02xxx`) has precedence over a warning;
* A warning (`01xxx`) has precedence over a success.
* A success (`00xxx`) has precedence over anything informational (`03xxx`)

**Migration from Notification**

Most properties in `Notification` exist in the new `GqlStatusObject`, except `Code` and `Title`.
The `GqlStatusObject.GqlStatus` is equivalent to `Code` in `Notification`, but with values compliant with GQL.
The properties `GqlStatusObject.Classification` and `GqlStatusObject.RawClassification` are equivalent to `Notification.Category` and `Notification.RawCategory`. The name change is needed because Category has a different meaning in GQL.

**Usage**

Disabling GqlStatusObjects can be done in the same way as disabling Notifications. However, non-notification status can not be filtered (such as Success or No Data):

```go
neo4j.NewDriverWithContext("neo4j://localhost", neo4j.BasicAuth("neo4j", "password", ""), func(config *config.Config) {
    config.NotificationsDisabledClassifications = notifications.DisableClassifications(notifications.Deprecation, notifications.Performance)
})
```

Iterating through GqlStatusObjects is also done in the same way as Notifications:

```go
gqlStatusObjects := result.Summary.GqlStatusObjects()
for _, gqlStatusObject := range gqlStatusObjects {
    fmt.Printf(gqlStatusObject.GqlStatus())
    fmt.Printf(gqlStatusObject.StatusDescription())
    fmt.Printf(gqlStatusObject.DiagnosticRecord())
    // and so on
}
``` 

**Deprecations**

- `neo4j.NotificationSeverity` please use `notifications.NotificationSeverity` directly.
- `neo4j.Warning` please use `notifications.Warning` directly.
- `neo4j.Information` please use `notifications.Information` directly.
- `neo4j.UnknownSeverity` please use `notifications.UnknownSeverity` directly.

- `neo4j.NotificationCategory` please use `notifications.NotificationCategory` directly.
- `neo4j.Hint` please use `notifications.Hint` directly.
- `neo4j.Unrecognized` please use `notifications.Unrecognized` directly.
- `neo4j.Unsupported` please use `notifications.Unsupported` directly.
- `neo4j.Performance` please use `notifications.Performance` directly.
- `neo4j.Deprecation` please use `notifications.Deprecation` directly.
- `neo4j.Generic` please use `notifications.Generic` directly.
- `neo4j.Security` please use `notifications.Security` directly.
- `neo4j.Topology` please use `notifications.Topology` directly.
- `neo4j.UnknownCategory` please use `notifications.Unknown` directly.