### PR TITLE
add Records method to ResultWithContext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/neo4j/neo4j-go-driver/v5
 
-go 1.18
+go 1.23.0

--- a/neo4j/driver_with_context_test.go
+++ b/neo4j/driver_with_context_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
+	"iter"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -681,6 +682,10 @@ func (f *fakeResult) Err() error {
 
 func (f *fakeResult) Record() *Record {
 	return f.nextRecords[f.nextIndex]
+}
+
+func (f *fakeResult) Records(context.Context) (iter.Seq2[*Record, error]) {
+	panic("implement me")
 }
 
 func (f *fakeResult) Collect(context.Context) ([]*Record, error) {

--- a/neo4j/result_with_context.go
+++ b/neo4j/result_with_context.go
@@ -19,6 +19,8 @@ package neo4j
 
 import (
 	"context"
+	"iter"
+
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
@@ -44,6 +46,8 @@ type ResultWithContext interface {
 	Record() *Record
 	// Collect fetches all remaining records and returns them.
 	Collect(ctx context.Context) ([]*Record, error)
+	// Collect fetches all remaining records and returns them.
+	Records(ctx context.Context) (iter.Seq2[*Record, error])
 	// Single returns the only remaining record from the stream.
 	// If none or more than one record is left, an error is returned.
 	// The result is fully consumed after this call and its summary is immediately available when calling Consume.
@@ -147,18 +151,29 @@ func (r *resultWithContext) Record() *Record {
 	return r.record
 }
 
-func (r *resultWithContext) Collect(ctx context.Context) ([]*Record, error) {
-	recs := make([]*Record, 0, 1024)
-	for r.summary == nil && r.err == nil {
-		r.advance(ctx)
-		if r.record != nil {
-			recs = append(recs, r.record)
+func (r *resultWithContext) Records(ctx context.Context) iter.Seq2[*Record, error] {
+	return func(yield func(*db.Record, error) bool) {
+		defer r.callAfterConsumptionHook()
+		for r.summary == nil && r.err == nil {
+			r.advance(ctx)
+			if r.record != nil && !yield(r.record, nil) {
+				return
+			}
+		}
+		if r.err != nil {
+			yield(nil, errorutil.WrapError(r.err))
 		}
 	}
-	if r.err != nil {
-		return nil, errorutil.WrapError(r.err)
+}
+
+func (r *resultWithContext) Collect(ctx context.Context) ([]*Record, error) {
+	recs := make([]*Record, 0, 1024)
+	for r, err := range r.Records(ctx) {
+		if err != nil {
+			return nil, err
+		}
+		recs = append(recs, r)
 	}
-	r.callAfterConsumptionHook()
 	return recs, nil
 }
 

--- a/neo4j/result_with_context_test.go
+++ b/neo4j/result_with_context_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 )
 
-type iter struct {
+type s_iter struct {
 	expectNext bool
 	expectRec  *db.Record
 	expectSum  *db.Summary
@@ -74,7 +74,7 @@ func TestResult(outer *testing.T) {
 	iterCases := []struct {
 		name   string
 		stream []Next
-		rounds []iter
+		rounds []s_iter
 		sum    db.Summary
 	}{
 		{
@@ -84,7 +84,7 @@ func TestResult(outer *testing.T) {
 				{Record: recs[1]},
 				{Summary: sums[0]},
 			},
-			rounds: []iter{
+			rounds: []s_iter{
 				{expectNext: true, expectRec: recs[0]},
 				{expectNext: true, expectRec: recs[1]},
 				{expectNext: false, expectSum: sums[0]},
@@ -96,7 +96,7 @@ func TestResult(outer *testing.T) {
 				{Record: recs[0]},
 				{Err: errs[0]},
 			},
-			rounds: []iter{
+			rounds: []s_iter{
 				{expectNext: true, expectRec: recs[0]},
 				{expectNext: false, expectErr: errs[0]},
 			},
@@ -107,7 +107,7 @@ func TestResult(outer *testing.T) {
 				{Record: recs[0]},
 				{Err: errs[0]},
 			},
-			rounds: []iter{
+			rounds: []s_iter{
 				{expectNext: true, expectRec: recs[0]},
 				{expectNext: false, expectErr: errs[0]},
 				{expectNext: false, expectErr: errs[0]},


### PR DESCRIPTION
With the introduction of go 1.23 it would be useful to add support for an `iter.Seq` from the `ResultWithContext` type to avoid allocating memory on the order of the size of the results. This PR adds a `Records` method returning an `iter.Seq2[*Record, error]` which allows the user to for loop over the records in a `ResultWithContext`.