### PR TITLE
Fix 32-bit ARM compatibility issue

### DIFF
--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -23,7 +23,6 @@ package pool
 import (
 	"container/list"
 	"context"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/homedb"
 	"math"
 	"sort"
 	"sync"
@@ -34,6 +33,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/bolt"
 	idb "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/db"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/errorutil"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/homedb"
 	itime "github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/time"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j/log"
 )
@@ -66,7 +66,7 @@ type Pool struct {
 	log        log.Logger
 	logId      string
 	cache      *homedb.Cache
-	ssrTracker ssrTracker
+	ssrTracker *ssrTracker
 }
 
 type serverPenalty struct {
@@ -87,7 +87,7 @@ func New(config *config.Config, connect Connect, logger log.Logger, logId string
 		logId:      logId,
 		log:        logger,
 		cache:      cache,
-		ssrTracker: ssrTracker{},
+		ssrTracker: &ssrTracker{},
 	}
 	p.log.Infof(log.Pool, p.logId, "Created")
 	return p

--- a/neo4j/internal/pool/ssr_tracker.go
+++ b/neo4j/internal/pool/ssr_tracker.go
@@ -24,27 +24,27 @@ import (
 )
 
 type ssrTracker struct {
-	ssrEnabledCount  uint64
-	ssrDisabledCount uint64
+	ssrEnabledCount  atomic.Uint64
+	ssrDisabledCount atomic.Uint64
 }
 
 func (s *ssrTracker) addConnection(c idb.Connection) {
 	if c.IsSsrEnabled() {
-		atomic.AddUint64(&s.ssrEnabledCount, ^uint64(0))
+		s.ssrEnabledCount.Add(1)
 	} else {
-		atomic.AddUint64(&s.ssrDisabledCount, ^uint64(0))
+		s.ssrDisabledCount.Add(1)
 	}
 }
 
 func (s *ssrTracker) removeConnection(c idb.Connection) {
 	if c.IsSsrEnabled() {
-		atomic.AddUint64(&s.ssrEnabledCount, 1)
+		s.ssrEnabledCount.Add(^uint64(0))
 	} else {
-		atomic.AddUint64(&s.ssrDisabledCount, 1)
+		s.ssrDisabledCount.Add(^uint64(0))
 	}
 }
 
 func (s *ssrTracker) ssrEnabled() bool {
-	return atomic.LoadUint64(&s.ssrEnabledCount) > 0 &&
-		atomic.LoadUint64(&s.ssrDisabledCount) == 0
+	return s.ssrEnabledCount.Load() > 0 &&
+		s.ssrDisabledCount.Load() == 0
 }

--- a/neo4j/internal/pool/ssr_tracker.go
+++ b/neo4j/internal/pool/ssr_tracker.go
@@ -24,27 +24,27 @@ import (
 )
 
 type ssrTracker struct {
-	ssrEnabledCount  atomic.Uint64
-	ssrDisabledCount atomic.Uint64
+	ssrEnabledCount  uint64
+	ssrDisabledCount uint64
 }
 
 func (s *ssrTracker) addConnection(c idb.Connection) {
 	if c.IsSsrEnabled() {
-		s.ssrEnabledCount.Add(1)
+		atomic.AddUint64(&s.ssrEnabledCount, 1)
 	} else {
-		s.ssrDisabledCount.Add(1)
+		atomic.AddUint64(&s.ssrDisabledCount, 1)
 	}
 }
 
 func (s *ssrTracker) removeConnection(c idb.Connection) {
 	if c.IsSsrEnabled() {
-		s.ssrEnabledCount.Add(^uint64(0))
+		atomic.AddUint64(&s.ssrEnabledCount, ^uint64(0))
 	} else {
-		s.ssrDisabledCount.Add(^uint64(0))
+		atomic.AddUint64(&s.ssrDisabledCount, ^uint64(0))
 	}
 }
 
 func (s *ssrTracker) ssrEnabled() bool {
-	return s.ssrEnabledCount.Load() > 0 &&
-		s.ssrDisabledCount.Load() == 0
+	return atomic.LoadUint64(&s.ssrEnabledCount) > 0 &&
+		atomic.LoadUint64(&s.ssrDisabledCount) == 0
 }


### PR DESCRIPTION
Fixes https://github.com/neo4j/neo4j-go-driver/issues/660.

Changed `ssrTracker` implementation to use a pointer instead of an embedded struct 
to ensure proper memory alignment for atomic operations.

Used `atomic.Uint64` type with correct increment/decrement logic for clarity in logs and to help with 32-bit issues.

Reproduced the crash and verified the fix using Docker - output below:

```docker
neo4j-1  | 2025-08-31 22:00:03.301+0000 INFO  Starting...
neo4j-1  | 2025-08-31 22:00:04.247+0000 INFO  This instance is ServerId{99901c7a} (99901c7a-81f4-46c2-adad-eac7dedc51bd)
neo4j-1  | 2025-08-31 22:00:05.351+0000 INFO  ======== Neo4j 5.26.11 ========
neo4j-1  | 2025-08-31 22:00:07.261+0000 INFO  Anonymous Usage Data is being sent to Neo4j, see https://neo4j.com/docs/usage-data/
neo4j-1  | 2025-08-31 22:00:07.404+0000 INFO  Bolt enabled on 0.0.0.0:7687.
neo4j-1  | 2025-08-31 22:00:08.443+0000 INFO  HTTP enabled on 0.0.0.0:7474.
neo4j-1  | 2025-08-31 22:00:08.445+0000 INFO  Remote interface available at http://localhost:7474/
neo4j-1  | 2025-08-31 22:00:08.454+0000 INFO  id: C1AC79C4520BF1227593000B04E69A81E68FCA26766E375C1A57C12D0FC939E2
neo4j-1  | 2025-08-31 22:00:08.455+0000 INFO  name: system
neo4j-1  | 2025-08-31 22:00:08.455+0000 INFO  creationDate: 2025-08-31T17:15:26.62Z
neo4j-1  | 2025-08-31 22:00:08.455+0000 INFO  Started.
test-fixed-1  | Testing with atomic alignment fix
test-broken-1  | Testing v5.28.2 (broken on 32-bit ARM)
test-broken-1  | Testing v5.28.2 (broken on 32-bit ARM)
test-fixed-1   | 2025-08-31 22:00:15.406   INFO  [pool 1] Created
test-fixed-1   | 2025-08-31 22:00:15.406   INFO  [pool 1] Created
test-fixed-1   | 2025-08-31 22:00:15.415   INFO  [router 1] Created {context: map[address:neo4j:7687]}
test-fixed-1   | 2025-08-31 22:00:15.415   INFO  [router 1] Created {context: map[address:neo4j:7687]}
test-fixed-1   | 2025-08-31 22:00:15.418   INFO  [driver 1] Created { target: neo4j:7687 }
test-fixed-1   | 2025-08-31 22:00:15.418   INFO  [driver 1] Created { target: neo4j:7687 }
test-broken-1  | 2025-08-31 22:00:15.414   INFO  [pool 1] Created
test-broken-1  | 2025-08-31 22:00:15.414   INFO  [pool 1] Created
test-fixed-1   | 2025-08-31 22:00:15.421   INFO  [router 1] Reading routing table from initial router: neo4j:7687
test-fixed-1   | 2025-08-31 22:00:15.421   INFO  [router 1] Reading routing table from initial router: neo4j:7687
test-broken-1  | 2025-08-31 22:00:15.420   INFO  [router 1] Created {context: map[address:neo4j:7687]}
test-broken-1  | 2025-08-31 22:00:15.420   INFO  [router 1] Created {context: map[address:neo4j:7687]}
test-broken-1  | 2025-08-31 22:00:15.422   INFO  [driver 1] Created { target: neo4j:7687 }
test-broken-1  | 2025-08-31 22:00:15.422   INFO  [driver 1] Created { target: neo4j:7687 }
test-fixed-1   | 2025-08-31 22:00:15.422   INFO  [pool 1] Connecting to neo4j:7687
test-fixed-1   | 2025-08-31 22:00:15.422   INFO  [pool 1] Connecting to neo4j:7687
test-broken-1  | 2025-08-31 22:00:15.425   INFO  [router 1] Reading routing table from initial router: neo4j:7687
test-broken-1  | 2025-08-31 22:00:15.425   INFO  [router 1] Reading routing table from initial router: neo4j:7687
test-broken-1  | 2025-08-31 22:00:15.426   INFO  [pool 1] Connecting to neo4j:7687
test-broken-1  | 2025-08-31 22:00:15.426   INFO  [pool 1] Connecting to neo4j:7687

test-fixed-1   | 2025-08-31 22:00:15.488   INFO  [bolt5 bolt-2@neo4j:7687] Connected
test-fixed-1   | 2025-08-31 22:00:15.489   INFO  [bolt5 bolt-2@neo4j:7687] Retrieving routing table
test-broken-1  | 2025-08-31 22:00:15.488   INFO  [bolt5 bolt-3@neo4j:7687] Connected
test-fixed-1   | 2025-08-31 22:00:15.489   INFO  [bolt5 bolt-2@neo4j:7687] Retrieving routing table


test-broken-1  | 2025-08-31 22:00:15.490   INFO  [pool 1] Closed
test-broken-1  | 2025-08-31 22:00:15.490   INFO  [pool 1] Closed
test-broken-1  | 2025-08-31 22:00:15.490   INFO  [driver 1] Closed
test-broken-1  | panic: unaligned 64-bit atomic operation
test-broken-1  | 
test-broken-1  | goroutine 1 [running]:
test-broken-1  | runtime/internal/atomic.panicUnaligned()
test-broken-1  | runtime/internal/atomic.panicUnaligned()
test-broken-1  |        /usr/local/go/src/runtime/internal/atomic/unaligned.go:8 +0x24
test-broken-1  |        /usr/local/go/src/runtime/internal/atomic/unaligned.go:8 +0x24
test-broken-1  | runtime/internal/atomic.Xadd64(0x8623d4, 0xffffffffffffffff)
test-broken-1  | runtime/internal/atomic.Xadd64(0x8623d4, 0xffffffffffffffff)
test-broken-1  |        /usr/local/go/src/runtime/internal/atomic/atomic_arm.s:258 +0x14
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool.(*ssrTracker).addConnection(0x8623d4, {0x2f553c, 0x8b8000})
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/pool/ssr_tracker.go:33 +0x4c
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool.(*Pool).tryBorrow(0x862380, {0x2f47bc, 0x8640f0}, {0x29c85a, 0xa}, {0x0, 0x0}, 0x7fffffffffffffff, 0x80c0c0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/pool/pool.go:362 +0x918
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool.(*Pool).Borrow(0x862380, {0x2f47bc, 0x8640f0}, 0x80c120, 0x1, {0x0, 0x0}, 0x7fffffffffffffff, 0x80c0c0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/pool/pool.go:226 +0x7c4
test-broken-1  |        /usr/local/go/src/runtime/internal/atomic/atomic_arm.s:258 +0x14
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool.(*ssrTracker).addConnection(0x8623d4, {0x2f553c, 0x8b8000})
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router.(*Router).GetOrUpdateWriters(0x8640a0, {0x2f47bc, 0x8640f0}, 0x810160, {{0x2997f1, 0x5}, 0x0}, 0x80c0c0, {0x0, 0x0}, ...)

test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/router/router.go:284 +0x6c
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).getOrUpdateServers(0x91c000, {0x2f47bc, 0x8640f0}, 0x0, 0x0, 0x0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:571 +0x1b0
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).getServerList(0x91c000, {0x2f47bc, 0x8640f0}, 0x0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:655 +0x320
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).getConnection(0x91c000, {0x2f471c, 0x441738}, 0x0, 0x7fffffffffffffff)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.gotest-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/pool/ssr_tracker.go:33 +0x4c
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).executeQueryWrite(0x91c000, {0x2f471c, 0x441738}, 0x800400, {0x0, 0x0, 0x0})
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:423 +0x64
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool.(*Pool).tryBorrow(0x862380, {0x2f47bc, 0x8640f0}, {0x29c85a, 0xa}, {0x0, 0x0}, 0x7fffffffffffffff, 0x80c0c0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/pool/pool.go:362 +0x918
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/pool.(*Pool).Borrow(0x862380, {0x2f47bc, 0x8640f0}, 0x80c120, 0x1, {0x0, 0x0}, 0x7fffffffffffffff, 0x80c0c0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/pool/pool.go:226 +0x7c4
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router.readTable({0x2f47bc, 0x8640f0}, {0x2f4180, 0x862380}, {0x90f944, 0x1, 0x1}, 0x800340, 0x7fffffffffffffff, {0x0, ...}, ...)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/router/readtable.go:51 +0x120
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router.(*Router).readTable(0x8640a0, {0x2f47bc, 0x8640f0}, 0x0, {0x0, 0x0, 0x0}, {0x2997f1, 0x5}, {0x0, ...}, ...)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/router/router.go:112 +0x3d4
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router.(*Router).updateTable(0x8640a0, {0x2f47bc, 0x8640f0}, 0x810160, {0x2997f1, 0x5}, 0x80c0c0, {0x0, 0x0}, 0x0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/router/router.go:220 +0xac
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router.(*Router).getOrUpdateTable(0x8640a0, {0x2f47bc, 0x8640f0}, 0x810160, {{0x2997f1, 0x5}, 0x0}, 0x80c0c0, {0x0, 0x0}, ...)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/router/router.go:192 +0x46c
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j/internal/router.(*Router).GetOrUpdateWriters(0x8640a0, {0x2f47bc, 0x8640f0}, 0x810160, {{0x2997f1, 0x5}, 0x0}, 0x80c0c0, {0x0, 0x0}, ...)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/internal/router/router.go:284 +0x6c
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).getOrUpdateServers(0x91c000, {0x2f47bc, 0x8640f0}, 0x0, 0x0, 0x0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:571 +0x1b0
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).getServerList(0x91c000, {0x2f47bc, 0x8640f0}, 0x0)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:655 +0x320
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).getConnection(0x91c000, {0x2f471c, 0x441738}, 0x0, 0x7fffffffffffffff)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:591 +0x9c
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).executeTransactionFunction(0x91c000, {0x2f471c, 0x441738}, 0x0, {0xffffffff80000000, 0x0}, 0x8623f0, 0x800400, 0x0, 0x3)
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:488 +0x74
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).runRetriable(0x91c000, {0x2f471c, 0x441738}, 0x0, 0x800400, 0x0, 0x3, {0x0, 0x0, 0x0})
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:469 +0x324
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.(*sessionWithContext).executeQueryWrite(0x91c000, {0x2f471c, 0x441738}, 0x800400, {0x0, 0x0, 0x0})
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/session_with_context.go:423 +0x64
test-broken-1  | github.com/neo4j/neo4j-go-driver/v5/neo4j.ExecuteQuery[...]({0x2f471c, 0x441738}, {0x2f4d3c, 0x900000}, {0x29cd08, 0x13}, 0x0, 0x2ac330, {0x90ff48, 0x1, ...})
test-broken-1  |        /go/pkg/mod/github.com/neo4j/neo4j-go-driver/v5@v5.28.2/neo4j/driver_with_context.go:550 +0x380
test-broken-1  | main.main()
test-broken-1  |        /app/main.go:37 +0x3c4
test-fixed-1   | Result: &{[42] [answer]}
test-fixed-1   | Result: &{[42] [answer]}
test-fixed-1   | 2025-08-31 22:00:15.551   INFO  [pool 1] Closed
test-fixed-1   | 2025-08-31 22:00:15.551   INFO  [driver 1] Closed
test-broken-1 exited with code 2
test-fixed-1 exited with code 0
```