### PR TITLE
Add Unwrap methods for bolt errors

### DIFF
--- a/neo4j/internal/errorutil/bolt.go
+++ b/neo4j/internal/errorutil/bolt.go
@@ -45,6 +45,10 @@ func (crt *ConnectionReadTimeout) Error() string {
 		crt.Err)
 }
 
+func (crt *ConnectionReadTimeout) Unwrap() error {
+	return crt.Err
+}
+
 type ConnectionWriteTimeout struct {
 	UserContext context.Context
 	Err         error
@@ -58,6 +62,10 @@ func (cwt *ConnectionWriteTimeout) Error() string {
 	return fmt.Sprintf("Timeout while writing to connection [user-provided context deadline: %s]: %s", userDeadline, cwt.Err)
 }
 
+func (crt *ConnectionWriteTimeout) Unwrap() error {
+	return crt.Err
+}
+
 type ConnectionReadCanceled struct {
 	Err error
 }
@@ -66,12 +74,20 @@ func (crc *ConnectionReadCanceled) Error() string {
 	return fmt.Sprintf("Reading from connection has been canceled: %s", crc.Err)
 }
 
+func (crt *ConnectionReadCanceled) Unwrap() error {
+	return crt.Err
+}
+
 type ConnectionWriteCanceled struct {
 	Err error
 }
 
 func (cwc *ConnectionWriteCanceled) Error() string {
 	return fmt.Sprintf("Writing to connection has been canceled: %s", cwc.Err)
+}
+
+func (crt *ConnectionWriteCanceled) Unwrap() error {
+	return crt.Err
 }
 
 type timeout interface {

--- a/neo4j/internal/errorutil/bolt_test.go
+++ b/neo4j/internal/errorutil/bolt_test.go
@@ -19,10 +19,12 @@ package errorutil_test
 
 import (
 	"context"
+	"errors"
+	"testing"
+
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/testutil"
-	"testing"
 )
 
 func TestIsFatalDuringDiscovery(outer *testing.T) {
@@ -135,6 +137,38 @@ func TestIsFatalDuringDiscovery(outer *testing.T) {
 	for _, testCase := range testCases {
 		outer.Run(testCase.description, func(t *testing.T) {
 			testutil.AssertBoolEqual(t, errorutil.IsFatalDuringDiscovery(testCase.err), testCase.isFatal)
+		})
+	}
+}
+
+func TestErrorSupportsUnwrap(outer *testing.T) {
+	type testCase struct {
+		description string
+		err         error
+	}
+
+	inner := errors.New("the inner error")
+
+	testCases := []testCase{
+		{
+			description: "ConnectionReadTimeout support Unwrap",
+			err:         &errorutil.ConnectionReadTimeout{Err: inner},
+		}, {
+			description: "ConnectionWriteTimeout support Unwrap",
+			err:         &errorutil.ConnectionWriteTimeout{Err: inner},
+		}, {
+			description: "ConnectionReadCanceled support Unwrap",
+			err:         &errorutil.ConnectionReadCanceled{Err: inner},
+		}, {
+			description: "ConnectionWriteCanceled support Unwrap",
+			err:         &errorutil.ConnectionWriteCanceled{Err: inner},
+		},
+	}
+
+	for _, testCase := range testCases {
+		outer.Run(testCase.description, func(t *testing.T) {
+
+			testutil.AssertBoolEqual(t, errors.Is(testCase.err, inner), true)
 		})
 	}
 }


### PR DESCRIPTION
Error types are in internal package, so casting is not possible. And because of missing `Unwrap` method, the `errors.Is()` doesn't work either.


Closing #631 