### PR TITLE
Fix context cancelled during clean-up GOODBYE

### DIFF
--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -189,6 +189,7 @@ func (b *bolt4) setError(err error, fatal bool) {
 		return
 	}
 
+	wasDead := b.state == bolt5Dead
 	// No previous error
 	if b.err == nil {
 		b.err = err
@@ -213,6 +214,8 @@ func (b *bolt4) setError(err error, fatal bool) {
 	neo4jErr, casted := err.(*db.Neo4jError)
 	if casted && neo4jErr.Classification() == "ClientError" {
 		b.log.Debugf(log.Bolt4, b.logId, "%s", err)
+	} else if wasDead {
+		b.log.Debugf(log.Bolt5, b.logId, "Already broken connection: %s", err)
 	} else {
 		b.log.Error(log.Bolt4, b.logId, err)
 	}

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -200,6 +200,7 @@ func (b *bolt5) setError(err error, fatal bool) {
 		return
 	}
 
+	wasDead := b.state == bolt5Dead
 	// No previous error
 	if b.err == nil {
 		b.err = err
@@ -224,6 +225,8 @@ func (b *bolt5) setError(err error, fatal bool) {
 	neo4jErr, casted := err.(*db.Neo4jError)
 	if casted && neo4jErr.Classification() == "ClientError" {
 		b.log.Debugf(log.Bolt5, b.logId, "%s", err)
+	} else if wasDead {
+		b.log.Debugf(log.Bolt5, b.logId, "Already broken connection: %s", err)
 	} else {
 		b.log.Error(log.Bolt5, b.logId, err)
 	}


### PR DESCRIPTION
 * Make sure that the pool's asynchronous connection closure (`GOODBYE`) does not get cancelled when the acquisition of return of a connection that triggered the clean-up ends (and thus cancels the parent context).
 * Lower log level from error to debug on errors occurring during connection closure or when the connection is already dead.