### PR TITLE
Short-circuit retries on context timeout

### DIFF
--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -71,6 +71,13 @@ func (s *State) Continue(ctx context.Context) bool {
 		s.start = itime.Now()
 	}
 
+	select {
+	case <-ctx.Done():
+		s.Errs = append(s.Errs, ctx.Err())
+		return false
+	default:
+	}
+
 	if len(s.Errs) == 0 {
 		return true
 	}
@@ -110,6 +117,7 @@ func (s *State) Continue(ctx context.Context) bool {
 				Cause:  err.Error(),
 				Errors: s.Errs,
 			}}
+			return false
 		}
 	}
 	return true

--- a/neo4j/session_test.go
+++ b/neo4j/session_test.go
@@ -182,6 +182,25 @@ func TestSession(outer *testing.T) {
 			assertCleanSessionState(t, sess)
 		})
 
+		inner.Run("Fails fast on context timeout", func(t *testing.T) {
+			_, pool, sess := createSession()
+			pool.BorrowConn = &ConnFake{Alive: false}
+			numRetries := 0
+			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(ctx, 0)
+			defer cancel()
+			<-ctx.Done()
+			_, err := sess.ExecuteWrite(ctx, func(tx ManagedTransaction) (any, error) {
+				numRetries++
+				return nil, ctx.Err()
+			})
+			if numRetries > 0 {
+				t.Error("Should fail fast on context timeout")
+			}
+			AssertTrue(t, IsConnectivityError(err))
+			assertCleanSessionState(t, sess)
+		})
+
 		inner.Run("Retrieves default database name for impersonated user", func(t *testing.T) {
 			sessConfig := SessionConfig{ImpersonatedUser: "me"}
 			router, pool, sess := createSessionFromConfig(sessConfig)


### PR DESCRIPTION
Port of #666 

Check explicitly for context completion in `State.Continue` to prevent unnecessary work that will inevitably fail.

This also fixes a bug where `ExecuteQuery` will loop without sleeping until a condition is hit (like `MaxTransactionRetryTime` or `MaxDeadConnections`) because the error handling sets skipSleep = true.