### PR TITLE
ADR 033: UnsupportedType

### DIFF
--- a/neo4j/dbtype/unsupported.go
+++ b/neo4j/dbtype/unsupported.go
@@ -36,9 +36,16 @@ import (
 // If your application requires handling this type, you must upgrade your driver to a
 // version that supports it.
 type UnsupportedType struct {
-	Name                   string
+	// Name is the name of the type.
+	Name string
+	// MinimumProtocolVersion returns the minimum required Bolt protocol version that supports this type.
+	// To understand which driver version this corresponds to, refer to the driver's release notes or documentation.
+	//
+	// Note: Bolt versions are not generally equivalent to driver versions.
+	// See https://neo4j.com/docs/go-manual/current/data-types/ for which driver version is required for new types.
 	MinimumProtocolVersion db.ProtocolVersion
-	Message                *string
+	// Message contains any additional information provided by the server about this type.
+	Message *string
 }
 
 // String returns a string representation of the UnsupportedType.

--- a/neo4j/dbtype/unsupported.go
+++ b/neo4j/dbtype/unsupported.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dbtype
+
+import (
+	"fmt"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
+)
+
+// UnsupportedType represents a type unknown to the driver, received from the server.
+// This type is used, for instance, when a newer DBMS produces a result containing a type
+// that the current version of the driver does not yet understand.
+//
+// Note that this type may only be received from the server, but cannot be sent to the
+// server (e.g., as a query parameter).
+//
+// The attributes exposed by this type are meant for displaying and debugging purposes.
+// They may change in future versions of the server, and should not be relied upon for
+// any logic in your application.
+// If your application requires handling this type, you must upgrade your driver to a
+// version that supports it.
+type UnsupportedType struct {
+	Name                   string
+	MinimumProtocolVersion db.ProtocolVersion
+	Message                *string
+}
+
+// String returns a string representation of the UnsupportedType.
+func (u *UnsupportedType) String() string {
+	return fmt.Sprintf("UnsupportedType<%s>", u.Name)
+}

--- a/neo4j/dbtype/unsupported.go
+++ b/neo4j/dbtype/unsupported.go
@@ -43,5 +43,5 @@ type UnsupportedType struct {
 
 // String returns a string representation of the UnsupportedType.
 func (u *UnsupportedType) String() string {
-	return fmt.Sprintf("UnsupportedType<%s>", u.Name)
+	return fmt.Sprintf("UnsupportedType[%s]", u.Name)
 }

--- a/neo4j/dbtype/unsupportedtypes_test.go
+++ b/neo4j/dbtype/unsupportedtypes_test.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dbtype
+
+import (
+	"testing"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
+)
+
+func TestUnsupportedTypes(t *testing.T) {
+	t.Run("String representation of UnsupportedType", func(t *testing.T) {
+		unsupported := &UnsupportedType{
+			Name:                   "UUID",
+			MinimumProtocolVersion: db.ProtocolVersion{Major: 6, Minor: 0},
+			Message:                nil,
+		}
+		actual := unsupported.String()
+		expect := "UnsupportedType<UUID>"
+		if actual != expect {
+			t.Errorf("Expected %s but was %s", expect, actual)
+		}
+	})
+}

--- a/neo4j/dbtype/unsupportedtypes_test.go
+++ b/neo4j/dbtype/unsupportedtypes_test.go
@@ -24,14 +24,28 @@ import (
 )
 
 func TestUnsupportedTypes(t *testing.T) {
-	t.Run("String representation of UnsupportedType", func(t *testing.T) {
+	t.Run("String representation of UnsupportedType with nil message", func(t *testing.T) {
 		unsupported := &UnsupportedType{
 			Name:                   "UUID",
 			MinimumProtocolVersion: db.ProtocolVersion{Major: 6, Minor: 0},
 			Message:                nil,
 		}
 		actual := unsupported.String()
-		expect := "UnsupportedType<UUID>"
+		expect := "UnsupportedType[UUID]"
+		if actual != expect {
+			t.Errorf("Expected %s but was %s", expect, actual)
+		}
+	})
+
+	t.Run("String representation of UnsupportedType with non-nil message", func(t *testing.T) {
+		message := "This type requires a newer driver version"
+		unsupported := &UnsupportedType{
+			Name:                   "CustomType",
+			MinimumProtocolVersion: db.ProtocolVersion{Major: 6, Minor: 0},
+			Message:                &message,
+		}
+		actual := unsupported.String()
+		expect := "UnsupportedType[CustomType]"
 		if actual != expect {
 			t.Errorf("Expected %s but was %s", expect, actual)
 		}

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -517,6 +517,8 @@ func (h *hydrator) value() any {
 			return h.localTime(n)
 		case 'E':
 			return h.duration(n)
+		case '?':
+			return h.unsupportedType(n)
 		default:
 			return h.unknownStructError(t)
 		}
@@ -1190,6 +1192,39 @@ func (h *hydrator) vector(n uint32) any {
 			Err:         fmt.Sprintf("Unknown vector type marker: %d", typeMarker[0]),
 		})
 		return nil
+	}
+}
+
+func (h *hydrator) unsupportedType(n uint32) any {
+	h.assertLength("unsupported", 4, n)
+	if h.getErr() != nil {
+		return nil
+	}
+
+	h.unp.Next()
+	name := h.unp.String()
+
+	h.unp.Next()
+	major := int(h.unp.Int())
+
+	h.unp.Next()
+	minor := int(h.unp.Int())
+
+	h.unp.Next()
+	extra := h.amap()
+
+	var message *string
+	if msg, ok := extra["message"].(string); ok {
+		message = &msg
+	}
+
+	return &dbtype.UnsupportedType{
+		Name: name,
+		MinimumProtocolVersion: db.ProtocolVersion{
+			Major: major,
+			Minor: minor,
+		},
+		Message: message,
 	}
 }
 

--- a/neo4j/internal/bolt/hydrator_test.go
+++ b/neo4j/internal/bolt/hydrator_test.go
@@ -1094,6 +1094,61 @@ func TestHydrator(outer *testing.T) {
 				Err:         "Expected byte array for vector values",
 			},
 		},
+		{
+			name: "UnsupportedType without message",
+			build: func() {
+				packer.StructHeader(byte(msgRecord), 1)
+				packer.ArrayHeader(1)
+				packer.StructHeader('?', 4)
+				packer.String("UUID")
+				packer.Int(255)
+				packer.Int(0)
+				packer.MapHeader(0)
+			},
+			x: &db.Record{Values: []any{
+				&dbtype.UnsupportedType{
+					Name:                   "UUID",
+					MinimumProtocolVersion: db.ProtocolVersion{Major: 255, Minor: 0},
+					Message:                nil,
+				},
+			}},
+		},
+		{
+			name: "UnsupportedType with message",
+			build: func() {
+				packer.StructHeader(byte(msgRecord), 1)
+				packer.ArrayHeader(1)
+				packer.StructHeader('?', 4)
+				packer.String("UUID")
+				packer.Int(255)
+				packer.Int(0)
+				packer.MapHeader(1)
+				packer.String("message")
+				packer.String("Some configuration message")
+			},
+			x: &db.Record{Values: []any{
+				&dbtype.UnsupportedType{
+					Name:                   "UUID",
+					MinimumProtocolVersion: db.ProtocolVersion{Major: 255, Minor: 0},
+					Message:                stringPtr("Some configuration message"),
+				},
+			}},
+		},
+		{
+			name: "UnsupportedType invalid length",
+			build: func() {
+				packer.StructHeader(byte(msgRecord), 1)
+				packer.ArrayHeader(1)
+				packer.StructHeader('?', 3)
+				packer.String("UUID")
+				packer.Int(255)
+				packer.Int(0)
+			},
+			err: &db.ProtocolError{
+				MessageType: "unsupported",
+				Err:         "Invalid length of struct, expected 4 but was 3",
+			},
+		},
 	}
 
 	// Shared among calls in real usage so we do the same while testing it.
@@ -1130,6 +1185,11 @@ func TestHydrator(outer *testing.T) {
 			}
 		})
 	}
