### PR TITLE
Bugfix: Retry mechanism doesn't respect the context

### DIFF
--- a/neo4j/internal/racing/time.go
+++ b/neo4j/internal/racing/time.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package racing
+
+import (
+	"context"
+	"time"
+)
+
+func Sleep(ctx context.Context, d time.Duration) error {
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/neo4j/internal/racing/time_test.go
+++ b/neo4j/internal/racing/time_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package racing_test
+
+import (
+	"context"
+	"errors"
+	rio "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/racing"
+	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
+	"testing"
+	"time"
+)
+
+func TestRacingSleep(outer *testing.T) {
+	outer.Parallel()
+
+	outer.Run("sleeps for the full duration", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		start := time.Now()
+		err := rio.Sleep(ctx, 100*time.Millisecond)
+		end := time.Now()
+
+		AssertNoError(t, err)
+		AssertTrue(t, end.Sub(start) >= 100*time.Millisecond)
+	})
+
+	outer.Run("reacts to context cancellation", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		start := time.Now()
+		cancel()
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+		}()
+		err := rio.Sleep(ctx, 1000*time.Millisecond)
+		end := time.Now()
+
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation error, got %+v", err)
+		}
+		AssertTrue(t, end.Sub(start) < 1000*time.Millisecond)
+	})
+
+	outer.Run("reacts to context deadline", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		start := time.Now()
+		err := rio.Sleep(ctx, 1000*time.Millisecond)
+		end := time.Now()
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context deadline exceeded error, got %+v", err)
+		}
+		AssertTrue(t, end.Sub(start) < 1000*time.Millisecond)
+
+	})
+}

--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -104,6 +104,7 @@ func (s *State) Continue(ctx context.Context) bool {
 			"Retrying transaction (%s): %s [after %s]", s.cause, lastErr, sleepTime)
 		select {
 		case <-ctx.Done():
+			s.Errs = []error{context.Canceled}
 			return false
 		case <-time.After(sleepTime):
 		}

--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -102,6 +102,7 @@ func (s *State) Continue(ctx context.Context) bool {
 		sleepTime := s.Throttle.delay()
 		s.Log.Debugf(s.LogName, s.LogId,
 			"Retrying transaction (%s): %s [after %s]", s.cause, lastErr, sleepTime)
+
 		select {
 		case <-ctx.Done():
 			s.Errs = []error{context.Canceled}

--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -105,7 +105,10 @@ func (s *State) Continue(ctx context.Context) bool {
 
 		select {
 		case <-ctx.Done():
-			s.Errs = []error{context.Canceled}
+			s.Errs = []error{&errorutil.TransactionExecutionLimit{
+				Cause:  context.Canceled.Error(),
+				Errors: s.Errs,
+			}}
 			return false
 		case <-time.After(sleepTime):
 		}

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -161,7 +161,7 @@ func TestState(outer *testing.T) {
 				}
 
 				state.OnFailure(ctx, invocation.err, invocation.conn, invocation.isCommitting)
-				continued := state.Continue()
+				continued := state.Continue(ctx)
 				if continued != invocation.expectContinued {
 					t.Errorf("Expected continue to return %v but returned %v", invocation.expectContinued, continued)
 				}

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -214,7 +214,7 @@ func TestContextCancel(t *testing.T) {
 
 	select {
 	case <-time.After(time.Second * 1):
-		t.Fatal("continue did not exit after context was canceled")
+		t.Error("continue did not exit after context was canceled")
 	case <-waitCh:
 	}
 }

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -147,7 +147,6 @@ func TestState(outer *testing.T) {
 				Log:                     log.ToVoid(),
 				LogName:                 "TEST",
 				LogId:                   "State",
-				Sleep:                   func(time.Duration) {},
 				MaxTransactionRetryTime: maxRetryTime,
 				MaxDeadConnections:      maxDead,
 				DatabaseName:            dbName,

--- a/neo4j/session_with_context.go
+++ b/neo4j/session_with_context.go
@@ -435,7 +435,7 @@ func (s *sessionWithContext) runRetriable(
 		Log:                     s.log,
 		LogName:                 log.Session,
 		LogId:                   s.logId,
-		Sleep:                   racing.Sleep,
+		Sleep:                   s.sleep,
 		Throttle:                retry.Throttler(s.throttleTime),
 		MaxDeadConnections:      s.driverConfig.MaxConnectionPoolSize,
 		DatabaseName:            s.config.DatabaseName,


### PR DESCRIPTION
This PR removes the `Sleep` func in the retry state and instead uses the following contruct to either wait the determined amount of time, _or_ cancel if the context is canceled. I also added a test case that reproduces this scenario.

```
select {
case <-ctx.Done():
	s.Errs = []error{context.Canceled}
	return false
case <-time.After(sleepTime):
}
```