### PR TITLE
Add config.OverrideInsecureSkipVerify to allow for skipping cert verification

### DIFF
--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -45,12 +45,20 @@ type Config struct {
 	// 'neo4j+s' and 'neo4j+ssc'.
 	//
 	// The default MinVersion attribute is tls.VersionTLS12. This is overridable.
-	// The InsecureSkipVerify attribute of TlsConfig is always derived from the initial URI scheme.
+	// The InsecureSkipVerify attribute of TlsConfig is always derived from the initial URI scheme unless OverrideInsecureSkipVerify is set.
 	// The ServerName attribute of TlsConfig is always derived from the initial URI host.
 	//
 	// This is considered an advanced setting, use it at your own risk.
 	// Introduced in 5.0.
 	TlsConfig *tls.Config
+	// OverrideInsecureSkipVerify specifies whether to override the value inferred for TlsConfig.InsecureSkipVerify from
+	// the URI scheme. 
+	//
+	// If OverrideInsecureSkipVerify is true then TlsConfig.InsecureSkipVerify will be true, regardless
+	// of the URI.
+	//
+	// default: false
+	OverrideInsecureSkipVerify bool
 	// ClientCertificateProvider specifies a provider for the client TLS certificate for mutual TLS authentication.
 	// Use auth.NewStaticClientCertificateProvider for static certificates, or auth.NewRotatingClientCertificateProvider
 	// for certificates that require runtime updates without application restart.

--- a/neo4j/internal/connector/connector.go
+++ b/neo4j/internal/connector/connector.go
@@ -172,7 +172,7 @@ func (c Connector) tlsConfig(serverName string) *tls.Config {
 
 	// Configure server name and whether to skip certificate verification.
 	config.ServerName = serverName
-	config.InsecureSkipVerify = c.SkipVerify
+	config.InsecureSkipVerify = c.SkipVerify || c.Config.OverrideInsecureSkipVerify
 
 	return config
 }


### PR DESCRIPTION
My use case:

- I have a Neo4J instance running on an AWS EC2 server. This server has a DNS entry for its public IP so that I can issue it a trusted certificate using certbot
- I would like to access this instance over TLS inside the same VPC, using the internal address
- The simplest way to do this is to change the hostname in the URI to the private VPC IP address and skip certificate verification. This is reasonably safe because I am connecting to an IP address within my VPC which I can expect to be a trusted service.
- I would also prefer to disable the server from accepting plaintext bolt connections as this is a security issue.
- Setting `TlsConfig.InsecureSkipVerify` in the `configurers` `func` in `NewDriverWithContext` is always overridden by `connector.go:172`.
- Add a new field in the config to allow for overriding the value inferred from the URI for such a use case.