### PR TITLE
[5.28] Flesh out Driver.Close docs

### DIFF
--- a/neo4j/driver.go
+++ b/neo4j/driver.go
@@ -36,8 +36,13 @@ type Driver interface {
 	// establishing a network connection with the remote. Returns nil if succesful
 	// or error describing the problem.
 	VerifyConnectivity() error
-	// Close the driver and all underlying connections
+	// Close the driver and all underlying connections.
 	// This function may not be called while the driver is in use (i.e., concurrently).
+	//
+	// Connections that are still in use will be closed lazily when returned to the connection pool.
+	// This can lead to behavior that is hard to predict and which depends on driver implementation details.
+	// Therefore, it is strongly recommended to make sure you are done using the driver and have closed
+	// all resources spawned from it (such as sessions or transactions) while calling this method.
 	Close() error
 	// IsEncrypted determines whether the driver communication with the server
 	// is encrypted. This is a static check. The function can also be called on

--- a/neo4j/driver_with_context.go
+++ b/neo4j/driver_with_context.go
@@ -83,7 +83,13 @@ type DriverWithContext interface {
 	// If the error is on that list, an `neo4j.InvalidAuthenticationError` is returned.
 	// Otherwise, the original error is returned.
 	VerifyAuthentication(ctx context.Context, auth *AuthToken) error
-	// Close the driver and all underlying connections
+	// Close the driver and all underlying connections.
+	// This function may not be called while the driver is in use (i.e., concurrently).
+	//
+	// Connections that are still in use will be closed lazily when returned to the connection pool.
+	// This can lead to behavior that is hard to predict and which depends on driver implementation details.
+	// Therefore, it is strongly recommended to make sure you are done using the driver and have closed
+	// all resources spawned from it (such as sessions or transactions) while calling this method.
 	Close(ctx context.Context) error
 	// IsEncrypted determines whether the driver communication with the server
 	// is encrypted. This is a static check. The function can also be called on


### PR DESCRIPTION
 * Copy over concurrency warning to `DriverWithContext.Close`.
 * Add to both Close docs recommendation to finish using driver resources before closing the driver for a more predictable behavior.

Backport of https://github.com/neo4j/neo4j-go-driver/pull/650