+}
+
+// Helper function to create string pointer
+func stringPtr(s string) *string {
+	return &s
 }
 
 func TestHydratorBolt5(outer *testing.T) {

--- a/neo4j/internal/bolt/hydrator_test.go
+++ b/neo4j/internal/bolt/hydrator_test.go
@@ -1130,7 +1130,7 @@ func TestHydrator(outer *testing.T) {
 				&dbtype.UnsupportedType{
 					Name:                   "UUID",
 					MinimumProtocolVersion: db.ProtocolVersion{Major: 255, Minor: 0},
-					Message:                stringPtr("Some configuration message"),
+					Message:                ptr("Some configuration message"),
 				},
 			}},
 		},
@@ -1187,9 +1187,9 @@ func TestHydrator(outer *testing.T) {
 	}
 }
 
-// Helper function to create string pointer
-func stringPtr(s string) *string {
-	return &s
+// Helper function to create a pointer (e.g., for an untyped literal)
+func ptr[T any](x T) *T {
+	return &x
 }
 
 func TestHydratorBolt5(outer *testing.T) {

--- a/testkit-backend/2cypher.go
+++ b/testkit-backend/2cypher.go
@@ -220,15 +220,14 @@ func nativeToCypher(v any) map[string]any {
 		return vectorToCypher("f64", x)
 	case *dbtype.UnsupportedType:
 		data := map[string]any{
-			"name":                 x.Name,
-			"minimumProtocolMajor": x.MinimumProtocolVersion.Major,
-			"minimumProtocolMinor": x.MinimumProtocolVersion.Minor,
+			"name":            x.Name,
+			"minimumProtocol": fmt.Sprintf("%d.%d", x.MinimumProtocolVersion.Major, x.MinimumProtocolVersion.Minor),
 		}
 		if x.Message != nil {
 			data["message"] = *x.Message
 		}
 		return map[string]any{
-			"name": "CypherUnknownType",
+			"name": "CypherUnsupportedType",
 			"data": data,
 		}
 	}

--- a/testkit-backend/2cypher.go
+++ b/testkit-backend/2cypher.go
@@ -218,6 +218,19 @@ func nativeToCypher(v any) map[string]any {
 		return vectorToCypher("f32", x)
 	case dbtype.Vector[float64]:
 		return vectorToCypher("f64", x)
+	case *dbtype.UnsupportedType:
+		data := map[string]any{
+			"name":                 x.Name,
+			"minimumProtocolMajor": x.MinimumProtocolVersion.Major,
+			"minimumProtocolMinor": x.MinimumProtocolVersion.Minor,
+		}
+		if x.Message != nil {
+			data["message"] = *x.Message
+		}
+		return map[string]any{
+			"name": "CypherUnknownType",
+			"data": data,
+		}
 	}
 
 	panic(fmt.Sprintf("Don't know how to patch %T", v))

--- a/testkit-backend/2native.go
+++ b/testkit-backend/2native.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/dbtype"
 )
 
@@ -221,6 +222,24 @@ func cypherToNative(c any) (any, error) {
 		default:
 			return nil, fmt.Errorf("unsupported vector dtype: %s", dtype)
 		}
+	case "CypherUnknownType":
+		name := d["name"].(string)
+		major := asInt(d["minimumProtocolMajor"].(json.Number))
+		minor := asInt(d["minimumProtocolMinor"].(json.Number))
+
+		var message *string
+		if msg, ok := d["message"].(string); ok {
+			message = &msg
+		}
+
+		return &dbtype.UnsupportedType{
+			Name: name,
+			MinimumProtocolVersion: db.ProtocolVersion{
+				Major: major,
+				Minor: minor,
+			},
+			Message: message,
+		}, nil
 	}
 	panic(fmt.Sprintf("Don't know how to convert %s to native", n))
 }

