### PR TITLE
Optimize serialization of []any and map[string]any

### DIFF
--- a/neo4j/internal/bolt/outgoing.go
+++ b/neo4j/internal/bolt/outgoing.go
@@ -408,6 +408,11 @@ func (o *outgoing) packX(x any) {
 			o.packer.Strings(s)
 		case []float64:
 			o.packer.Float64s(s)
+		case []any:
+			o.packer.ArrayHeader(len(s))
+			for _, e := range s {
+				o.packX(e)
+			}
 		default:
 			num := v.Len()
 			o.packer.ArrayHeader(num)
@@ -422,17 +427,27 @@ func (o *outgoing) packX(x any) {
 			o.packer.IntMap(m)
 		case map[string]string:
 			o.packer.StringMap(m)
+		case map[string]any:
+			o.packMap(m)
 		default:
 			t := reflect.TypeOf(x)
 			if t.Key().Kind() != reflect.String {
 				o.onPackErr(&db.UnsupportedTypeError{Type: reflect.TypeOf(x)})
 				return
 			}
-			o.packer.MapHeader(v.Len())
-			// TODO Use MapRange when min Go version is >= 1.12
-			for _, ki := range v.MapKeys() {
-				o.packer.String(ki.String())
-				o.packX(v.MapIndex(ki).Interface())
+			l := v.Len()
+			o.packer.MapHeader(l)
+			if l == 0 {
+				return
+			}
+			key := reflect.New(t.Key()).Elem()
+			value := reflect.New(t.Elem()).Elem()
+			r := v.MapRange()
+			for r.Next() {
+				key.SetIterKey(r)
+				value.SetIterValue(r)
+				o.packer.String(key.String())
+				o.packX(value.Interface())
 			}
 		}
 	default:

--- a/neo4j/internal/bolt/outgoing.go
+++ b/neo4j/internal/bolt/outgoing.go
@@ -391,7 +391,7 @@ func (o *outgoing) packX(x any) {
 		case reflect.Struct:
 			o.packStruct(x)
 		default:
-			o.packX(i.Interface())
+			o.packV(i)
 		}
 	case reflect.Struct:
 		o.packStruct(x)
@@ -417,7 +417,7 @@ func (o *outgoing) packX(x any) {
 			num := v.Len()
 			o.packer.ArrayHeader(num)
 			for i := 0; i < num; i++ {
-				o.packX(v.Index(i).Interface())
+				o.packV(v.Index(i))
 			}
 		}
 	case reflect.Map:
@@ -448,16 +448,50 @@ func (o *outgoing) packX(x any) {
 			}
 			key := reflect.New(t.Key()).Elem()
 			value := reflect.New(t.Elem()).Elem()
-			r := v.MapRange()
-			for r.Next() {
-				key.SetIterKey(r)
-				value.SetIterValue(r)
+			iter := v.MapRange()
+			for iter.Next() {
+				key.SetIterKey(iter)
+				value.SetIterValue(iter)
 				o.packer.String(key.String())
-				o.packX(value.Interface())
+				o.packV(value)
 			}
 		}
 	default:
 		o.onPackErr(&db.UnsupportedTypeError{Type: reflect.TypeOf(x)})
+	}
+}
+
+func (o *outgoing) packV(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Bool:
+		o.packer.Bool(v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		o.packer.Int64(v.Int())
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		o.packer.Uint32(uint32(v.Uint()))
+	case reflect.Uint64, reflect.Uint:
+		o.packer.Uint64(v.Uint())
+	case reflect.Float32, reflect.Float64:
+		o.packer.Float64(v.Float())
+	case reflect.String:
+		o.packer.String(v.String())
+	case reflect.Ptr:
+		if v.IsNil() {
+			o.packer.Nil()
+			return
+		}
+		// Inspect what the pointer points to
+		i := reflect.Indirect(v)
+		switch i.Kind() {
+		case reflect.Struct:
+			o.packStruct(v.Interface())
+		default:
+			o.packV(i)
+		}
+	case reflect.Struct:
+		o.packStruct(v.Interface())
+	default:
+		o.packX(v.Interface())
 	}
 }
 

--- a/neo4j/internal/bolt/outgoing.go
+++ b/neo4j/internal/bolt/outgoing.go
@@ -490,6 +490,27 @@ func (o *outgoing) packV(v reflect.Value) {
 		}
 	case reflect.Struct:
 		o.packStruct(v.Interface())
+	case reflect.Slice:
+		switch v.Type().Elem().Kind() {
+		case reflect.Uint8:
+			o.packer.Bytes(v.Bytes())
+			return
+		case reflect.Int, reflect.Int64, reflect.String, reflect.Float64, reflect.Interface:
+			if v.Len() > 5 {
+				// Accept the cost of an allocation (v.Interface())
+				// because this slice type is optimized in packX.
+				// The exact length from which the optimization amortizes
+				// the allocation cost depends on many factors.
+				// 5 is an arbitrary guess.
+				o.packX(v.Interface())
+				return
+			}
+		}
+		num := v.Len()
+		o.packer.ArrayHeader(num)
+		for i := 0; i < num; i++ {
+			o.packV(v.Index(i))
+		}
 	default:
 		o.packX(v.Interface())
 	}

