### PR TITLE
Add support for serializing custom parameter types

### DIFF
--- a/neo4j/dbtype/spatial.go
+++ b/neo4j/dbtype/spatial.go
@@ -19,6 +19,7 @@ package dbtype
 
 import (
 	"fmt"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/packstream"
 )
 
 // Point2D represents a two dimensional point in a particular coordinate reference system.
@@ -34,6 +35,23 @@ type Point3D struct {
 	Y            float64
 	Z            float64
 	SpatialRefId uint32 // Id of coordinate reference system.
+}
+
+// SerializeNeo4j serializes this point into the Packer.
+func (p Point2D) SerializeNeo4j(packer packstream.Packer) {
+	packer.StructHeader('X', 3)
+	packer.Uint32(p.SpatialRefId)
+	packer.Float64(p.X)
+	packer.Float64(p.Y)
+}
+
+// SerializeNeo4j serializes this point into the Packer.
+func (p Point3D) SerializeNeo4j(packer packstream.Packer) {
+	packer.StructHeader('Y', 4)
+	packer.Uint32(p.SpatialRefId)
+	packer.Float64(p.X)
+	packer.Float64(p.Y)
+	packer.Float64(p.Z)
 }
 
 // String returns string representation of this point.

--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -125,7 +125,9 @@ func NewBolt3(
 	}
 	b.out = &outgoing{
 		chunker: newChunker(),
-		packer:  packstream.Packer{},
+		packer:  packstream.Packer{
+			UseUtc: false,
+		},
 		onPackErr: func(err error) {
 			if b.err == nil {
 				b.err = err
@@ -142,7 +144,6 @@ func NewBolt3(
 			b.state = bolt3_dead
 		},
 		boltLogger: boltLog,
-		useUtc:     false,
 	}
 	return b
 }

--- a/neo4j/internal/bolt/bolt3_test.go
+++ b/neo4j/internal/bolt/bolt3_test.go
@@ -123,7 +123,7 @@ func TestBolt3(outer *testing.T) {
 
 		bolt := c.(*bolt3)
 		assertBoltState(t, bolt3_ready, bolt)
-		if bolt.out.useUtc {
+		if bolt.out.packer.UseUtc {
 			t.Fatalf("Bolt 3 connections must never send and receive UTC datetimes")
 		}
 		return bolt, cleanup

--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -1109,7 +1109,7 @@ func (b *bolt4) onHelloSuccess(checkUtcPatch bool) func(*success) {
 		if checkUtcPatch {
 			useUtc := collections.SliceContains(helloSuccess.patches, "utc")
 			b.queue.in.hyd.useUtc = useUtc
-			b.queue.out.useUtc = useUtc
+			b.queue.out.packer.UseUtc = useUtc
 		}
 		b.connId = helloSuccess.connectionId
 		b.serverVersion = helloSuccess.server

--- a/neo4j/internal/bolt/bolt4_test.go
+++ b/neo4j/internal/bolt/bolt4_test.go
@@ -144,7 +144,7 @@ func TestBolt4(outer *testing.T) {
 		AssertStringEqual(t, bolt.ServerName(), "serverName")
 		AssertTrue(t, bolt.IsAlive())
 		AssertTrue(t, reflect.DeepEqual(bolt.queue.in.connReadTimeout, time.Duration(-1)))
-		AssertFalse(t, bolt.queue.out.useUtc)
+		AssertFalse(t, bolt.queue.out.packer.UseUtc)
 	})
 
 	outer.Run("Connect success with timeout hint", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestBolt4(outer *testing.T) {
 			defer cleanup()
 			defer bolt.Close(context.Background())
 
-			AssertTrue(t, bolt.queue.out.useUtc)
+			AssertTrue(t, bolt.queue.out.packer.UseUtc)
 		})
 
 		outer.Run(fmt.Sprintf("[%d.%d] Connect success with unknown patch", major, minor), func(t *testing.T) {
@@ -186,7 +186,7 @@ func TestBolt4(outer *testing.T) {
 			defer cleanup()
 			defer bolt.Close(context.Background())
 
-			AssertFalse(t, bolt.queue.out.useUtc)
+			AssertFalse(t, bolt.queue.out.packer.UseUtc)
 		})
 	}
 

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -148,12 +148,13 @@ func NewBolt5(
 			connReadTimeout: -1,
 		},
 		&outgoing{
-			chunker:    newChunker(),
-			packer:     packstream.Packer{},
+			chunker: newChunker(),
+			packer: packstream.Packer{
+				UseUtc: true,
+			},
 			onPackErr:  func(err error) { b.setError(err, true) },
 			onIoErr:    b.onIoError,
 			boltLogger: boltLog,
-			useUtc:     true,
 		},
 		b.onNextMessage,
 		b.onIoError,

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -144,7 +144,7 @@ func TestBolt5(outer *testing.T) {
 
 		bolt := c.(*bolt5)
 		assertBoltState(t, bolt5Ready, bolt)
-		if !bolt.queue.out.useUtc {
+		if !bolt.queue.out.packer.UseUtc {
 			t.Fatalf("Bolt 5+ connections must always send and receive UTC datetimes")
 		}
 		return bolt, cleanup

--- a/neo4j/internal/bolt/outgoing_test.go
+++ b/neo4j/internal/bolt/outgoing_test.go
@@ -368,9 +368,9 @@ func TestOutgoing(ot *testing.T) {
 			name: "UTC datetime struct, with timezone offset",
 			build: func(t *testing.T, out *outgoing) {
 				defer func() {
-					out.useUtc = false
+					out.packer.UseUtc = false
 				}()
-				out.useUtc = true
+				out.packer.UseUtc = true
 				minusTwoHours := -2 * 60 * 60
 				tz := time.FixedZone("Offset", minusTwoHours)
 				out.begin()
@@ -393,9 +393,9 @@ func TestOutgoing(ot *testing.T) {
 			name: "UTC datetime struct, with timezone name",
 			build: func(t *testing.T, out *outgoing) {
 				defer func() {
-					out.useUtc = false
+					out.packer.UseUtc = false
 				}()
-				out.useUtc = true
+				out.packer.UseUtc = true
 				tz, err := time.LoadLocation("Pacific/Honolulu")
 				if err != nil {
 					t.Fatal(err)

--- a/neo4j/packstream/packstream.go
+++ b/neo4j/packstream/packstream.go
@@ -1,0 +1,23 @@
+package packstream
+
+type Packer interface {
+	Nil()
+	Bool(b bool)
+	Int(i int)
+	Int8(i int8)
+	Int16(i int16)
+	Int32(i int32)
+	Int64(i int64)
+	Uint(i uint)
+	Uint8(i uint8)
+	Uint16(i uint16)
+	Uint32(i uint32)
+	Uint64(i uint64)
+	Float32(f float32)
+	Float64(f float64)
+	String(s string)
+	Bytes(b []byte)
+	MapHeader(l int)
+	ArrayHeader(l int)
+	StructHeader(tag byte, num int)
+}


### PR DESCRIPTION
Add support for serializing custom types that define a particular SerializeNeo4j method.

* Exposes a Packer interface to the public API that data can be serialized into.
* Adds a check for a method SerializeNeo4j(Packer) on parameter types - if it exists, use it to serialize the value.
* Moves serialization logic for dbtype types to SerializeNeo4j methods.
* Rearranges some serialization logic into new Packer methods so that it can be accessed by the SerializeNeo4j methods - in particular for time.Time.