--- a/testkit-backend/2native.go
+++ b/testkit-backend/2native.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/dbtype"
 )
 
@@ -222,24 +221,6 @@ func cypherToNative(c any) (any, error) {
 		default:
 			return nil, fmt.Errorf("unsupported vector dtype: %s", dtype)
 		}
-	case "CypherUnknownType":
-		name := d["name"].(string)
-		major := asInt(d["minimumProtocolMajor"].(json.Number))
-		minor := asInt(d["minimumProtocolMinor"].(json.Number))
-
-		var message *string
-		if msg, ok := d["message"].(string); ok {
-			message = &msg
-		}
-
-		return &dbtype.UnsupportedType{
-			Name: name,
-			MinimumProtocolVersion: db.ProtocolVersion{
-				Major: major,
-				Minor: minor,
-			},
-			Message: message,
-		}, nil
 	}
 	panic(fmt.Sprintf("Don't know how to convert %s to native", n))
 }

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1357,7 +1357,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"Feature:API:Type.Spatial",
 				"Feature:API:Type.Temporal",
 				"Feature:API:Type.Vector",
-				"Feature:API:Type.UnknownType",
+				"Feature:API:Type.UnsupportedType",
 				"Feature:Auth:Bearer",
 				"Feature:Auth:Custom",
 				"Feature:Auth:Kerberos",

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1357,6 +1357,7 @@ func (b *backend) handleRequest(req map[string]any) {
 				"Feature:API:Type.Spatial",
 				"Feature:API:Type.Temporal",
 				"Feature:API:Type.Vector",
+				"Feature:API:Type.UnknownType",
 				"Feature:Auth:Bearer",
 				"Feature:Auth:Custom",
 				"Feature:Auth:Kerberos",


### PR DESCRIPTION
Bolt 6 introduces a new data type representing a value of a type that the server cannot transmit to the client due to the negotiation of an incompatible bolt protocol version.