--- a/neo4j/internal/bolt/outgoing.go
+++ b/neo4j/internal/bolt/outgoing.go
@@ -461,6 +461,17 @@ func (o *outgoing) packX(x any) {
 	}
 }
 
+func typeForPrimitive[T any]() reflect.Type {
+	var v T
+	return reflect.TypeOf(v)
+}
+
+var intT = typeForPrimitive[int]()
+var int64T = typeForPrimitive[int64]()
+var stringT = typeForPrimitive[string]()
+var float64T = typeForPrimitive[float64]()
+var anyT = reflect.TypeOf((*any)(nil)).Elem()
+
 func (o *outgoing) packV(v reflect.Value) {
 	switch v.Kind() {
 	case reflect.Bool:
@@ -491,22 +502,26 @@ func (o *outgoing) packV(v reflect.Value) {
 	case reflect.Struct:
 		o.packStruct(v.Interface())
 	case reflect.Slice:
-		switch v.Type().Elem().Kind() {
-		case reflect.Uint8:
+		elemType := v.Type().Elem()
+		if elemType.Kind() == reflect.Uint8 {
 			o.packer.Bytes(v.Bytes())
 			return
-		case reflect.Int, reflect.Int64, reflect.String, reflect.Float64, reflect.Interface:
-			if v.Len() > 5 {
+		}
+		num := v.Len()
+		if num > 5 {
+			switch elemType {
+			case intT, int64T, stringT, float64T, anyT:
 				// Accept the cost of an allocation (v.Interface())
 				// because this slice type is optimized in packX.
 				// The exact length from which the optimization amortizes
 				// the allocation cost depends on many factors.
-				// 5 is an arbitrary guess.
+				// 5 seemed a close to the cross-over point on my system
+				// running Go 1.23.0 linux/amd64.
+				// cf. https://github.com/neo4j/neo4j-go-driver/pull/617
 				o.packX(v.Interface())
 				return
 			}
 		}
-		num := v.Len()
 		o.packer.ArrayHeader(num)
 		for i := 0; i < num; i++ {
 			o.packV(v.Index(i))

--- a/neo4j/internal/bolt/outgoing.go
+++ b/neo4j/internal/bolt/outgoing.go
@@ -423,10 +423,16 @@ func (o *outgoing) packX(x any) {
 	case reflect.Map:
 		// Optimizations
 		switch m := x.(type) {
+		case map[string][]byte:
+			o.packer.BytesMap(m)
 		case map[string]int:
 			o.packer.IntMap(m)
+		case map[string]int64:
+			o.packer.Int64Map(m)
 		case map[string]string:
 			o.packer.StringMap(m)
+		case map[string]float64:
+			o.packer.Float64Map(m)
 		case map[string]any:
 			o.packMap(m)
 		default:

--- a/neo4j/internal/bolt/outgoing_test.go
+++ b/neo4j/internal/bolt/outgoing_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -434,9 +435,59 @@ func TestOutgoing(ot *testing.T) {
 		customInt         int64
 		customString      string
 		customByteSlice   []byte
+		customByte        byte
 		customStringSlice []string
 		customMapOfInts   map[string]int
 	)
+
+	someBool := true
+	var someBoolPtr = &someBool
+	var nilBool *bool = nil
+	someInt := 1
+	var someIntPtr = &someInt
+	var nilInt *int = nil
+	someInt8 := int8(2)
+	var someInt8Ptr = &someInt8
+	var nilInt8 *int8 = nil
+	someInt16 := int16(3)
+	var someInt16Ptr = &someInt16
+	var nilInt16 *int16 = nil
+	someInt32 := int32(4)
+	var someInt32Ptr = &someInt32
+	var nilInt32 *int32 = nil
+	someInt64 := int64(5)
+	var someInt64Ptr = &someInt64
+	var nilInt64 *int64 = nil
+	someUint := uint(6)
+	var someUintPtr = &someUint
+	var nilUint *uint = nil
+	someUint8 := uint8(7)
+	var someUint8Ptr = &someUint8
+	var nilUint8 *uint8 = nil
+	someByte := byte(8)
+	var someBytePtr = &someByte
+	var nilByte *byte = nil
+	someUint16 := uint16(9)
+	var someUint16Ptr = &someUint16
+	var nilUint16 *uint16 = nil
+	someUint32 := uint32(10)
+	var someUint32Ptr = &someUint32
+	var nilUint32 *uint32 = nil
+	someUint64 := uint64(11)
+	var someUint64Ptr = &someUint64
+	var nilUint64 *uint64 = nil
+	someFloat32 := float32(3.25)
+	var someFloat32Ptr = &someFloat32
+	var nilFloat32 *float32 = nil
+	someFloat64 := 1.5
+	var someFloat64Ptr = &someFloat64
+	var nilFloat64 *float64 = nil
+	someString := "hello"
+	var someStringPtr = &someString
+	var nilString *string = nil
+
+	someCustomInt := customInt(someInt)
+
 	// Test packing of maps in more detail, essentially tests allowed parameters to Run command
 	// tests for top level appending and sending outgoing messages
 	paramCases := []struct {
@@ -444,6 +495,484 @@ func TestOutgoing(ot *testing.T) {
 		inp    map[string]any
 		expect map[string]any
 	}{
+		{
+			name: "simple types",
+			inp: map[string]any{
+				"nil":     nil,
+				"bool":    true,
+				"int":     1,
+				"int8":    int8(2),
+				"int16":   int16(3),
+				"int32":   int32(4),
+				"int64":   int64(5),
+				"uint":    uint(6),
+				"uint8":   uint8(7),
+				"byte":    byte(8),
+				"[]uint8": []uint8{9},
+				"[]byte":  []byte{10},
+				"uint16":  uint16(11),
+				"uint32":  uint32(12),
+				"uint64":  uint64(13),
+				"float32": float32(3.25),
+				"float64": 1.5,
+				"string":  "hello",
+			},
+			expect: map[string]any{
+				"nil":     nil,
+				"bool":    true,
+				"int":     int64(1),
+				"int8":    int64(2),
+				"int16":   int64(3),
+				"int32":   int64(4),
+				"int64":   int64(5),
+				"uint":    int64(6),
+				"uint8":   int64(7),
+				"byte":    int64(8),
+				"[]uint8": []byte{9},
+				"[]byte":  []byte{10},
+				"uint16":  int64(11),
+				"uint32":  int64(12),
+				"uint64":  int64(13),
+				"float32": 3.25,
+				"float64": 1.5,
+				"string":  "hello",
+			},
+		},
+		{
+			name: "simple type slices",
+			inp: map[string]any{
+				"[]nil any":  []any{nil},
+				"[]nil *int": []*int{nil},
+				"[]bool":     []bool{true},
+				"[]int":      []int{1},
+				"[]int8":     []int8{2},
+				"[]int16":    []int16{3},
+				"[]int32":    []int32{4},
+				"[]int64":    []int64{5},
+				"[]uint":     []uint{6},
+				"[]uint8":    []uint8{7},
+				"[]byte":     []byte{8},
+				"[][]uint8":  [][]uint8{{9}},
+				"[][]byte":   [][]byte{{10}},
+				"[]uint16":   []uint16{11},
+				"[]uint32":   []uint32{12},
+				"[]uint64":   []uint64{13},
+				"[]float32":  []float32{3.25},
+				"[]float64":  []float64{1.5},
+				"[]float32 long": []float32{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+					11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+				},
+				"[]float64 long": []float64{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+					11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+				},
+				"[][]float32 long": [][]float32{{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+					11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+				}},
+				"[][]float64 long": [][]float64{{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+					11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+				}},
+				"[]string": []string{"hello"},
+			},
+			expect: map[string]any{
+				"[]nil any":  []any{nil},
+				"[]nil *int": []any{nil},
+				"[]bool":     []any{true},
+				"[]int":      []any{int64(1)},
+				"[]int8":     []any{int64(2)},
+				"[]int16":    []any{int64(3)},
+				"[]int32":    []any{int64(4)},
+				"[]int64":    []any{int64(5)},
+				"[]uint":     []any{int64(6)},
+				"[]uint8":    []byte{7},
+				"[]byte":     []byte{8},
+				"[][]uint8":  []any{[]byte{9}},
+				"[][]byte":   []any{[]byte{10}},
+				"[]uint16":   []any{int64(11)},
+				"[]uint32":   []any{int64(12)},
+				"[]uint64":   []any{int64(13)},
+				"[]float32":  []any{3.25},
+				"[]float64":  []any{1.5},
+				"[]float32 long": []any{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+					11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+				},
+				"[]float64 long": []any{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+					11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+				},
+				"[][]float32 long": []any{[]any{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+					11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+				}},
+				"[][]float64 long": []any{[]any{
+					1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+					11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+				}},
+				"[]string": []any{"hello"},
+			},
+		},
+		{
+			name: "empty simple type slices",
+			inp: map[string]any{
+				"[]any":     []any{},
+				"[]bool":    []bool{},
+				"[]int":     []int{},
+				"[]int8":    []int8{},
+				"[]int16":   []int16{},
+				"[]int32":   []int32{},
+				"[]int64":   []int64{},
+				"[]uint":    []uint{},
+				"[]uint8":   []uint8{},
+				"[]byte":    []byte{},
+				"[]uint16":  []uint16{},
+				"[]uint32":  []uint32{},
+				"[]uint64":  []uint64{},
+				"[]float32": []float32{},
+				"[]float64": []float64{},
+				"[]string":  []string{},
+			},
+			expect: map[string]any{
+				"[]any":     []any{},
+				"[]bool":    []any{},
+				"[]int":     []any{},
+				"[]int8":    []any{},
+				"[]int16":   []any{},
+				"[]int32":   []any{},
+				"[]int64":   []any{},
+				"[]uint":    []any{},
+				"[]uint8":   []byte{},
+				"[]byte":    []byte{},
+				"[]uint16":  []any{},
+				"[]uint32":  []any{},
+				"[]uint64":  []any{},
+				"[]float32": []any{},
+				"[]float64": []any{},
+				"[]string":  []any{},
+			},
+		},
+		{
+			name: "simple type maps",
+			inp: map[string]any{
+				"map[string]nil any":  map[string]any{"key": nil},
+				"map[string]nil *int": map[string]*int{"key": nil},
+				"map[string]bool":     map[string]bool{"key": true},
+				"map[string]int":      map[string]int{"key": 1},
+				"map[string]int8":     map[string]int8{"key": 2},
+				"map[string]int16":    map[string]int16{"key": 3},
+				"map[string]int32":    map[string]int32{"key": 4},
+				"map[string]int64":    map[string]int64{"key": 5},
+				"map[string]uint":     map[string]uint{"key": 6},
+				"map[string]uint8":    map[string]uint8{"key": 7},
+				"map[string]byte":     map[string]byte{"key": 8},
+				"map[string]uint16":   map[string]uint16{"key": 9},
+				"map[string]uint32":   map[string]uint32{"key": 10},
+				"map[string]uint64":   map[string]uint64{"key": 11},
+				"map[string]float32":  map[string]float32{"key": 3.25},
+				"map[string]float64":  map[string]float64{"key": 1.5},
+				"map[string]string":   map[string]string{"key": "hello"},
+			},
+			expect: map[string]any{
+				"map[string]nil any":  map[string]any{"key": nil},
+				"map[string]nil *int": map[string]any{"key": nil},
+				"map[string]bool":     map[string]any{"key": true},
+				"map[string]int":      map[string]any{"key": int64(1)},
+				"map[string]int8":     map[string]any{"key": int64(2)},
+				"map[string]int16":    map[string]any{"key": int64(3)},
+				"map[string]int32":    map[string]any{"key": int64(4)},
+				"map[string]int64":    map[string]any{"key": int64(5)},
+				"map[string]uint":     map[string]any{"key": int64(6)},
+				"map[string]uint8":    map[string]any{"key": int64(7)},
+				"map[string]byte":     map[string]any{"key": int64(8)},
+				"map[string]uint16":   map[string]any{"key": int64(9)},
+				"map[string]uint32":   map[string]any{"key": int64(10)},
+				"map[string]uint64":   map[string]any{"key": int64(11)},
+				"map[string]float32":  map[string]any{"key": 3.25},
+				"map[string]float64":  map[string]any{"key": 1.5},
+				"map[string]string":   map[string]any{"key": "hello"},
+			},
+		},
+		{
+			name: "empty simple type maps",
+			inp: map[string]any{
+				"map[string]any":     map[string]any{},
+				"map[string]*int":    map[string]*int{},
+				"map[string]bool":    map[string]bool{},
+				"map[string]int":     map[string]int{},
+				"map[string]int8":    map[string]int8{},
+				"map[string]int16":   map[string]int16{},
+				"map[string]int32":   map[string]int32{},
+				"map[string]int64":   map[string]int64{},
+				"map[string]uint":    map[string]uint{},
+				"map[string]uint8":   map[string]uint8{},
+				"map[string]byte":    map[string]byte{},
+				"map[string]uint16":  map[string]uint16{},
+				"map[string]uint32":  map[string]uint32{},
+				"map[string]uint64":  map[string]uint64{},
+				"map[string]float32": map[string]float32{},
+				"map[string]float64": map[string]float64{},
+				"map[string]string":  map[string]string{},
+			},
+			expect: map[string]any{
+				"map[string]any":     map[string]any{},
+				"map[string]*int":    map[string]any{},
+				"map[string]bool":    map[string]any{},
+				"map[string]int":     map[string]any{},
+				"map[string]int8":    map[string]any{},
+				"map[string]int16":   map[string]any{},
+				"map[string]int32":   map[string]any{},
+				"map[string]int64":   map[string]any{},
+				"map[string]uint":    map[string]any{},
+				"map[string]uint8":   map[string]any{},
+				"map[string]byte":    map[string]any{},
+				"map[string]uint16":  map[string]any{},
+				"map[string]uint32":  map[string]any{},
+				"map[string]uint64":  map[string]any{},
+				"map[string]float32": map[string]any{},
+				"map[string]float64": map[string]any{},
+				"map[string]string":  map[string]any{},
+			},
+		},
+		{
+			name: "simple type slice in maps",
+			inp: map[string]any{
+				"map[string][]nil any":  map[string][]any{"key": {nil}},
+				"map[string][]nil *int": map[string][]*int{"key": {nil}},
+				"map[string][]bool":     map[string][]bool{"key": {true}},
+				"map[string][]int":      map[string][]int{"key": {1}},
+				"map[string][]int8":     map[string][]int8{"key": {2}},
+				"map[string][]int16":    map[string][]int16{"key": {3}},
+				"map[string][]int32":    map[string][]int32{"key": {4}},
+				"map[string][]int64":    map[string][]int64{"key": {5}},
+				"map[string][]uint":     map[string][]uint{"key": {6}},
+				"map[string][]uint8":    map[string][]uint8{"key": {7}},
+				"map[string][]byte":     map[string][]byte{"key": {8}},
+				"map[string][]uint16":   map[string][]uint16{"key": {9}},
+				"map[string][]uint32":   map[string][]uint32{"key": {10}},
+				"map[string][]uint64":   map[string][]uint64{"key": {11}},
+				"map[string][]float32":  map[string][]float32{"key": {3.25}},
+				"map[string][]float64":  map[string][]float64{"key": {1.5}},
+				"map[string][]string":   map[string][]string{"key": {"hello"}},
+			},
+			expect: map[string]any{
+				"map[string][]nil any":  map[string]any{"key": []any{nil}},
+				"map[string][]nil *int": map[string]any{"key": []any{nil}},
+				"map[string][]bool":     map[string]any{"key": []any{true}},
+				"map[string][]int":      map[string]any{"key": []any{int64(1)}},
+				"map[string][]int8":     map[string]any{"key": []any{int64(2)}},
+				"map[string][]int16":    map[string]any{"key": []any{int64(3)}},
+				"map[string][]int32":    map[string]any{"key": []any{int64(4)}},
+				"map[string][]int64":    map[string]any{"key": []any{int64(5)}},
+				"map[string][]uint":     map[string]any{"key": []any{int64(6)}},
+				"map[string][]uint8":    map[string]any{"key": []byte{7}},
+				"map[string][]byte":     map[string]any{"key": []byte{8}},
+				"map[string][]uint16":   map[string]any{"key": []any{int64(9)}},
+				"map[string][]uint32":   map[string]any{"key": []any{int64(10)}},
+				"map[string][]uint64":   map[string]any{"key": []any{int64(11)}},
+				"map[string][]float32":  map[string]any{"key": []any{3.25}},
+				"map[string][]float64":  map[string]any{"key": []any{1.5}},
+				"map[string][]string":   map[string]any{"key": []any{"hello"}},
+			},
+		},
+
+		{
+			name: "simple type pointers",
+			inp: map[string]any{
+				"*bool":        someBoolPtr,
+				"*int":         someIntPtr,
+				"*int8":        someInt8Ptr,
+				"*int16":       someInt16Ptr,
+				"*int32":       someInt32Ptr,
+				"*int64":       someInt64Ptr,
+				"*uint":        someUintPtr,
+				"*uint8":       someUint8Ptr,
+				"*byte":        someBytePtr,
+				"*uint16":      someUint16Ptr,
+				"*uint32":      someUint32Ptr,
+				"*uint64":      someUint64Ptr,
+				"*float32":     someFloat32Ptr,
+				"*float64":     someFloat64Ptr,
+				"*string":      someStringPtr,
+				"*bool nil":    nilBool,
+				"*int nil":     nilInt,
+				"*int8 nil":    nilInt8,
+				"*int16 nil":   nilInt16,
+				"*int32 nil":   nilInt32,
+				"*int64 nil":   nilInt64,
+				"*uint nil":    nilUint,
+				"*uint8 nil":   nilUint8,
+				"*byte nil":    nilByte,
+				"*uint16 nil":  nilUint16,
+				"*uint32 nil":  nilUint32,
+				"*uint64 nil":  nilUint64,
+				"*float32 nil": nilFloat32,
+				"*float64 nil": nilFloat64,
+				"*string nil":  nilString,
+				"**bool":       &someBoolPtr,
+				"**int":        &someIntPtr,
+				"**int8":       &someInt8Ptr,
+				"**int16":      &someInt16Ptr,
+				"**int32":      &someInt32Ptr,
+				"**int64":      &someInt64Ptr,
+				"**uint":       &someUintPtr,
+				"**uint8":      &someUint8Ptr,
+				"**byte":       &someBytePtr,
+				"**uint16":     &someUint16Ptr,
+				"**uint32":     &someUint32Ptr,
+				"**uint64":     &someUint64Ptr,
+				"**float32":    &someFloat32Ptr,
+				"**float64":    &someFloat64Ptr,
+				"**string":     &someStringPtr,
+			},
+			expect: map[string]any{
+				"*bool":        someBool,
+				"*int":         int64(someInt),
+				"*int8":        int64(someInt8),
+				"*int16":       int64(someInt16),
+				"*int32":       int64(someInt32),
+				"*int64":       someInt64,
+				"*uint":        int64(someUint),
+				"*uint8":       int64(someUint8),
+				"*byte":        int64(someByte),
+				"*uint16":      int64(someUint16),
+				"*uint32":      int64(someUint32),
+				"*uint64":      int64(someUint64),
+				"*float32":     float64(someFloat32),
+				"*float64":     someFloat64,
+				"*string":      "hello",
+				"*bool nil":    nil,
+				"*int nil":     nil,
+				"*int8 nil":    nil,
+				"*int16 nil":   nil,
+				"*int32 nil":   nil,
+				"*int64 nil":   nil,
+				"*uint nil":    nil,
+				"*uint8 nil":   nil,
+				"*byte nil":    nil,
+				"*uint16 nil":  nil,
+				"*uint32 nil":  nil,
+				"*uint64 nil":  nil,
+				"*float32 nil": nil,
+				"*float64 nil": nil,
+				"*string nil":  nil,
+				"**bool":       someBool,
+				"**int":        int64(someInt),
+				"**int8":       int64(someInt8),
+				"**int16":      int64(someInt16),
+				"**int32":      int64(someInt32),
+				"**int64":      someInt64,
+				"**uint":       int64(someUint),
+				"**uint8":      int64(someUint8),
+				"**byte":       int64(someByte),
+				"**uint16":     int64(someUint16),
+				"**uint32":     int64(someUint32),
+				"**uint64":     int64(someUint64),
+				"**float32":    float64(someFloat32),
+				"**float64":    someFloat64,
+				"**string":     "hello",
+			},
+		},
+		{
+			name: "simple type pointer slices",
+			inp: map[string]any{
+				"[]*bool":        []*bool{someBoolPtr},
+				"[]*int":         []*int{someIntPtr},
+				"[]*int8":        []*int8{someInt8Ptr},
+				"[]*int16":       []*int16{someInt16Ptr},
+				"[]*int32":       []*int32{someInt32Ptr},
+				"[]*int64":       []*int64{someInt64Ptr},
+				"[]*uint":        []*uint{someUintPtr},
+				"[]*uint8":       []*uint8{someUint8Ptr},
+				"[]*byte":        []*byte{someBytePtr},
+				"[]*uint16":      []*uint16{someUint16Ptr},
+				"[]*uint32":      []*uint32{someUint32Ptr},
+				"[]*uint64":      []*uint64{someUint64Ptr},
+				"[]*float32":     []*float32{someFloat32Ptr},
+				"[]*float64":     []*float64{someFloat64Ptr},
+				"[]*string":      []*string{someStringPtr},
+				"[]*bool nil":    []*bool{nilBool},
+				"[]*int nil":     []*int{nilInt},
+				"[]*int8 nil":    []*int8{nilInt8},
+				"[]*int16 nil":   []*int16{nilInt16},
+				"[]*int32 nil":   []*int32{nilInt32},
+				"[]*int64 nil":   []*int64{nilInt64},
+				"[]*uint nil":    []*uint{nilUint},
+				"[]*uint8 nil":   []*uint8{nilUint8},
+				"[]*byte nil":    []*byte{nilByte},
+				"[]*uint16 nil":  []*uint16{nilUint16},
+				"[]*uint32 nil":  []*uint32{nilUint32},
+				"[]*uint64 nil":  []*uint64{nilUint64},
+				"[]*float32 nil": []*float32{nilFloat32},
+				"[]*float64 nil": []*float64{nilFloat64},
+				"[]*string nil":  []*string{nilString},
+				"[]**bool":       []**bool{&someBoolPtr},
+				"[]**int":        []**int{&someIntPtr},
+				"[]**int8":       []**int8{&someInt8Ptr},
+				"[]**int16":      []**int16{&someInt16Ptr},
+				"[]**int32":      []**int32{&someInt32Ptr},
+				"[]**int64":      []**int64{&someInt64Ptr},
+				"[]**uint":       []**uint{&someUintPtr},
+				"[]**uint8":      []**uint8{&someUint8Ptr},
+				"[]**byte":       []**byte{&someBytePtr},
+				"[]**uint16":     []**uint16{&someUint16Ptr},
+				"[]**uint32":     []**uint32{&someUint32Ptr},
+				"[]**uint64":     []**uint64{&someUint64Ptr},
+				"[]**float32":    []**float32{&someFloat32Ptr},
+				"[]**float64":    []**float64{&someFloat64Ptr},
+				"[]**string":     []**string{&someStringPtr},
+			},
+			expect: map[string]any{
+				"[]*bool":        []any{someBool},
+				"[]*int":         []any{int64(someInt)},
+				"[]*int8":        []any{int64(someInt8)},
+				"[]*int16":       []any{int64(someInt16)},
+				"[]*int32":       []any{int64(someInt32)},
+				"[]*int64":       []any{someInt64},
+				"[]*uint":        []any{int64(someUint)},
+				"[]*uint8":       []any{int64(someUint8)},
+				"[]*byte":        []any{int64(someByte)},
+				"[]*uint16":      []any{int64(someUint16)},
+				"[]*uint32":      []any{int64(someUint32)},
+				"[]*uint64":      []any{int64(someUint64)},
+				"[]*float32":     []any{float64(someFloat32)},
+				"[]*float64":     []any{someFloat64},
+				"[]*string":      []any{"hello"},
+				"[]*bool nil":    []any{nil},
+				"[]*int nil":     []any{nil},
+				"[]*int8 nil":    []any{nil},
+				"[]*int16 nil":   []any{nil},
+				"[]*int32 nil":   []any{nil},
+				"[]*int64 nil":   []any{nil},
+				"[]*uint nil":    []any{nil},
+				"[]*uint8 nil":   []any{nil},
+				"[]*byte nil":    []any{nil},
+				"[]*uint16 nil":  []any{nil},
+				"[]*uint32 nil":  []any{nil},
+				"[]*uint64 nil":  []any{nil},
+				"[]*float32 nil": []any{nil},
+				"[]*float64 nil": []any{nil},
+				"[]*string nil":  []any{nil},
+				"[]**bool":       []any{someBool},
+				"[]**int":        []any{int64(someInt)},
+				"[]**int8":       []any{int64(someInt8)},
+				"[]**int16":      []any{int64(someInt16)},
+				"[]**int32":      []any{int64(someInt32)},
+				"[]**int64":      []any{someInt64},
+				"[]**uint":       []any{int64(someUint)},
+				"[]**uint8":      []any{int64(someUint8)},
+				"[]**byte":       []any{int64(someByte)},
+				"[]**uint16":     []any{int64(someUint16)},
+				"[]**uint32":     []any{int64(someUint32)},
+				"[]**uint64":     []any{int64(someUint64)},
+				"[]**float32":    []any{float64(someFloat32)},
+				"[]**float64":    []any{someFloat64},
+				"[]**string":     []any{"hello"},
+			},
+		},
+
 		{
 			name: "map of maps",
 			inp: map[string]any{
@@ -462,14 +991,16 @@ func TestOutgoing(ot *testing.T) {
 		{
 			name: "map of spatial",
 			inp: map[string]any{
-				"p1": dbtype.Point2D{SpatialRefId: 1, X: 2, Y: 3},
-				"p2": dbtype.Point3D{SpatialRefId: 4, X: 5, Y: 6, Z: 7},
-				"ps": []dbtype.Point3D{{SpatialRefId: 4, X: 5, Y: 6, Z: 7}},
+				"p1":     dbtype.Point2D{SpatialRefId: 1, X: 2, Y: 3},
+				"p2":     dbtype.Point3D{SpatialRefId: 4, X: 5, Y: 6, Z: 7},
+				"ps":     []dbtype.Point3D{{SpatialRefId: 4, X: 5, Y: 6, Z: 7}},
+				"ps_ptr": []*dbtype.Point3D{{SpatialRefId: 4, X: 5, Y: 6, Z: 7}},
 			},
 			expect: map[string]any{
-				"p1": &testStruct{tag: 'X', fields: []any{int64(1), float64(2), float64(3)}},
-				"p2": &testStruct{tag: 'Y', fields: []any{int64(4), float64(5), float64(6), float64(7)}},
-				"ps": []any{&testStruct{tag: 'Y', fields: []any{int64(4), float64(5), float64(6), float64(7)}}},
+				"p1":     &testStruct{tag: 'X', fields: []any{int64(1), float64(2), float64(3)}},
+				"p2":     &testStruct{tag: 'Y', fields: []any{int64(4), float64(5), float64(6), float64(7)}},
+				"ps":     []any{&testStruct{tag: 'Y', fields: []any{int64(4), float64(5), float64(6), float64(7)}}},
+				"ps_ptr": []any{&testStruct{tag: 'Y', fields: []any{int64(4), float64(5), float64(6), float64(7)}}},
 			},
 		},
 		{
@@ -507,13 +1038,14 @@ func TestOutgoing(ot *testing.T) {
 		{
 			name: "map of custom native types",
 			inp: map[string]any{
-				"custom bool":         customBool(true),
-				"custom float":        customFloat(3.14),
-				"custom int":          customInt(12345),
-				"custom string":       customString("Hello"),
-				"custom byte slice":   customByteSlice([]byte{1, 2, 3}),
-				"custom string slice": customStringSlice([]string{"hello", "again"}),
-				"custom map of ints":  customMapOfInts(map[string]int{"l": 1}),
+				"custom bool":           customBool(true),
+				"custom float":          customFloat(3.14),
+				"custom int":            customInt(12345),
+				"custom string":         customString("Hello"),
+				"custom byte slice":     customByteSlice([]byte{1, 2, 3}),
+				"slice of custom bytes": []customByte{1, 2, 3},
+				"custom string slice":   customStringSlice([]string{"hello", "again"}),
+				"custom map of ints":    customMapOfInts(map[string]int{"l": 1}),
 			},
 			expect: map[string]any{
 				"custom bool":   true,
@@ -521,35 +1053,129 @@ func TestOutgoing(ot *testing.T) {
 				"custom int":    int64(12345),
 				"custom string": "Hello",
 				// Custom will cause []byte to come back as []any, could be handled but maybe not worth it
-				"custom byte slice":   []any{int64(1), int64(2), int64(3)},
-				"custom string slice": []any{"hello", "again"},
-				"custom map of ints":  map[string]any{"l": int64(1)},
+				"custom byte slice":     []any{int64(1), int64(2), int64(3)},
+				"slice of custom bytes": []any{int64(1), int64(2), int64(3)},
+				"custom string slice":   []any{"hello", "again"},
+				"custom map of ints":    map[string]any{"l": int64(1)},
 			},
 		},
 		{
 			name: "map of pointer types",
 			inp: map[string]any{
+				"*int":               someIntPtr,
 				"*[]int":             &([]int{3}),
+				"[]*int (nil)":       []*int{nil},
+				"[]*any (nil)":       []*any{nil},
 				"*map[string]string": &(map[string]string{"x": "y"}),
 			},
 			expect: map[string]any{
+				"*int":               int64(someInt),
 				"*[]int":             []any{int64(3)},
+				"[]*int (nil)":       []any{nil},
+				"[]*any (nil)":       []any{nil},
 				"*map[string]string": map[string]any{"x": "y"},
+			},
+		},
+		{
+			name: "map of custom pointer types",
+			inp: map[string]any{
+				"*customInt":                     &someCustomInt,
+				"*[]customInt":                   &([]customInt{3}),
+				"*[]any (CustomInt)":             &([]any{customInt(4)}),
+				"*map[customString]customString": &(map[customString]customString{"x": "y"}),
+			},
+			expect: map[string]any{
+				"*customInt":                     int64(someCustomInt),
+				"*[]customInt":                   []any{int64(3)},
+				"*[]any (CustomInt)":             []any{int64(4)},
+				"*map[customString]customString": map[string]any{"x": "y"},
+			},
+		},
+	}
+
+	paramWrappings := []struct {
+		name string
+		wrap func(map[string]any) map[string]any
+	}{
+
+		{
+			name: "",
+			wrap: func(m map[string]any) map[string]any { return m },
+		},
+		{
+			name: " (root in map)",
+			wrap: func(m map[string]any) map[string]any {
+				map_ := make(map[string]any)
+				map_["map"] = m
+				return map_
+			},
+		},
+		{
+			name: " (root in slice in map)",
+			wrap: func(m map[string]any) map[string]any {
+				map_ := make(map[string]any)
+				map_["map"] = []any{m}
+				return map_
+			},
+		},
+		{
+			name: " (root in map in map)",
+			wrap: func(m map[string]any) map[string]any {
+				map_ := make(map[string]any)
+				map_["map"] = map[string]any{"mapp": m}
+				return map_
+			},
+		},
+		{
+			name: " (elements in map)",
+			wrap: func(m map[string]any) map[string]any {
+				map_ := make(map[string]any)
+				for key, value := range m {
+					map_[key] = map[string]any{"elem": value}
+				}
+				return map_
+			},
+		},
+		{
+			name: " (elements in slice)",
+			wrap: func(m map[string]any) map[string]any {
+				map_ := make(map[string]any)
+				for key, value := range m {
+					map_[key] = []any{value}
+				}
+				return map_
+			},
+		},
+		{
+			name: " (all elements as slice)",
+			wrap: func(m map[string]any) map[string]any {
+				slice := make([]any, 0, len(m))
+				keys := make([]string, 0, len(m))
+				for key := range m {
+					keys = append(keys, key)
+				}
+				sort.Strings(keys)
+				for _, key := range keys {
+					slice = append(slice, m[key])
+				}
+				return map[string]any{"slice": slice}
 			},
 		},
 	}
 
 	for _, c := range paramCases {
-		ot.Run(c.name, func(t *testing.T) {
-			x := dechunkAndUnpack(t, func(t *testing.T, out *outgoing) {
-				out.begin()
-				out.packMap(c.inp)
-				out.end()
+		for _, w := range paramWrappings {
+			ot.Run(c.name+w.name, func(t *testing.T) {
+				x := dechunkAndUnpack(t, func(t *testing.T, out *outgoing) {
+					out.begin()
+					out.packMap(w.wrap(c.inp))
+					out.end()
+				})
+				if !reflect.DeepEqual(x, w.wrap(c.expect)) {
+					t.Errorf("Unpacked differs, expected\n %#v but was\n %#v", c.expect, x)
+				}
 			})
-			if !reflect.DeepEqual(x, c.expect) {
-				t.Errorf("Unpacked differs, expected\n %#v but was\n %#v", c.expect, x)
-			}
-		})
+		}
 	}
 
 	type aStruct struct{}

--- a/neo4j/internal/packstream/packer.go
+++ b/neo4j/internal/packstream/packer.go
@@ -183,6 +183,14 @@ func (p *Packer) MapHeader(l int) {
 	p.listHeader(l, 0xa0, 0xd8)
 }
 
+func (p *Packer) BytesMap(m map[string][]byte) {
+	p.listHeader(len(m), 0xa0, 0xd8)
+	for k, v := range m {
+		p.String(k)
+		p.Bytes(v)
+	}
+}
+
 func (p *Packer) IntMap(m map[string]int) {
 	p.listHeader(len(m), 0xa0, 0xd8)
 	for k, v := range m {
@@ -191,11 +199,27 @@ func (p *Packer) IntMap(m map[string]int) {
 	}
 }
 
+func (p *Packer) Int64Map(m map[string]int64) {
+	p.listHeader(len(m), 0xa0, 0xd8)
+	for k, v := range m {
+		p.String(k)
+		p.Int64(v)
+	}
+}
+
 func (p *Packer) StringMap(m map[string]string) {
 	p.listHeader(len(m), 0xa0, 0xd8)
 	for k, v := range m {
 		p.String(k)
 		p.String(v)
+	}
+}
+
+func (p *Packer) Float64Map(m map[string]float64) {
+	p.listHeader(len(m), 0xa0, 0xd8)
+	for k, v := range m {
+		p.String(k)
+		p.Float64(v)
 	}
 }
 


### PR DESCRIPTION
Improve serialization performance by specializing slices or maps of `any`, and optimizing reflective looping through maps.

Special-casing `[]any` and especially `map[string]any`, which are common parameter types, eliminates allocation overhead to loop through these values.

Using `MapRange` rather than `MapKeys` and `MapIndex` (and using `Value.SetIterKey/Value` rather than `MapIter.Key/Value`) significantly reduces allocations when looping through other map types. 