### PR TITLE
TestKit: skip one of the newly added summary tests

### DIFF
--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1714,7 +1714,7 @@ func testSkips() map[string]string {
 		"stub.routing.test_routing_v*.RoutingV*.test_should_fail_discovery_when_router_fails_with_unknown_code":              "Unify: other drivers have a list of fast failing errors during discover: on anything else, the driver will try the next router",
 		"stub.routing.test_routing_v*.RoutingV*.test_should_drop_connections_failing_liveness_check":                         "Liveness check error handling is not (yet) unified: https://github.com/neo-technology/drivers-adr/pull/83",
 		"stub.*.test_0_timeout": "Fixme: driver omits 0 as tx timeout value",
-		"stub.summary.test_summary.TestSummaryBasicInfo.test_server_info": "pending unification: should the server address be pre or post DNS resolution?",
+		"stub.summary.test_summary.TestSummaryBasicInfo*.test_server_info": "pending unification: should the server address be pre or post DNS resolution?",
 	}
 }
 


### PR DESCRIPTION
Skips one of the newly introduced tests from
 * https://github.com/neo4j-drivers/testkit/pull/653