### PR TITLE
ADR 023: GQL Compliant Errors

### DIFF
--- a/neo4j/db/errors.go
+++ b/neo4j/db/errors.go
@@ -32,22 +32,51 @@ const (
 	UnknownError   ErrorClassification = "UNKNOWN"
 )
 
-// Neo4jError is created when the database server failed to fulfill request.
-// TODO 6.0: rename to GqlError
+// TODO: when we no longer need to support the old Neo4jError, rename the following fields:
+// - Neo4jError -> GqlError
+// - GqlStatusDescription -> StatusDescription
+// - GqlClassification -> Classification
+// - GqlRawClassification -> RawClassification
+// - GqlDiagnosticRecord -> DiagnosticRecord
+// - GqlCause -> Cause
+// - GqlStatus to remain as-is to comply with GQLSTATUS.
+
+// Neo4jError is created when the database server fails to fulfill a request.
 type Neo4jError struct {
-	// TODO 6.0: to be deprecated.
-	Code      string
-	Msg       string
+	// Code is the Neo4j-specific error code, to be deprecated in favor of GqlStatus.
+	Code string
+	// Msg is the specific error message describing the failure.
+	Msg string
+	// GqlStatus returns the GQLSTATUS.
+	// GqlStatus is the error code compliant with the GQL specification.
+	//
+	// GqlStatus is part of the GQL compliant errors preview feature
+	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlStatus string
-	// TODO 6.0: rename to StatusDescription
+	// GqlStatusDescription provides a standard description for the associated GQLStatus code.
+	//
+	// GqlStatusDescription is part of the GQL compliant errors preview feature
+	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlStatusDescription string
-	// TODO 6.0: rename to Classification
+	// GqlClassification is a high-level categorization of the error, specific to GQL error handling.
+	//
+	// GqlClassification is part of the GQL compliant errors preview feature
+	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlClassification ErrorClassification
-	// TODO 6.0: rename to RawClassification
+	// GqlRawClassification holds the raw classification as received from the server.
+	//
+	// GqlRawClassification is part of the GQL compliant errors preview feature
+	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlRawClassification string
-	// TODO 6.0: rename to DiagnosticRecord
+	// GqlDiagnosticRecord returns further information about the status for diagnostic purposes.
+	//
+	// GqlDiagnosticRecord is part of the GQL compliant errors preview feature
+	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlDiagnosticRecord map[string]any
-	// TODO 6.0: rename to Cause
+	// GqlCause represents the underlying error, if any, which caused the current error.
+	//
+	// GqlCause is part of the GQL compliant errors preview feature
+	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlCause       *Neo4jError
 	parsed         bool
 	classification string // Legacy non-GQL classification

--- a/neo4j/db/errors.go
+++ b/neo4j/db/errors.go
@@ -23,12 +23,34 @@ import (
 	"strings"
 )
 
+type ErrorClassification string
+
+const (
+	ClientError    ErrorClassification = "CLIENT_ERROR"
+	DatabaseError  ErrorClassification = "DATABASE_ERROR"
+	TransientError ErrorClassification = "TRANSIENT_ERROR"
+	UnknownError   ErrorClassification = "UNKNOWN"
+)
+
 // Neo4jError is created when the database server failed to fulfill request.
+// TODO 6.0: rename to GqlError
 type Neo4jError struct {
-	Code           string
-	Msg            string
+	// TODO 6.0: to be deprecated.
+	Code      string
+	Msg       string
+	GqlStatus string
+	// TODO 6.0: rename to StatusDescription
+	GqlStatusDescription string
+	// TODO 6.0: rename to Classification
+	GqlClassification ErrorClassification
+	// TODO 6.0: rename to RawClassification
+	GqlRawClassification string
+	// TODO 6.0: rename to DiagnosticRecord
+	GqlDiagnosticRecord map[string]any
+	// TODO 6.0: rename to Cause
+	GqlCause       *Neo4jError
 	parsed         bool
-	classification string
+	classification string // Legacy non-GQL classification
 	category       string
 	title          string
 	retriable      bool
@@ -38,6 +60,7 @@ func (e *Neo4jError) Error() string {
 	return fmt.Sprintf("Neo4jError: %s (%s)", e.Code, e.Msg)
 }
 
+// TODO 6.0: remove in favour of GqlClassification
 func (e *Neo4jError) Classification() string {
 	e.parse()
 	return e.classification

--- a/neo4j/internal/bolt/connect.go
+++ b/neo4j/internal/bolt/connect.go
@@ -37,7 +37,7 @@ type protocolVersion struct {
 
 // Supported versions in priority order
 var versions = [4]protocolVersion{
-	{major: 5, minor: 6, back: 6},
+	{major: 5, minor: 7, back: 7},
 	{major: 4, minor: 4, back: 2},
 	{major: 4, minor: 1},
 	{major: 3, minor: 0},

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -20,6 +20,8 @@ package bolt
 import (
 	"errors"
 	"fmt"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/gql"
 	"time"
 
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
@@ -157,7 +159,7 @@ func (h *hydrator) hydrate(buf []byte) (x any, err error) {
 	case msgIgnored:
 		x = h.ignored(n)
 	case msgFailure:
-		x = h.failure(n)
+		x = h.failure(n, false)
 	case msgRecord:
 		x = h.record(n)
 	default:
@@ -178,27 +180,42 @@ func (h *hydrator) ignored(n uint32) *ignored {
 	return &h.cachedIgnored
 }
 
-func (h *hydrator) failure(n uint32) *db.Neo4jError {
+func (h *hydrator) failure(n uint32, isNestedError bool) *db.Neo4jError {
 	h.assertLength("failure", 1, n)
 	if h.getErr() != nil {
 		return nil
 	}
 	dberr := db.Neo4jError{}
-	h.unp.Next() // Detect map
+	// Skip h.unp.Next() for nested errors to avoid reprocessing the unpacker,
+	// as it's already handled by the recursive call.
+	if !isNestedError {
+		h.unp.Next() // Detect map
+	}
 	for maplen := h.unp.Len(); maplen > 0; maplen-- {
 		h.unp.Next()
 		key := h.unp.String()
 		h.unp.Next()
 		switch key {
+		case "gql_status":
+			dberr.GqlStatus = h.unp.String()
+		case "description":
+			dberr.GqlStatusDescription = h.unp.String()
+		case "neo4j_code":
+			fallthrough
 		case "code":
 			dberr.Code = h.unp.String()
 		case "message":
 			dberr.Msg = h.unp.String()
+		case "diagnostic_record":
+			dberr.GqlDiagnosticRecord = h.amap()
+		case "isNestedError":
+			dberr.GqlCause = h.failure(1, true)
 		default:
 			// Do not fail on unknown value in map
 			h.trash()
 		}
 	}
+	errorutil.PolyfillGqlError(&dberr)
 	if h.boltLogger != nil {
 		h.boltLogger.LogServerMessage(h.logId, "FAILURE %s", loggableFailure(dberr))
 	}
@@ -1003,14 +1020,6 @@ func parseNotification(m map[string]any) db.Notification {
 	return n
 }
 
-func newDefaultDiagnosticRecord() map[string]any {
-	return map[string]any{
-		"OPERATION":      "",
-		"OPERATION_CODE": "0",
-		"CURRENT_SCHEMA": "/",
-	}
-}
-
 func parseGqlStatusObject(m map[string]any) db.GqlStatusObject {
 	g := db.GqlStatusObject{}
 
@@ -1042,7 +1051,7 @@ func parseGqlStatusObject(m map[string]any) db.GqlStatusObject {
 	}
 
 	// Initialize the default diagnostic record
-	diagnosticRecord := newDefaultDiagnosticRecord()
+	diagnosticRecord := gql.NewDefaultDiagnosticRecord()
 
 	// Merge the diagnostic record from the map m
 	if dr, ok := m["diagnostic_record"].(map[string]any); ok {

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -208,7 +208,7 @@ func (h *hydrator) failure(n uint32, isNestedError bool) *db.Neo4jError {
 			dberr.Msg = h.unp.String()
 		case "diagnostic_record":
 			dberr.GqlDiagnosticRecord = h.amap()
-		case "isNestedError":
+		case "cause":
 			dberr.GqlCause = h.failure(1, true)
 		default:
 			// Do not fail on unknown value in map

--- a/neo4j/internal/bolt/hydrator_test.go
+++ b/neo4j/internal/bolt/hydrator_test.go
@@ -19,6 +19,7 @@ package bolt
 
 import (
 	"fmt"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/gql"
 	"math"
 	"reflect"
 	"runtime/debug"
@@ -47,7 +48,7 @@ func TestHydrator(outer *testing.T) {
 		panic(err)
 	}
 
-	fullDiagnosticRecord := newDefaultDiagnosticRecord()
+	fullDiagnosticRecord := gql.NewDefaultDiagnosticRecord()
 	fullDiagnosticRecord["_severity"] = "s1"
 	fullDiagnosticRecord["_classification"] = "c1"
 	fullDiagnosticRecord["_position"] = map[string]any{
@@ -379,7 +380,7 @@ func TestHydrator(outer *testing.T) {
 					{
 						GqlStatus:         "g2",
 						StatusDescription: "sd2",
-						DiagnosticRecord:  newDefaultDiagnosticRecord(),
+						DiagnosticRecord:  gql.NewDefaultDiagnosticRecord(),
 						IsNotification:    false,
 					},
 				}},

--- a/neo4j/internal/bolt/hydrator_test.go
+++ b/neo4j/internal/bolt/hydrator_test.go
@@ -1034,6 +1034,56 @@ func TestHydratorBolt5(outer *testing.T) {
 					}},
 			}},
 		},
+		{
+			name: "Failure with GQL Error",
+			build: func() {
+				packer.StructHeader(byte(msgFailure), 1)
+				packer.MapHeader(6)
+				packer.String("gql_status")
+				packer.String("g1")
+				packer.String("description")
+				packer.String("d1")
+				packer.String("message")
+				packer.String("m1")
+				packer.String("neo4j_code")
+				packer.String("c1")
+				packer.String("diagnostic_record")
+				packer.MapHeader(1) // diagnostic record map
+				packer.String("_classification")
+				packer.String("CLIENT_ERROR")
+				packer.String("cause")
+				packer.MapHeader(3) // nested cause error map
+				packer.String("gql_status")
+				packer.String("g2")
+				packer.String("description")
+				packer.String("d2")
+				packer.String("message")
+				packer.String("m2")
+			},
+			x: &db.Neo4jError{
+				Code:                 "c1",
+				Msg:                  "m1",
+				GqlStatus:            "g1",
+				GqlStatusDescription: "d1",
+				GqlClassification:    db.ClientError,
+				GqlRawClassification: "CLIENT_ERROR",
+				GqlDiagnosticRecord: map[string]any{
+					"OPERATION":       "",
+					"OPERATION_CODE":  "0",
+					"CURRENT_SCHEMA":  "/",
+					"_classification": "CLIENT_ERROR",
+				},
+				GqlCause: &db.Neo4jError{
+					Code:                 "Neo.DatabaseError.General.UnknownError",
+					Msg:                  "m2",
+					GqlStatus:            "g2",
+					GqlStatusDescription: "d2",
+					GqlClassification:    db.UnknownError,
+					GqlRawClassification: "",
+					GqlDiagnosticRecord:  gql.NewDefaultDiagnosticRecord(),
+				},
+			},
+		},
 	}
 
 	hydrator := hydrator{boltMajor: 5, useUtc: true}

--- a/neo4j/internal/errorutil/errors_test.go
+++ b/neo4j/internal/errorutil/errors_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/gql"
-	"reflect"
+	. "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
 	"testing"
 )
 
@@ -69,9 +69,7 @@ func TestCombineErrors(outer *testing.T) {
 		outer.Run(testCase.description, func(t *testing.T) {
 			output := errorutil.CombineErrors(testCase.input1, testCase.input2)
 
-			if !reflect.DeepEqual(testCase.output, output) {
-				t.Errorf("expected %v, got %v", testCase.output, output)
-			}
+			AssertDeepEquals(t, testCase.output, output)
 		})
 	}
 }
@@ -126,9 +124,7 @@ func TestCombineAllErrors(outer *testing.T) {
 		outer.Run(testCase.description, func(t *testing.T) {
 			output := errorutil.CombineAllErrors(testCase.input...)
 
-			if !reflect.DeepEqual(testCase.output, output) {
-				t.Errorf("expected %v, got %v", testCase.output, output)
-			}
+			AssertDeepEquals(t, testCase.output, output)
 		})
 	}
 }
@@ -193,9 +189,7 @@ func TestPolyfillGqlError(outer *testing.T) {
 		outer.Run(testCase.description, func(t *testing.T) {
 			errorutil.PolyfillGqlError(testCase.input)
 
-			if !reflect.DeepEqual(testCase.input, testCase.output) {
-				t.Errorf("expected %v, got %v", testCase.input, testCase.output)
-			}
+			AssertDeepEquals(t, testCase.input, testCase.output)
 		})
 	}
 }

--- a/neo4j/internal/gql/diagnostic_record.go
+++ b/neo4j/internal/gql/diagnostic_record.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gql
+
+func NewDefaultDiagnosticRecord() map[string]any {
+	return map[string]any{
+		"OPERATION":      "",
+		"OPERATION_CODE": "0",
+		"CURRENT_SCHEMA": "/",
+	}
+}

--- a/neo4j/internal/notifications/notifications.go
+++ b/neo4j/internal/notifications/notifications.go
@@ -1,23 +1,33 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package notifications
 
 import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/gql"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/notifications"
 )
-
-func newDefaultDiagnosticRecord() map[string]any {
-	return map[string]any{
-		"OPERATION":      "",
-		"OPERATION_CODE": "0",
-		"CURRENT_SCHEMA": "/",
-	}
-}
 
 func newSuccessGqlStatusObject() *db.GqlStatusObject {
 	return &db.GqlStatusObject{
 		GqlStatus:         "00000",
 		StatusDescription: "note: successful completion",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+		DiagnosticRecord:  gql.NewDefaultDiagnosticRecord(),
 	}
 }
 
@@ -25,7 +35,7 @@ func newNoDataGqlStatusObject() *db.GqlStatusObject {
 	return &db.GqlStatusObject{
 		GqlStatus:         "02000",
 		StatusDescription: "note: no data",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+		DiagnosticRecord:  gql.NewDefaultDiagnosticRecord(),
 	}
 }
 
@@ -33,7 +43,7 @@ func newOmittedResultGqlStatusObject() *db.GqlStatusObject {
 	return &db.GqlStatusObject{
 		GqlStatus:         "00001",
 		StatusDescription: "note: successful completion - omitted result",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+		DiagnosticRecord:  gql.NewDefaultDiagnosticRecord(),
 	}
 }
 
@@ -41,7 +51,7 @@ func newUnknownWarningResultGqlStatusObject() *db.GqlStatusObject {
 	return &db.GqlStatusObject{
 		GqlStatus:         "01N42",
 		StatusDescription: "warn: unknown warning",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+		DiagnosticRecord:  gql.NewDefaultDiagnosticRecord(),
 	}
 }
 
@@ -49,7 +59,7 @@ func newUnknownInformationResultGqlStatusObject() *db.GqlStatusObject {
 	return &db.GqlStatusObject{
 		GqlStatus:         "03N42",
 		StatusDescription: "info: unknown notification",
-		DiagnosticRecord:  newDefaultDiagnosticRecord(),
+		DiagnosticRecord:  gql.NewDefaultDiagnosticRecord(),
 	}
 }
 
@@ -84,7 +94,7 @@ func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
 		statusDescription = defaultStatus.StatusDescription
 	}
 
-	diagnosticRecord := newDefaultDiagnosticRecord()
+	diagnosticRecord := gql.NewDefaultDiagnosticRecord()
 
 	if notification.Position != nil {
 		diagnosticRecord["_position"] = map[string]any{


### PR DESCRIPTION
 ⚠️ This feature is in PREVIEW and may change without following the deprecation policy.
 
This PR adds GQL Error support to the Neo4jError struct. The new fields are added in a backward-compatible way, meaning existing error messages and codes will remain functional, even for GQL-compliant errors. Additionally, this update includes a polyfill function to set default values for GQL fields if they are not provided.

This is part of a broader effort to align Neo4j drivers with GQL standards.