### PR TITLE
chore(bolt5): add received error to logging when closing socket fails

### DIFF
--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -949,7 +949,7 @@ func (b *bolt5) Close(ctx context.Context) {
 		b.queue.send(ctx)
 	}
 	if err := b.conn.Close(); err != nil {
-		b.log.Warnf(log.Driver, b.serverName, "could not close underlying socket")
+		b.log.Warnf(log.Driver, b.serverName, "Could not close underlying socket: %v", err)
 	}
 }
 


### PR DESCRIPTION
We are facing some issues related to socket closing and noticed that to actual error is not added to logging. This would be good to be added, for easier debugging