### PR TITLE
Make PoolOutOfServers error retryable.

### DIFF
--- a/neo4j/error_test.go
+++ b/neo4j/error_test.go
@@ -36,7 +36,10 @@ func TestIsRetryable(outer *testing.T) {
 		{true, &ConnectivityError{
 			Inner: fmt.Errorf("hello, is it me you are looking for"),
 		}},
-		{true, &errorutil.PoolOutOfServers{}},
+		// PoolOutOfServers is wrapped by session.getConnection() before users see it
+		{true, &ConnectivityError{
+			Inner: &errorutil.PoolOutOfServers{},
+		}},
 		{true, &db.Neo4jError{
 			Code: "Neo.TransientError.No.Stress",
 			Msg:  "Relax: Retry it Easyyy",

--- a/neo4j/error_test.go
+++ b/neo4j/error_test.go
@@ -36,6 +36,7 @@ func TestIsRetryable(outer *testing.T) {
 		{true, &ConnectivityError{
 			Inner: fmt.Errorf("hello, is it me you are looking for"),
 		}},
+		{true, &errorutil.PoolOutOfServers{}},
 		{true, &db.Neo4jError{
 			Code: "Neo.TransientError.No.Stress",
 			Msg:  "Relax: Retry it Easyyy",

--- a/neo4j/internal/errorutil/errors.go
+++ b/neo4j/internal/errorutil/errors.go
@@ -70,7 +70,7 @@ func WrapError(err error) error {
 		return &UsageError{Message: err.Error()}
 	case *TlsError, net.Error:
 		return &ConnectivityError{Inner: err}
-	case *PoolTimeout, *PoolFull:
+	case *PoolTimeout, *PoolFull, *PoolOutOfServers:
 		return &ConnectivityError{Inner: err}
 	case *ReadRoutingTableError:
 		return &ConnectivityError{Inner: err}

--- a/neo4j/internal/errorutil/errors_test.go
+++ b/neo4j/internal/errorutil/errors_test.go
@@ -18,6 +18,7 @@
 package errorutil_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -127,6 +128,23 @@ func TestCombineAllErrors(outer *testing.T) {
 
 			AssertDeepEquals(t, testCase.output, output)
 		})
+	}
+}
+
+func TestWrapError(t *testing.T) {
+	// Test that PoolOutOfServers is wrapped as ConnectivityError (making it retryable)
+	err := &errorutil.PoolOutOfServers{}
+	wrapped := errorutil.WrapError(err)
+
+	var connErr *errorutil.ConnectivityError
+	ok := errors.As(wrapped, &connErr)
+	if !ok {
+		t.Fatalf("Expected PoolOutOfServers to be wrapped as ConnectivityError, got %T", wrapped)
+	}
+
+	var poolOutOfServers *errorutil.PoolOutOfServers
+	if !errors.As(connErr.Inner, &poolOutOfServers) {
+		t.Fatalf("Expected inner error to be PoolOutOfServers, got %T", connErr.Inner)
 	}
 }
 

--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -141,9 +141,6 @@ func IsRetryable(err error) bool {
 	if _, ok := err.(*errorutil.PoolTimeout); ok {
 		return true
 	}
-	if _, ok := err.(*errorutil.PoolOutOfServers); ok {
-		return true
-	}
 	var dbError *db.Neo4jError
 	if !errors.As(err, &dbError) {
 		return false

--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -141,6 +141,9 @@ func IsRetryable(err error) bool {
 	if _, ok := err.(*errorutil.PoolTimeout); ok {
 		return true
 	}
+	if _, ok := err.(*errorutil.PoolOutOfServers); ok {
+		return true
+	}
 	var dbError *db.Neo4jError
 	if !errors.As(err, &dbError) {
 		return false

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -71,8 +71,10 @@ func TestState(outer *testing.T) {
 				expectLastErrWasRetryable: true, expectLastErrType: &errorutil.PoolTimeout{}},
 		},
 		"Retry on PoolOutOfServers": {
-			{conn: nil, err: &errorutil.PoolOutOfServers{}, expectContinued: true,
-				expectLastErrWasRetryable: true, expectLastErrType: &errorutil.PoolOutOfServers{}},
+			// Note: PoolOutOfServers is wrapped as ConnectivityError by session.getConnection()
+			// before reaching the retry logic.
+			{conn: nil, err: &errorutil.ConnectivityError{Inner: &errorutil.PoolOutOfServers{}}, expectContinued: true,
+				expectLastErrWasRetryable: true, expectLastErrType: &errorutil.ConnectivityError{}},
 		},
 		"Retry connect timeout": {
 			{conn: nil, err: dbTransientErr, expectContinued: true, freezeTime: true,

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -70,6 +70,10 @@ func TestState(outer *testing.T) {
 			{conn: nil, err: &errorutil.PoolTimeout{}, expectContinued: true,
 				expectLastErrWasRetryable: true, expectLastErrType: &errorutil.PoolTimeout{}},
 		},
+		"Retry on PoolOutOfServers": {
+			{conn: nil, err: &errorutil.PoolOutOfServers{}, expectContinued: true,
+				expectLastErrWasRetryable: true, expectLastErrType: &errorutil.PoolOutOfServers{}},
+		},
 		"Retry connect timeout": {
 			{conn: nil, err: dbTransientErr, expectContinued: true, freezeTime: true,
 				expectLastErrWasRetryable: true},


### PR DESCRIPTION
When multiple goroutines access the pool concurrently, one may remove all servers from the routing table while another is trying to borrow a connection, resulting in a `PoolOutOfServers` error. This error should trigger a retry with a fresh routing table fetch, similar to `PoolTimeout`.

- Wrapped `PoolOutOfServers` as `ConnectivityError` for consistency.