### PR TITLE
Fix Close deadlock

### DIFF
--- a/neo4j/driver.go
+++ b/neo4j/driver.go
@@ -418,6 +418,7 @@ func (d *driver) Close(ctx context.Context) error {
 	d.mut.Lock()
 	if d.pool == nil {
 		// Safeguard against closing more than once
+		d.mut.Unlock()
 		return nil
 	}
 	pool := d.pool

--- a/neo4j/driver.go
+++ b/neo4j/driver.go
@@ -416,14 +416,13 @@ func (d *driver) GetServerInfo(ctx context.Context) (_ ServerInfo, err error) {
 
 func (d *driver) Close(ctx context.Context) error {
 	d.mut.Lock()
+	defer d.mut.Unlock()
 	if d.pool == nil {
 		// Safeguard against closing more than once
-		d.mut.Unlock()
 		return nil
 	}
 	pool := d.pool
 	d.pool = nil
-	d.mut.Unlock()
 
 	pool.Close(ctx)
 	pool = nil

--- a/neo4j/driver_test.go
+++ b/neo4j/driver_test.go
@@ -219,6 +219,20 @@ func TestNewDriverAndClose(t *testing.T) {
 	}
 }
 
+func TestDriverMultipleCloseCalls(t *testing.T) {
+	ctx := context.Background()
+	driver, err := NewDriver("bolt://localhost:7687", NoAuth())
+	AssertNoError(t, err)
+
+	// Test multiple Close calls - should not deadlock
+	for i := range 10 {
+		err = driver.Close(ctx)
+		if err != nil {
+			t.Errorf("Close() call %d unexpected error = %v", i+1, err)
+		}
+	}
+}
+
 func TestDriverSessionCreation(t *testing.T) {
 	driverSessionCreationTests := []struct {
 		name      string


### PR DESCRIPTION
Potential fix for deadlocking when calling `Driver.Close` multiple times:

```go
for i := 0; i < 10; i++ {
    err = driver.Close(ctx)
    // can deadlock
}
```

- `Close` didn't unlock the mutex when the pool was already closed.
- First `Close` sets `pool = nil`; second `Close` sees `pool = nil` but doesn't unlock mutex.
- Third `Close` tries to acquire a mutex that's still locked by the second call.
