### PR TITLE
ADR 032: Advertised Address

### DIFF
--- a/neo4j/directrouter.go
+++ b/neo4j/directrouter.go
@@ -28,6 +28,10 @@ type directRouter struct {
 	address string
 }
 
+func (r *directRouter) IsMultiServer() bool {
+	return false
+}
+
 func (r *directRouter) InvalidateWriter(string, string) {}
 
 func (r *directRouter) InvalidateReader(string, string) {}

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -220,7 +220,7 @@ func NewDriverWithContext(target string, auth auth.TokenManager, configurers ...
 	d.connector.Config = d.config
 
 	// Let the pool use the same log ID as the driver to simplify log reading.
-	d.pool = pool.New(d.config, d.connector.Connect, d.log, d.logId)
+	d.pool = pool.New(d.config, d.connector.Connect, d.log, d.logId, routing)
 
 	if !routing {
 		d.router = &directRouter{address: address}

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -220,7 +220,7 @@ func NewDriverWithContext(target string, auth auth.TokenManager, configurers ...
 	d.connector.Config = d.config
 
 	// Let the pool use the same log ID as the driver to simplify log reading.
-	d.pool = pool.New(d.config, d.connector.Connect, d.log, d.logId, routing)
+	d.pool = pool.New(d.config, d.connector.Connect, d.log, d.logId)
 
 	if !routing {
 		d.router = &directRouter{address: address}
@@ -312,6 +312,7 @@ type sessionRouter interface {
 	InvalidateWriter(db string, server string)
 	InvalidateReader(db string, server string)
 	InvalidateServer(server string)
+	IsMultiServer() bool
 }
 
 type driverWithContext struct {

--- a/neo4j/driver_with_context_testkit.go
+++ b/neo4j/driver_with_context_testkit.go
@@ -51,6 +51,10 @@ func ForceRoutingTableUpdate(d DriverWithContext, database string, bookmarks []s
 	return errorutil.WrapError(err)
 }
 
+func RegisterDnsResolver(d DriverWithContext, hook func(address string) []string) {
+	d.(*driverWithContext).connector.TestKitResolver = hook
+}
+
 func GetRoutingTable(d DriverWithContext, database string) (*RoutingTable, error) {
 	driver := d.(*driverWithContext)
 	router, ok := driver.router.(*router.Router)

--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -151,6 +151,15 @@ func (b *bolt3) ServerName() string {
 	return b.serverName
 }
 
+func (b *bolt3) AdvertisedServerName() string {
+	// Advertised address not supported by this protocol version
+	return ""
+}
+
+func (b *bolt3) SetServerName(serverName string) {
+	b.serverName = serverName
+}
+
 func (b *bolt3) ServerVersion() string {
 	return b.serverVersion
 }

--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -174,6 +174,15 @@ func (b *bolt4) ServerName() string {
 	return b.serverName
 }
 
+func (b *bolt4) AdvertisedServerName() string {
+	// Advertised address not supported by this protocol version
+	return ""
+}
+
+func (b *bolt4) SetServerName(serverName string) {
+	b.serverName = serverName
+}
+
 func (b *bolt4) ServerVersion() string {
 	return b.serverVersion
 }
@@ -985,7 +994,7 @@ func (b *bolt4) GetCurrentAuth() (auth.TokenManager, iauth.Token) {
 }
 
 func (b *bolt4) Telemetry(telemetry.API, func()) {
-	// TELEMETRY not support by this protocol version, so we ignore it.
+	// TELEMETRY not supported by this protocol version, so we ignore it.
 }
 
 func (b *bolt4) helloResponseHandler(checkUtcPatch bool) responseHandler {

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -93,28 +93,29 @@ func (i *internalTx5) toMeta(logger log.Logger, logId string, version db.Protoco
 }
 
 type bolt5 struct {
-	state            int
-	txId             idb.TxHandle
-	streams          openstreams
-	conn             io.ReadWriteCloser
-	serverName       string
-	queue            messageQueue
-	connId           string
-	logId            string
-	serverVersion    string
-	bookmark         string // Last bookmark
-	birthDate        time.Time
-	log              log.Logger
-	databaseName     string
-	err              error // Last fatal error
-	minor            int
-	lastQid          int64 // Last seen qid
-	idleDate         time.Time
-	auth             map[string]any
-	authManager      auth.TokenManager
-	resetAuth        bool
-	errorListener    ConnectionErrorListener
-	telemetryEnabled bool
+	state                int
+	txId                 idb.TxHandle
+	streams              openstreams
+	conn                 io.ReadWriteCloser
+	serverName           string // Initial server name
+	advertisedServerName string // Preferred server name
+	queue                messageQueue
+	connId               string
+	logId                string
+	serverVersion        string
+	bookmark             string // Last bookmark
+	birthDate            time.Time
+	log                  log.Logger
+	databaseName         string
+	err                  error // Last fatal error
+	minor                int
+	lastQid              int64 // Last seen qid
+	idleDate             time.Time
+	auth                 map[string]any
+	authManager          auth.TokenManager
+	resetAuth            bool
+	errorListener        ConnectionErrorListener
+	telemetryEnabled     bool
 }
 
 func NewBolt5(
@@ -176,6 +177,14 @@ func (b *bolt5) checkStreams() {
 
 func (b *bolt5) ServerName() string {
 	return b.serverName
+}
+
+func (b *bolt5) AdvertisedServerName() string {
+	return b.advertisedServerName
+}
+
+func (b *bolt5) SetServerName(serverName string) {
+	b.serverName = serverName
 }
 
 func (b *bolt5) ServerVersion() string {
@@ -989,6 +998,9 @@ func (b *bolt5) logoffResponseHandler() responseHandler {
 }
 
 func (b *bolt5) logonResponseHandler() responseHandler {
+	if b.Version().Major >= 5 && b.Version().Minor >= 8 {
+		return b.expectedSuccessHandler(b.onLogonSuccess)
+	}
 	return b.expectedSuccessHandler(onSuccessNoOp)
 }
 
@@ -1125,6 +1137,10 @@ func (b *bolt5) onHelloSuccess(helloSuccess *success) {
 	b.queue.setLogId(connectionLogId)
 	b.initializeReadTimeoutHint(helloSuccess.configurationHints)
 	b.initializeTelemetryHint(helloSuccess.configurationHints)
+}
+
+func (b *bolt5) onLogonSuccess(logonSuccess *success) {
+	b.advertisedServerName = logonSuccess.advertisedAddress
 }
 
 func (b *bolt5) onCommitSuccess(commitSuccess *success) {

--- a/neo4j/internal/bolt/connect.go
+++ b/neo4j/internal/bolt/connect.go
@@ -37,7 +37,7 @@ type protocolVersion struct {
 
 // Supported versions in priority order
 var versions = [4]protocolVersion{
-	{major: 5, minor: 7, back: 7},
+	{major: 5, minor: 8, back: 8},
 	{major: 4, minor: 4, back: 2},
 	{major: 4, minor: 1},
 	{major: 3, minor: 0},

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -56,6 +56,7 @@ type success struct {
 	num                uint32
 	configurationHints map[string]any
 	patches            []string
+	advertisedAddress  string
 }
 
 func (s *success) String() string {
@@ -302,6 +303,8 @@ func (h *hydrator) success(n uint32) *success {
 		case "patch_bolt":
 			patches := h.strings()
 			succ.patches = patches
+		case "advertised_address":
+			succ.advertisedAddress = h.unp.String()
 		default:
 			// Unknown key, waste it
 			h.trash()

--- a/neo4j/internal/connector/connector.go
+++ b/neo4j/internal/connector/connector.go
@@ -41,9 +41,10 @@ type Connector struct {
 	Network          string
 	Config           *config.Config
 	SupplyConnection func(context.Context, string) (net.Conn, error)
+	TestKitResolver  func(string) []string
 }
 
-func (c Connector) Connect(
+func (c *Connector) Connect(
 	ctx context.Context,
 	address string,
 	auth *db.ReAuthToken,
@@ -138,7 +139,24 @@ func (c Connector) createConnection(ctx context.Context, address string) (net.Co
 		dialer.KeepAlive = -1 * time.Second // Turns keep-alive off
 	}
 
-	return dialer.DialContext(ctx, c.Network, address)
+	if c.TestKitResolver == nil {
+		return dialer.DialContext(ctx, c.Network, address)
+	}
+
+	addresses := c.TestKitResolver(address)
+
+	if len(addresses) == 0 {
+		return nil, errors.New("TestKit DNS resolver returned no address")
+	}
+
+	var err error = nil
+	for _, address := range addresses {
+		con, err := dialer.DialContext(ctx, c.Network, address)
+		if err == nil {
+			return con, nil
+		}
+	}
+	return nil, err
 }
 
 func (c Connector) tlsConfig(serverName string) *tls.Config {

--- a/neo4j/internal/db/connection.go
+++ b/neo4j/internal/db/connection.go
@@ -124,6 +124,10 @@ type Connection interface {
 	Bookmark() string
 	// ServerName returns the name of the remote server
 	ServerName() string
+	// AdvertisedServerName returns the advertised name of the remote server.
+	AdvertisedServerName() string
+	// SetServerName updates the server name to given value.
+	SetServerName(serverName string)
 	// ServerVersion returns the server version on pattern Neo4j/1.2.3
 	ServerVersion() string
 	// IsAlive returns true if the connection is fully functional.

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -64,6 +64,7 @@ type Pool struct {
 	closed     bool
 	log        log.Logger
 	logId      string
+	routing    bool
 }
 
 type serverPenalty struct {
@@ -71,7 +72,7 @@ type serverPenalty struct {
 	penalty uint32
 }
 
-func New(config *config.Config, connect Connect, logger log.Logger, logId string) *Pool {
+func New(config *config.Config, connect Connect, logger log.Logger, logId string, routing bool) *Pool {
 	// Means infinite life, simplifies checking later on
 
 	p := &Pool{
@@ -83,6 +84,7 @@ func New(config *config.Config, connect Connect, logger log.Logger, logId string
 		queueMut:   sync.Mutex{},
 		logId:      logId,
 		log:        logger,
+		routing:    routing,
 	}
 	p.log.Infof(log.Pool, p.logId, "Created")
 	return p
@@ -393,7 +395,8 @@ func (p *Pool) Return(ctx context.Context, c idb.Connection) {
 	age := now.Sub(c.Birthdate())
 
 	// Check if we have an advertised server name and if so replace connection from initial server.
-	if c.AdvertisedServerName() != "" && c.ServerName() != c.AdvertisedServerName() {
+	// Only do this when routing is enabled.
+	if p.routing && c.AdvertisedServerName() != "" && c.ServerName() != c.AdvertisedServerName() {
 		// Remove connection from busy list of initial server.
 		p.unreg(ctx, c.ServerName(), c, now, false)
 		p.log.Debugf(log.Pool, p.logId, "Transferring connection from %s to advertised server %s", c.ServerName(), c.AdvertisedServerName())

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -400,9 +400,11 @@ func (p *Pool) Return(ctx context.Context, c idb.Connection) {
 		// Update connection server name to that of the advertised address.
 		c.SetServerName(c.AdvertisedServerName())
 		// Create a fresh server.
+		p.serversMut.Lock()
 		if _, ok := p.servers[c.ServerName()]; !ok {
 			p.servers[c.ServerName()] = NewServer()
 		}
+		p.serversMut.Unlock()
 	}
 
 	// Get the name of the server that the connection belongs to

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -47,6 +47,7 @@ type poolRouter interface {
 	InvalidateWriter(db string, server string)
 	InvalidateReader(db string, server string)
 	InvalidateServer(server string)
+	IsMultiServer() bool
 }
 
 type qitem struct {
@@ -64,7 +65,6 @@ type Pool struct {
 	closed     bool
 	log        log.Logger
 	logId      string
-	routing    bool
 }
 
 type serverPenalty struct {
@@ -72,7 +72,7 @@ type serverPenalty struct {
 	penalty uint32
 }
 
-func New(config *config.Config, connect Connect, logger log.Logger, logId string, routing bool) *Pool {
+func New(config *config.Config, connect Connect, logger log.Logger, logId string) *Pool {
 	// Means infinite life, simplifies checking later on
 
 	p := &Pool{
@@ -84,7 +84,6 @@ func New(config *config.Config, connect Connect, logger log.Logger, logId string
 		queueMut:   sync.Mutex{},
 		logId:      logId,
 		log:        logger,
-		routing:    routing,
 	}
 	p.log.Infof(log.Pool, p.logId, "Created")
 	return p
@@ -396,7 +395,7 @@ func (p *Pool) Return(ctx context.Context, c idb.Connection) {
 
 	// Check if we have an advertised server name and if so replace connection from initial server.
 	// Only do this when routing is enabled.
-	if p.routing && c.AdvertisedServerName() != "" && c.ServerName() != c.AdvertisedServerName() {
+	if p.router.IsMultiServer() && c.AdvertisedServerName() != "" && c.ServerName() != c.AdvertisedServerName() {
 		// Remove connection from busy list of initial server.
 		p.unreg(ctx, c.ServerName(), c, now, false)
 		p.log.Debugf(log.Pool, p.logId, "Transferring connection from %s to advertised server %s", c.ServerName(), c.AdvertisedServerName())

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -393,7 +393,7 @@ func (p *Pool) Return(ctx context.Context, c idb.Connection) {
 	age := now.Sub(c.Birthdate())
 
 	// Check if we have an advertised server name and if so replace connection from initial server.
-	if c.ServerName() != c.AdvertisedServerName() {
+	if c.AdvertisedServerName() != "" && c.ServerName() != c.AdvertisedServerName() {
 		// Remove connection from busy list of initial server.
 		p.unreg(ctx, c.ServerName(), c, now, false)
 		p.log.Debugf(log.Pool, p.logId, "Transferring connection from %s to advertised server %s", c.ServerName(), c.AdvertisedServerName())

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -303,7 +303,7 @@ func (p *Pool) tryBorrow(
 			if healthy {
 				return connection, nil
 			}
-			p.unreg(ctx, serverName, connection, itime.Now())
+			p.unreg(ctx, serverName, connection, itime.Now(), true)
 			if err != nil {
 				p.log.Debugf(log.Pool, p.logId, "Health check failed for %s: %s", serverName, err)
 				return nil, err
@@ -343,16 +343,18 @@ func (p *Pool) tryBorrow(
 	return c, nil
 }
 
-func (p *Pool) unreg(ctx context.Context, serverName string, c idb.Connection, now time.Time) {
+func (p *Pool) unreg(ctx context.Context, serverName string, c idb.Connection, now time.Time, close bool) {
 	p.serversMut.Lock()
 	defer p.serversMut.Unlock()
-	p.unregLocked(ctx, serverName, c, now)
+	p.unregLocked(ctx, serverName, c, now, close)
 }
 
-func (p *Pool) unregLocked(ctx context.Context, serverName string, c idb.Connection, now time.Time) {
+func (p *Pool) unregLocked(ctx context.Context, serverName string, c idb.Connection, now time.Time, close bool) {
 	defer func() {
 		// Close connection in another thread to avoid potential long blocking operation during close.
-		go c.Close(ctx)
+		if close {
+			go c.Close(ctx)
+		}
 	}()
 
 	server := p.servers[serverName]
@@ -384,16 +386,30 @@ func (p *Pool) Return(ctx context.Context, c idb.Connection) {
 		return
 	}
 
-	// Get the name of the server that the connection belongs to.
-	serverName := c.ServerName()
-	isAlive := c.IsAlive()
-	p.log.Debugf(log.Pool, p.logId, "Returning connection to %s {alive:%t}", serverName, isAlive)
-
 	// If the connection is dead, remove all other idle connections on the same server that older
 	// or of the same age as the dead connection, otherwise perform normal cleanup of old connections
 	maxAge := p.config.MaxConnectionLifetime
 	now := itime.Now()
 	age := now.Sub(c.Birthdate())
+
+	// Check if we have an advertised server name and if so replace connection from initial server.
+	if c.ServerName() != c.AdvertisedServerName() {
+		// Remove connection from busy list of initial server.
+		p.unreg(ctx, c.ServerName(), c, now, false)
+		p.log.Debugf(log.Pool, p.logId, "Transferring connection from %s to advertised server %s", c.ServerName(), c.AdvertisedServerName())
+		// Update connection server name to that of the advertised address.
+		c.SetServerName(c.AdvertisedServerName())
+		// Create a fresh server.
+		if _, ok := p.servers[c.ServerName()]; !ok {
+			p.servers[c.ServerName()] = NewServer()
+		}
+	}
+
+	// Get the name of the server that the connection belongs to
+	serverName := c.ServerName()
+	isAlive := c.IsAlive()
+	p.log.Debugf(log.Pool, p.logId, "Returning connection to %s {alive:%t}", serverName, isAlive)
+
 	if !isAlive {
 		// Since this connection has died all other connections that connected before this one
 		// might also be bad, remove the idle ones.
@@ -418,7 +434,7 @@ func (p *Pool) Return(ctx context.Context, c idb.Connection) {
 		// Fix for race condition where expired connections could be reused or closed concurrently.
 		// See: https://github.com/neo4j/neo4j-go-driver/issues/574
 		isAlive = false
-		p.unreg(ctx, serverName, c, now)
+		p.unreg(ctx, serverName, c, now, true)
 		p.log.Infof(log.Pool, p.logId, "Unregistering dead or too old connection to %s", serverName)
 	}
 

--- a/neo4j/internal/pool/pool_test.go
+++ b/neo4j/internal/pool/pool_test.go
@@ -22,6 +22,7 @@ package pool
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
@@ -42,6 +43,17 @@ var logger = log.ToVoid()
 var ctx = context.Background()
 var reAuthToken = &idb.ReAuthToken{FromSession: false, Manager: iauth.Token{Tokens: map[string]any{"scheme": "none"}}}
 
+type connectFunc = func(ctx context.Context, name string, _ *idb.ReAuthToken, _ bolt.ConnectionErrorListener, _ log.BoltLogger) (idb.Connection, error)
+
+func newPool(
+	conf *config.Config,
+	connect connectFunc,
+) *Pool {
+	pool := New(conf, connect, logger, "pool id")
+	pool.router = &RouterFake{}
+	return pool
+}
+
 func TestPoolBorrowReturn(outer *testing.T) {
 	maxAge := 1 * time.Second
 	birthdate := time.Now()
@@ -59,7 +71,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -82,7 +94,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -114,7 +126,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -136,7 +148,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: maxConnections}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		serverNames := []string{"srv1"}
 		numWorkers := 5
 		wg := sync.WaitGroup{}
@@ -170,7 +182,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 2}
-		p := New(&conf, failingConnect, logger, "pool id")
+		p := newPool(&conf, failingConnect)
 		p.SetRouter(&RouterFake{})
 		serverNames := []string{"srv1"}
 		c, err := p.Borrow(ctx, getServers(serverNames), true, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
@@ -185,7 +197,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		c1, _ := p.Borrow(ctx, getServers([]string{"A"}), true, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
 		cancelableCtx, cancel := context.WithCancel(ctx)
 		wg := sync.WaitGroup{}
@@ -216,7 +228,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 			t.Errorf("y u call me?")
 		}}
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		pool := New(&conf, nil, logger, "pool id")
+		pool := newPool(&conf, nil)
 		setIdleConnections(pool, map[string][]idb.Connection{"a server": {
 			deadAfterReset,
 			stayingAlive,
@@ -239,7 +251,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 			t.Errorf("force reset should not be called on new connections")
 		}}
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		pool := New(&conf, connectTo(healthyConnection), logger, "pool id")
+		pool := newPool(&conf, connectTo(healthyConnection))
 		setIdleConnections(pool, map[string][]idb.Connection{serverName: {deadAfterReset1, deadAfterReset2}})
 
 		result, err := pool.tryBorrow(ctx, serverName, nil, idlenessThreshold, reAuthToken)
@@ -254,7 +266,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		c1, err := p.Borrow(ctx, getServers([]string{"A"}), true, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
 		assertConnection(t, c1, err)
 		ctx = context.Background()
@@ -283,7 +295,7 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		c1, err := p.Borrow(ctx, getServers([]string{"A"}), true, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
 		assertConnection(t, c1, err)
 		ctx = context.Background()
@@ -314,7 +326,8 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		defer itime.ForceUnfreezeTime()
 		advertisedServerName := "advertised-server"
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
+		p.router.(*RouterFake).IsMultiServerReturn = true
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -327,11 +340,39 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		if len(servers) != 1 {
 			t.Errorf("Expected only 1 server, but %v were found", len(servers))
 		}
-		if _, exists := servers[advertisedServerName]; !exists {
+		serv, exists := servers[advertisedServerName]
+		if !exists {
 			t.Errorf("Expected connection to be transferred to %s, but server was not found", advertisedServerName)
-		}
-		if servers[advertisedServerName].numIdle() != 1 {
+		} else if serv.numIdle() != 1 {
 			t.Errorf("Expected 1 idle connection in %s, found %d", advertisedServerName, servers[advertisedServerName].numIdle())
+		}
+	})
+
+	outer.Run("Connection is not transferred to advertised server on return for direct pool", func(t *testing.T) {
+		itime.ForceFreezeTime()
+		defer itime.ForceUnfreezeTime()
+		advertisedServerName := "advertised-server"
+		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
+		p := newPool(&conf, succeedingConnect)
+		p.router.(*RouterFake).IsMultiServerReturn = false
+		defer func() {
+			p.Close(ctx)
+		}()
+		serverName := "srvA"
+		c, _ := p.Borrow(ctx, getServers([]string{serverName}), true, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
+		c.(*ConnFake).AdvertisedName = advertisedServerName
+		p.Return(ctx, c)
+		servers := p.getServers()
+
+		fmt.Printf("%v\n", servers["foo"])
+		if len(servers) != 1 {
+			t.Errorf("Expected only 1 server, but %v were found", len(servers))
+		}
+		serv, exists := servers[serverName]
+		if !exists {
+			t.Errorf("Expected connection not to be transferred to %s, but server was not found", serverName)
+		} else if serv.numIdle() != 1 {
+			t.Errorf("Expected 1 idle connection in %s, found %d", serverName, servers[serverName].numIdle())
 		}
 	})
 }
@@ -349,7 +390,7 @@ func TestPoolResourceUsage(ot *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -364,7 +405,7 @@ func TestPoolResourceUsage(ot *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 2}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -382,7 +423,7 @@ func TestPoolResourceUsage(ot *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 2}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -400,7 +441,7 @@ func TestPoolResourceUsage(ot *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: 1<<63 - 1, MaxConnectionPoolSize: 3}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		// Trigger creation of three connections on the same server
 		c1, _ := p.Borrow(ctx, getServers([]string{"A"}), true, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
 		c2, _ := p.Borrow(ctx, getServers([]string{"A"}), true, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
@@ -428,7 +469,7 @@ func TestPoolResourceUsage(ot *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -449,7 +490,7 @@ func TestPoolResourceUsage(ot *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -481,7 +522,7 @@ func TestPoolCleanup(ot *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxLife, MaxConnectionPoolSize: 0}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -502,7 +543,7 @@ func TestPoolCleanup(ot *testing.T) {
 		itime.ForceFreezeTime()
 		defer itime.ForceUnfreezeTime()
 		conf := config.Config{MaxConnectionLifetime: maxLife, MaxConnectionPoolSize: 0}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		defer func() {
 			p.Close(ctx)
 		}()
@@ -525,7 +566,7 @@ func TestPoolCleanup(ot *testing.T) {
 			return nil, errors.New("an error")
 		}
 		conf := config.Config{MaxConnectionLifetime: maxLife, MaxConnectionPoolSize: 0}
-		p := New(&conf, failingConnect, logger, "pool id")
+		p := newPool(&conf, failingConnect)
 		p.SetRouter(&RouterFake{})
 		defer func() {
 			p.Close(ctx)
@@ -555,7 +596,7 @@ func TestPoolCleanup(ot *testing.T) {
 			MaxConnectionLifetime:        maxLife,
 			MaxConnectionPoolSize:        1,
 		}
-		p := New(&conf, succeedingConnect, logger, "pool id")
+		p := newPool(&conf, succeedingConnect)
 		servers := getServers([]string{"example.com"})
 		conn, err := p.Borrow(ctx, servers, false, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
 		assertConnection(t, conn, err)

--- a/neo4j/internal/pool/pool_test.go
+++ b/neo4j/internal/pool/pool_test.go
@@ -308,6 +308,32 @@ func TestPoolBorrowReturn(outer *testing.T) {
 		wg.Wait()
 		AssertTrue(t, reAuthCalled)
 	})
+
+	outer.Run("Connection is transferred to advertised server on return", func(t *testing.T) {
+		itime.ForceFreezeTime()
+		defer itime.ForceUnfreezeTime()
+		advertisedServerName := "advertised-server"
+		conf := config.Config{MaxConnectionLifetime: maxAge, MaxConnectionPoolSize: 1}
+		p := New(&conf, succeedingConnect, logger, "pool id")
+		defer func() {
+			p.Close(ctx)
+		}()
+		serverNames := []string{"srvA"}
+		c, _ := p.Borrow(ctx, getServers(serverNames), true, nil, DefaultConnectionLivenessCheckTimeout, reAuthToken)
+		c.(*ConnFake).AdvertisedName = advertisedServerName
+		p.Return(ctx, c)
+		servers := p.getServers()
+
+		if len(servers) != 1 {
+			t.Errorf("Expected only 1 server, but %v were found", len(servers))
+		}
+		if _, exists := servers[advertisedServerName]; !exists {
+			t.Errorf("Expected connection to be transferred to %s, but server was not found", advertisedServerName)
+		}
+		if servers[advertisedServerName].numIdle() != 1 {
+			t.Errorf("Expected 1 idle connection in %s, found %d", advertisedServerName, servers[advertisedServerName].numIdle())
+		}
+	})
 }
 
 // Resource usage scenarios

--- a/neo4j/internal/router/router.go
+++ b/neo4j/internal/router/router.go
@@ -81,6 +81,10 @@ func New(rootRouter string, getRouters func() []string, routerContext map[string
 	return r
 }
 
+func (r *Router) IsMultiServer() bool {
+	return true
+}
+
 func (r *Router) readTable(
 	ctx context.Context,
 	dbRouter *databaseRouter,

--- a/neo4j/internal/testutil/connfake.go
+++ b/neo4j/internal/testutil/connfake.go
@@ -90,6 +90,13 @@ func (c *ConnFake) ServerName() string {
 	return c.Name
 }
 
+func (c *ConnFake) AdvertisedServerName() string {
+	return ""
+}
+
+func (c *ConnFake) SetServerName(serverName string) {
+}
+
 func (c *ConnFake) IsAlive() bool {
 	return c.Alive
 }

--- a/neo4j/internal/testutil/connfake.go
+++ b/neo4j/internal/testutil/connfake.go
@@ -45,6 +45,7 @@ type RecordedTx struct {
 
 type ConnFake struct {
 	Name               string
+	AdvertisedName     string
 	ConnectionVersion  db.ProtocolVersion
 	Alive              bool
 	Birth              time.Time
@@ -91,10 +92,11 @@ func (c *ConnFake) ServerName() string {
 }
 
 func (c *ConnFake) AdvertisedServerName() string {
-	return ""
+	return c.AdvertisedName
 }
 
 func (c *ConnFake) SetServerName(serverName string) {
+	c.Name = serverName
 }
 
 func (c *ConnFake) IsAlive() bool {

--- a/neo4j/internal/testutil/routerfake.go
+++ b/neo4j/internal/testutil/routerfake.go
@@ -35,6 +35,11 @@ type RouterFake struct {
 	Err                    error
 	CleanUpHook            func()
 	GetNameOfDefaultDbHook func(user string) (string, error)
+	IsMultiServerReturn    bool
+}
+
+func (r *RouterFake) IsMultiServer() bool {
+	return r.IsMultiServerReturn
 }
 
 func (r *RouterFake) InvalidateReader(database string, server string) {

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -52,6 +52,7 @@ type backend struct {
 	explicitTransactions            map[string]neo4j.ExplicitTransaction
 	recordedErrors                  map[string]error
 	resolvedAddresses               map[string][]any
+	dnsResolutions                  map[string][]any
 	authTokenManagers               map[string]auth.TokenManager
 	resolvedGetAuthTokens           map[string]neo4j.AuthToken
 	resolvedHandleSecurityException map[string]bool
@@ -496,6 +497,27 @@ func (b *backend) customAddressResolverFunction() config.ServerAddressResolver {
 	}
 }
 
+func (b *backend) dnsResolverFunction() func(address string) []string {
+	return func(address string) []string {
+		id := b.nextId()
+		b.writeResponse("DomainNameResolutionRequired", map[string]string{
+			"id":   id,
+			"name": address,
+		})
+		for {
+			b.process()
+			if addresses, ok := b.dnsResolutions[id]; ok {
+				delete(b.dnsResolutions, id)
+				result := make([]string, len(addresses))
+				for i, address := range addresses {
+					result[i] = address.(string)
+				}
+				return result
+			}
+		}
+	}
+}
+
 type serverAddress struct {
 	hostname string
 	port     string
@@ -532,6 +554,11 @@ func (b *backend) handleRequest(req map[string]any) {
 
 	fmt.Printf("REQ: %s %s\n", name, dataJson)
 	switch name {
+
+	case "DomainNameResolutionCompleted":
+		requestId := data["requestId"].(string)
+		addresses := data["addresses"].([]any)
+		b.dnsResolutions[requestId] = addresses
 
 	case "ResolverResolutionCompleted":
 		requestId := data["requestId"].(string)
@@ -637,6 +664,11 @@ func (b *backend) handleRequest(req map[string]any) {
 			b.writeError(err)
 			return
 		}
+
+		if data["domainNameResolverRegistered"] != nil && data["domainNameResolverRegistered"].(bool) == true {
+			neo4j.RegisterDnsResolver(driver, b.dnsResolverFunction())
+		}
+
 		idKey := b.nextId()
 		b.drivers[idKey] = driver
 		b.writeResponse("Driver", map[string]any{"id": idKey})

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -149,6 +149,7 @@ func newBackend(rd *bufio.Reader, wr io.Writer) *backend {
 		explicitTransactions:            make(map[string]neo4j.ExplicitTransaction),
 		recordedErrors:                  make(map[string]error),
 		resolvedAddresses:               make(map[string][]any),
+		dnsResolutions:                  make(map[string][]any),
 		authTokenManagers:               make(map[string]auth.TokenManager),
 		resolvedGetAuthTokens:           make(map[string]neo4j.AuthToken),
 		resolvedHandleSecurityException: make(map[string]bool),
@@ -665,7 +666,7 @@ func (b *backend) handleRequest(req map[string]any) {
 			return
 		}
 
-		if data["domainNameResolverRegistered"] != nil && data["domainNameResolverRegistered"].(bool) == true {
+		if data["domainNameResolverRegistered"] != nil && data["domainNameResolverRegistered"].(bool) {
 			neo4j.RegisterDnsResolver(driver, b.dnsResolverFunction())
 		}
 

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1302,6 +1302,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"Feature:Bolt:5.5",
 				"Feature:Bolt:5.6",
 				"Feature:Bolt:5.7",
+				"Feature:Bolt:5.8",
 				"Feature:Bolt:Patch:UTC",
 				"Feature:Impersonation",
 				//"Feature:TLS:1.1",

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1363,6 +1363,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"ConfHint:connection.recv_timeout_seconds",
 
 				// === BACKEND FEATURES FOR TESTING ===
+				"Backend:DNSResolver",
 				"Backend:MockTime",
 				"Backend:RTFetch",
 				"Backend:RTForceUpdate",
@@ -1724,10 +1725,6 @@ func testSkips() map[string]string {
 		"stub.routing.test_routing_v3.RoutingV3.test_should_fail_when_writing_on_unexpectedly_interrupting_writer_on_pull_using_tx_run":            "Won't fix - only Bolt 3 affected (not officially supported by this driver): broken servers are not removed from routing table",
 		"stub.routing.test_routing_v3.RoutingV3.test_should_fail_when_writing_on_unexpectedly_interrupting_writer_on_run_using_tx_run":             "Won't fix - only Bolt 3 affected (not officially supported by this driver): broken servers are not removed from routing table",
 		"stub.routing.test_routing_v3.RoutingV3.test_should_fail_when_writing_on_unexpectedly_interrupting_writer_using_tx_run":                    "Won't fix - only Bolt 3 affected (not officially supported by this driver): broken servers are not removed from routing table",
-
-		// Missing message support in testkit backend
-		"stub.routing.*.*.test_should_request_rt_from_all_initial_routers_until_successful_on_unknown_failure":       "Add DNS resolver TestKit message and connection timeout support",
-		"stub.routing.*.*.test_should_request_rt_from_all_initial_routers_until_successful_on_authorization_expired": "Add DNS resolver TestKit message and connection timeout support",
 
 		// To fix/to decide whether to fix
 		"stub.routing.test_routing_v*.RoutingV*.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors": "Driver always uses configured URL first and custom resolver only if that fails",

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "5.0"
+    "ref": "advertised-address"
   }
 }


### PR DESCRIPTION
Update driver to handle the `advertised_address` field returned in the `SUCCESS` message during the `LOGON` process. This ensures the driver correctly identifies the actual server it connects to, allowing improved connection reuse and reducing unnecessary connection churn when operating behind a load balancer or proxy.

Bolt logs (notice the "Transferring connection from" log):

```
2024-12-04 09:54:40.892   INFO  [pool 1] Created
2024-12-04 09:54:40.892   INFO  [router 1] Created {context: map[address:cathcart-devcore.databases.neo4j-dev.io:7687]}
2024-12-04 09:54:40.892   INFO  [driver 1] Created { target: cathcart-devcore.databases.neo4j-dev.io:7687 }
2024-12-04 09:54:40.892  DEBUG  [session 2] Created
2024-12-04 09:54:40.892  DEBUG  [session 2] connection acquisition timeout is 1m0s, resolved deadline is: 2024-12-04 09:55:40.892878 +0000 GMT m=+60.001365513
2024-12-04 09:54:40.892   INFO  [router 1] Reading routing table from initial router: cathcart-devcore.databases.neo4j-dev.io:7687
2024-12-04 09:54:40.892  DEBUG  [pool 1] Trying to borrow connection from [cathcart-devcore.databases.neo4j-dev.io:7687]
2024-12-04 09:54:40.892   INFO  [pool 1] Connecting to cathcart-devcore.databases.neo4j-dev.io:7687
2024-12-04 09:54:40.950   BOLT  C: <MAGIC> 0X6060B017
2024-12-04 09:54:40.950   BOLT  C: <HANDSHAKE> 0X00080805 0X00020404 0X00000104 0X00000003
2024-12-04 09:54:40.974   BOLT  S: <HANDSHAKE> 0X00000805
2024-12-04 09:54:40.974   BOLT  C: HELLO {"bolt_agent":{"language":"Go/go1.20.3","platform":"darwin; amd64","product":"neo4j-go/5.27.0"},"routing":{"address":"cathcart-devcore.databases.neo4j-dev.io:7687"},"user_agent":"Go Driver/5.27.0"}
2024-12-04 09:54:40.974   BOLT  C: LOGON {"credentials":"<redacted>","principal":"neo4j","scheme":"basic"}
2024-12-04 09:54:40.995   BOLT  S: SUCCESS {"server":"Neo4j/2024.12-aura","connection_id":"bolt-27442","hints":{"connection.recv_timeout_seconds":60,"ssr.enabled":true,"telemetry.enabled":true}}
2024-12-04 09:54:40.997   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] S: SUCCESS {}
2024-12-04 09:54:40.997   INFO  [bolt5 bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] Connected
2024-12-04 09:54:40.997   INFO  [bolt5 bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] Retrieving routing table
2024-12-04 09:54:40.997   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] C: ROUTE {"address":"cathcart-devcore.databases.neo4j-dev.io:7687"} null {"db":"neo4j"}
2024-12-04 09:54:41.020   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] S: SUCCESS {"routing_table":{"ttl":10,"db":"neo4j","routers":["p-cathcart-f4c4-0002.devcore-orch-0001.neo4j-dev.io:7687","p-cathcart-f4c4-0003.devcore-orch-0001.neo4j-dev.io:7687","p-cathcart-f4c4-0001.devcore-orch-0001.neo4j-dev.io:7687"],"readers":["p-cathcart-f4c4-0001.devcore-orch-0001.neo4j-dev.io:7687","p-cathcart-f4c4-0003.devcore-orch-0001.neo4j-dev.io:7687"],"writers":["p-cathcart-f4c4-0002.devcore-orch-0001.neo4j-dev.io:7687"]}}
2024-12-04 09:54:41.020  DEBUG  [pool 1] Transferring connection from cathcart-devcore.databases.neo4j-dev.io:7687 to advertised server p-cathcart-f4c4-0002.devcore-orch-0001.neo4j-dev.io:7687
2024-12-04 09:54:41.020  DEBUG  [pool 1] Returning connection to p-cathcart-f4c4-0002.devcore-orch-0001.neo4j-dev.io:7687 {alive:true}
2024-12-04 09:54:41.020  DEBUG  [bolt5 bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] Resetting connection internal state
2024-12-04 09:54:41.020  DEBUG  [router 1] New routing table for 'neo4j', TTL 10
2024-12-04 09:54:41.020  DEBUG  [pool 1] Trying to borrow connection from [p-cathcart-f4c4-0002.devcore-orch-0001.neo4j-dev.io:7687]
2024-12-04 09:54:41.020   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] C: TELEMETRY 3
2024-12-04 09:54:41.020   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] C: BEGIN {"db":"neo4j"}
2024-12-04 09:54:41.020   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] C: RUN "RETURN 1" {} {}
2024-12-04 09:54:41.020   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] C: PULL {"n":1000}
2024-12-04 09:54:41.042   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] S: SUCCESS {}
2024-12-04 09:54:41.043   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] S: SUCCESS {}
2024-12-04 09:54:41.044   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] S: SUCCESS {"fields":["1"]}
2024-12-04 09:54:41.045   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] S: RECORD [1]
2024-12-04 09:54:41.045   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] S: SUCCESS {"db":"neo4j"}
2024-12-04 09:54:41.045   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] C: COMMIT
2024-12-04 09:54:41.067   BOLT  [bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] S: SUCCESS {"bookmark":"FB:kcwQwwvW7LUdQdS+Y3dAUMpvkAOQ"}
2024-12-04 09:54:41.067  DEBUG  [pool 1] Returning connection to p-cathcart-f4c4-0002.devcore-orch-0001.neo4j-dev.io:7687 {alive:true}
2024-12-04 09:54:41.067  DEBUG  [bolt5 bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] Resetting connection internal state
2024-12-04 09:54:41.067  DEBUG  [router 1] Cleaning up
2024-12-04 09:54:41.067  DEBUG  [session 2] Closed
2024-12-04 09:54:41.067   INFO  [pool 1] Closed
2024-12-04 09:54:41.067   INFO  [driver 1] Closed
2024-12-04 09:54:41.067   INFO  [bolt5 bolt-27442@cathcart-devcore.databases.neo4j-dev.io:7687] Close
```

Depends on:
 * https://github.com/neo4j-drivers/testkit/pull/642
   (after merge, undo the temporary change of `testkit/testkit.json` and re-run CI)