### PR TITLE
Deprecate Notifications and Stabilize GqlStatusObjects

### DIFF
--- a/neo4j/auth/auth.go
+++ b/neo4j/auth/auth.go
@@ -86,6 +86,7 @@ func (m *neo4jAuthTokenManager) GetAuthToken(ctx context.Context) (auth.Token, e
 }
 
 func (m *neo4jAuthTokenManager) HandleSecurityException(ctx context.Context, token auth.Token, securityException *db.Neo4jError) (bool, error) {
+	//lint:ignore SA1019 Code is supported for security exception handling
 	if !m.handledSecurityCodes.Contains(securityException.Code) {
 		return false, nil
 	}

--- a/neo4j/config.go
+++ b/neo4j/config.go
@@ -29,17 +29,18 @@ import (
 
 func defaultConfig() *config.Config {
 	return &config.Config{
-		AddressResolver:                      nil,
-		MaxTransactionRetryTime:              30 * time.Second,
-		MaxConnectionPoolSize:                100,
-		MaxConnectionLifetime:                1 * time.Hour,
-		ConnectionAcquisitionTimeout:         1 * time.Minute,
-		ConnectionLivenessCheckTimeout:       pool.DefaultConnectionLivenessCheckTimeout,
-		SocketConnectTimeout:                 5 * time.Second,
-		SocketKeepalive:                      true,
-		UserAgent:                            UserAgent,
-		FetchSize:                            FetchDefault,
-		NotificationsMinSeverity:             notifications.DefaultLevel,
+		AddressResolver:                nil,
+		MaxTransactionRetryTime:        30 * time.Second,
+		MaxConnectionPoolSize:          100,
+		MaxConnectionLifetime:          1 * time.Hour,
+		ConnectionAcquisitionTimeout:   1 * time.Minute,
+		ConnectionLivenessCheckTimeout: pool.DefaultConnectionLivenessCheckTimeout,
+		SocketConnectTimeout:           5 * time.Second,
+		SocketKeepalive:                true,
+		UserAgent:                      UserAgent,
+		FetchSize:                      FetchDefault,
+		NotificationsMinSeverity:       notifications.DefaultLevel,
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 		NotificationsDisabledCategories:      notifications.NotificationDisabledCategories{},
 		NotificationsDisabledClassifications: notifications.NotificationDisabledClassifications{},
 		TelemetryDisabled:                    false,
@@ -83,6 +84,7 @@ func validateAndNormaliseConfig(config *config.Config) error {
 	}
 
 	// Check notifications have not been configured with both categories and classifications.
+	//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 	if len(config.NotificationsDisabledCategories.DisabledCategories()) > 0 &&
 		len(config.NotificationsDisabledClassifications.DisabledClassifications()) > 0 {
 		return &UsageError{Message: "Notifications cannot be disabled for both categories and classifications at the same time."}

--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -174,12 +174,12 @@ type Config struct {
 	// NotificationsDisabledCategories defines the categories of notifications the server should not send.
 	// By default, the server's settings are used.
 	// Disabling categories allows the server to skip analysis for those, which can speed up query execution.
+	//
+	// Deprecated: Use NotificationsDisabledClassifications instead. This will be removed in a future release.
+	//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
 	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
 	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.
-	//
-	// NotificationsDisabledClassifications is part of the GQL compliant notifications preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
 	NotificationsDisabledClassifications notifications.NotificationDisabledClassifications
 	// By default, if the server requests it, the driver will automatically transmit anonymous usage
 	// statistics to the server it is connected to.

--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -178,8 +178,9 @@ type Config struct {
 	// Deprecated: Use NotificationsDisabledClassifications instead. This will be removed in a future release.
 	//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
-	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
-	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.
+	// NotificationsDisabledClassifications defines the classifications of notifications the server should not send.
+	// By default, the server's settings are used.
+	// Disabling classifications allows the server to skip analysis for those, which can speed up query execution.
 	NotificationsDisabledClassifications notifications.NotificationDisabledClassifications
 	// By default, if the server requests it, the driver will automatically transmit anonymous usage
 	// statistics to the server it is connected to.

--- a/neo4j/config_test.go
+++ b/neo4j/config_test.go
@@ -127,6 +127,8 @@ func TestValidateAndNormaliseConfig(rt *testing.T) {
 	rt.Run("Configure both NotificationsDisabledCategories and NotificationsDisabledCategories", func(t *testing.T) {
 		config := defaultConfig()
 
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
+		//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 		config.NotificationsDisabledCategories = notifications.DisableCategories(notifications.Deprecation)
 		config.NotificationsDisabledClassifications = notifications.DisableClassifications(notifications.Deprecation)
 

--- a/neo4j/db/errors.go
+++ b/neo4j/db/errors.go
@@ -44,39 +44,24 @@ const (
 // Neo4jError is created when the database server fails to fulfill a request.
 type Neo4jError struct {
 	// Code is the Neo4j-specific error code, to be deprecated in favor of GqlStatus.
+	//
+	// Deprecated: Use GqlStatus instead. This will be removed in a future release.
 	Code string
 	// Msg is the specific error message describing the failure.
-	Msg string
-	// GqlStatus returns the GQLSTATUS.
-	// GqlStatus is the error code compliant with the GQL specification.
 	//
-	// GqlStatus is part of the GQL compliant errors preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
+	// Deprecated: Use GqlStatusDescription instead. This will be removed in a future release.
+	Msg string
+	// GqlStatus is the error code compliant with the GQL specification.
 	GqlStatus string
 	// GqlStatusDescription provides a standard description for the associated GQLStatus code.
-	//
-	// GqlStatusDescription is part of the GQL compliant errors preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlStatusDescription string
 	// GqlClassification is a high-level categorization of the error, specific to GQL error handling.
-	//
-	// GqlClassification is part of the GQL compliant errors preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlClassification ErrorClassification
 	// GqlRawClassification holds the raw classification as received from the server.
-	//
-	// GqlRawClassification is part of the GQL compliant errors preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlRawClassification string
 	// GqlDiagnosticRecord returns further information about the status for diagnostic purposes.
-	//
-	// GqlDiagnosticRecord is part of the GQL compliant errors preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlDiagnosticRecord map[string]any
 	// GqlCause represents the underlying error, if any, which caused the current error.
-	//
-	// GqlCause is part of the GQL compliant errors preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlCause       *Neo4jError
 	parsed         bool
 	classification string // Legacy non-GQL classification
@@ -89,17 +74,19 @@ func (e *Neo4jError) Error() string {
 	return fmt.Sprintf("Neo4jError: %s (%s)", e.Code, e.Msg)
 }
 
-// TODO 6.0: remove in favour of GqlClassification
+// Deprecated: Use GqlClassification instead. This will be removed in a future release.
 func (e *Neo4jError) Classification() string {
 	e.parse()
 	return e.classification
 }
 
+// Deprecated: Use GqlClassification instead. This will be removed in a future release.
 func (e *Neo4jError) Category() string {
 	e.parse()
 	return e.category
 }
 
+// Deprecated: Use GqlStatusDescription for error information instead. This will be removed in a future release.
 func (e *Neo4jError) Title() string {
 	e.parse()
 	return e.title

--- a/neo4j/db/summary.go
+++ b/neo4j/db/summary.go
@@ -90,13 +90,12 @@ type ProfiledPlan struct {
 	Time              int64
 }
 
-// StreamSummary is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 type StreamSummary struct {
 	HadRecord bool
 	HadKey    bool
 }
 
+// Deprecated: Use GqlStatusObject instead. This will be removed in a future release.
 type Notification struct {
 	Code        string
 	Title       string
@@ -109,9 +108,6 @@ type Notification struct {
 // GqlStatusObject represents a GqlStatusObject generated when executing a statement.
 // A GqlStatusObject can be visualized in a client pinpointing problems or other information about the statement.
 // Contrary to failures or errors, GqlStatusObjects do not affect the execution of the statement.
-//
-// GqlStatusObject is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 type GqlStatusObject struct {
 	// Deprecated: for backward compatibility with Notification.Code only.
 	Code string

--- a/neo4j/driver.go
+++ b/neo4j/driver.go
@@ -441,8 +441,11 @@ func (d *driver) VerifyAuthentication(ctx context.Context, auth *AuthToken) (err
 		return &InvalidAuthenticationError{inner: tokenExpiredError}
 	}
 	if neo4jError, ok := err.(*Neo4jError); ok {
+		//lint:ignore SA1019 Code is supported for authentication error detection
 		if neo4jError.Code == "Neo.ClientError.Security.CredentialsExpired" ||
+			//lint:ignore SA1019 Code is supported for authentication error detection
 			neo4jError.Code == "Neo.ClientError.Security.Forbidden" ||
+			//lint:ignore SA1019 Code is supported for authentication error detection
 			neo4jError.Code == "Neo.ClientError.Security.Unauthorized" {
 			return &InvalidAuthenticationError{inner: neo4jError}
 		}

--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -183,6 +183,7 @@ func (b *bolt3) receiveSuccess(ctx context.Context) *success {
 	case *db.Neo4jError:
 		b.state = bolt3_failed
 		b.err = message
+		//lint:ignore SA1019 Classification is supported for error handling
 		if message.Classification() == "ClientError" {
 			// These could include potentially large cypher statement, only log to debug
 			b.log.Debugf(log.Bolt3, b.logId, "%s", message)
@@ -667,6 +668,7 @@ func (b *bolt3) receiveNext(ctx context.Context) (*db.Record, *db.Summary, error
 		b.currStream.err = b.err
 		b.currStream = nil
 		b.state = bolt3_failed
+		//lint:ignore SA1019 Classification is supported for error handling
 		if message.Classification() == "ClientError" {
 			// These could include potentially large cypher statement, only log to debug
 			b.log.Debugf(log.Bolt3, b.logId, "%s", message)
@@ -793,6 +795,7 @@ func (b *bolt3) GetRoutingTable(ctx context.Context,
 	if err != nil {
 		// Give a better error
 		dbError, isDbError := err.(*db.Neo4jError)
+		//lint:ignore SA1019 Code is supported for error handling
 		if isDbError && dbError.Code == "Neo.ClientError.Procedure.ProcedureNotFound" {
 			return nil, &db.FeatureNotSupportedError{Server: b.serverName, Feature: "routing", Reason: "requires cluster setup"}
 		}

--- a/neo4j/internal/bolt/bolt3_test.go
+++ b/neo4j/internal/bolt/bolt3_test.go
@@ -201,6 +201,7 @@ func TestBolt3(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -220,6 +221,7 @@ func TestBolt3(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -227,12 +229,14 @@ func TestBolt3(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported for backward compatibility
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,

--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -212,6 +212,7 @@ func (b *bolt4) setError(err error, fatal bool) {
 
 	// Do not log big cypher statements as errors
 	neo4jErr, casted := err.(*db.Neo4jError)
+	//lint:ignore SA1019 Classification is supported for error handling
 	if casted && neo4jErr.Classification() == "ClientError" {
 		b.log.Debugf(log.Bolt4, b.logId, "%s", err)
 	} else if wasDead {
@@ -1202,5 +1203,6 @@ func (b *bolt4) extractSummary(success *success, stream *stream) *db.Summary {
 
 func isFatalError(err *db.Neo4jError) bool {
 	// Treat expired auth as fatal so that pool is cleaned up of old connections
+	//lint:ignore SA1019 Code is supported for error handling
 	return err != nil && err.Code == "Status.Security.AuthorizationExpired"
 }

--- a/neo4j/internal/bolt/bolt4_test.go
+++ b/neo4j/internal/bolt/bolt4_test.go
@@ -389,6 +389,7 @@ func TestBolt4(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -408,6 +409,7 @@ func TestBolt4(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -415,12 +417,14 @@ func TestBolt4(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported for backward compatibility
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -223,6 +223,7 @@ func (b *bolt5) setError(err error, fatal bool) {
 
 	// Do not log big cypher statements as errors
 	neo4jErr, casted := err.(*db.Neo4jError)
+	//lint:ignore SA1019 Classification is supported for error handling
 	if casted && neo4jErr.Classification() == "ClientError" {
 		b.log.Debugf(log.Bolt5, b.logId, "%s", err)
 	} else if wasDead {

--- a/neo4j/internal/bolt/bolt5_test.go
+++ b/neo4j/internal/bolt/bolt5_test.go
@@ -563,8 +563,9 @@ func TestBolt5(outer *testing.T) {
 	outer.Run("with notifications", func(inner *testing.T) {
 		warningSev := "WARNING"
 		type testCase struct {
-			description     string
-			MinSev          notifications.NotificationMinimumSeverityLevel
+			description string
+			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 			DisCats         notifications.NotificationDisabledCategories
 			ExpectedMinSev  *string
 			ExpectDisCats   bool
@@ -585,15 +586,17 @@ func TestBolt5(outer *testing.T) {
 					Method:         s,
 				},
 				testCase{
-					description:     "disabled categories",
+					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:         notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{"UNSUPPORTED", "GENERIC"},
 					Method:          s,
 				},
 				testCase{
-					description:     "warning minimum severity and disabled categories",
-					MinSev:          notifications.WarningLevel,
+					description: "warning minimum severity and disabled categories",
+					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:         notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{"UNSUPPORTED", "GENERIC"},
@@ -601,7 +604,8 @@ func TestBolt5(outer *testing.T) {
 					Method:          s,
 				},
 				testCase{
-					description:     "disable no categories",
+					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported for backward compatibility
 					DisCats:         notifications.DisableNoCategories(),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{},
@@ -668,6 +672,7 @@ func TestBolt5(outer *testing.T) {
 		type testCase struct {
 			description string
 			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 			DisCats     notifications.NotificationDisabledCategories
 			ExpectError bool
 			Method      string
@@ -687,6 +692,7 @@ func TestBolt5(outer *testing.T) {
 				},
 				testCase{
 					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
@@ -694,12 +700,14 @@ func TestBolt5(outer *testing.T) {
 				testCase{
 					description: "warning minimum severity and disabled categories",
 					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:     notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectError: true,
 					Method:      s,
 				},
 				testCase{
 					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported for backward compatibility
 					DisCats:     notifications.DisableNoCategories(),
 					ExpectError: true,
 					Method:      s,

--- a/neo4j/internal/bolt/bolt6.go
+++ b/neo4j/internal/bolt/bolt6.go
@@ -218,6 +218,7 @@ func (b *bolt6) setError(err error, fatal bool) {
 
 	// Do not log big cypher statements as errors
 	neo4jErr, casted := err.(*db.Neo4jError)
+	//lint:ignore SA1019 Classification is supported for error handling
 	if casted && neo4jErr.Classification() == "ClientError" {
 		b.log.Debugf(log.Bolt6, b.logId, "%s", err)
 	} else if wasDead {

--- a/neo4j/internal/bolt/bolt6_test.go
+++ b/neo4j/internal/bolt/bolt6_test.go
@@ -469,8 +469,9 @@ func TestBolt6(outer *testing.T) {
 	outer.Run("with notifications", func(inner *testing.T) {
 		warningSev := "WARNING"
 		type testCase struct {
-			description     string
-			MinSev          notifications.NotificationMinimumSeverityLevel
+			description string
+			MinSev      notifications.NotificationMinimumSeverityLevel
+			//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 			DisCats         notifications.NotificationDisabledCategories
 			ExpectedMinSev  *string
 			ExpectDisCats   bool
@@ -491,15 +492,17 @@ func TestBolt6(outer *testing.T) {
 					Method:         s,
 				},
 				testCase{
-					description:     "disabled categories",
+					description: "disabled categories",
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:         notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{"UNSUPPORTED", "GENERIC"},
 					Method:          s,
 				},
 				testCase{
-					description:     "warning minimum severity and disabled categories",
-					MinSev:          notifications.WarningLevel,
+					description: "warning minimum severity and disabled categories",
+					MinSev:      notifications.WarningLevel,
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					DisCats:         notifications.DisableCategories(notifications.Unsupported, notifications.Generic),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{"UNSUPPORTED", "GENERIC"},
@@ -507,7 +510,8 @@ func TestBolt6(outer *testing.T) {
 					Method:          s,
 				},
 				testCase{
-					description:     "disable no categories",
+					description: "disable no categories",
+					//lint:ignore SA1019 DisableNoCategories is supported for backward compatibility
 					DisCats:         notifications.DisableNoCategories(),
 					ExpectDisCats:   true,
 					ExpectedDisCats: []any{},

--- a/neo4j/internal/bolt/bolt_logging.go
+++ b/neo4j/internal/bolt/bolt_logging.go
@@ -120,7 +120,9 @@ type loggableFailure db.Neo4jError
 
 func (f loggableFailure) String() string {
 	return serializeTrace(map[string]any{
-		"code":    f.Code,
+		//lint:ignore SA1019 Code is supported for logging
+		"code": f.Code,
+		//lint:ignore SA1019 Msg is supported for logging
 		"message": f.Msg,
 	})
 }

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -38,19 +38,20 @@ const containsUpdatesKey = "contains-updates"
 
 type ignored struct{}
 type success struct {
-	fields             []string
-	tfirst             int64
-	qid                int64
-	bookmark           string
-	connectionId       string
-	server             string
-	db                 string
-	hasMore            bool
-	tlast              int64
-	qtype              db.StatementType
-	counters           map[string]any
-	plan               *db.Plan
-	profile            *db.ProfiledPlan
+	fields       []string
+	tfirst       int64
+	qid          int64
+	bookmark     string
+	connectionId string
+	server       string
+	db           string
+	hasMore      bool
+	tlast        int64
+	qtype        db.StatementType
+	counters     map[string]any
+	plan         *db.Plan
+	profile      *db.ProfiledPlan
+	//lint:ignore SA1019 db.Notification is supported for backward compatibility
 	notifications      []db.Notification
 	statuses           []db.GqlStatusObject
 	routingTable       *idb.RoutingTable
@@ -204,8 +205,10 @@ func (h *hydrator) failure(n uint32, isNestedError bool) *db.Neo4jError {
 		case "neo4j_code":
 			fallthrough
 		case "code":
+			//lint:ignore SA1019 Code is supported for backward compatibility
 			dberr.Code = h.unp.String()
 		case "message":
+			//lint:ignore SA1019 Msg is supported for backward compatibility
 			dberr.Msg = h.unp.String()
 		case "diagnostic_record":
 			dberr.GqlDiagnosticRecord = h.amap()
@@ -891,9 +894,12 @@ func (h *hydrator) duration(n uint32) any {
 	return dbtype.Duration{Months: mon, Days: day, Seconds: sec, Nanos: int(nan)}
 }
 
+//lint:ignore SA1019 db.Notification is supported for backward compatibility
 func parseNotifications(notificationsx []any) []db.Notification {
+	//lint:ignore SA1019 db.Notification is supported for backward compatibility
 	var notifications []db.Notification
 	if notificationsx != nil {
+		//lint:ignore SA1019 db.Notification is supported for backward compatibility
 		notifications = make([]db.Notification, 0, len(notificationsx))
 		for _, x := range notificationsx {
 			notificationx, ok := x.(map[string]any)
@@ -1010,7 +1016,9 @@ func parseInputPosition(m map[string]any) *db.InputPosition {
 	return pos
 }
 
+//lint:ignore SA1019 db.Notification is supported for backward compatibility
 func parseNotification(m map[string]any) db.Notification {
+	//lint:ignore SA1019 db.Notification is supported for backward compatibility
 	n := db.Notification{}
 	n.Code, _ = m["code"].(string)
 	if description, ok := m["description"].(string); ok {

--- a/neo4j/internal/bolt/hydrator_test.go
+++ b/neo4j/internal/bolt/hydrator_test.go
@@ -313,6 +313,7 @@ func TestHydrator(outer *testing.T) {
 				packer.String("s2")
 			},
 			x: &success{tlast: -1, tfirst: -1, bookmark: "bm", db: "sys", qid: -1, num: 4,
+				//lint:ignore SA1019 db.Notification is supported for backward compatibility
 				notifications: []db.Notification{
 					{Code: "c1", Title: "t1", Description: "d1", Severity: "s1", Position: &db.InputPosition{Offset: 1, Line: 2, Column: 3}},
 					{Code: "c2", Title: "t2", Description: "d2", Severity: "s2"},

--- a/neo4j/internal/bolt/notifications.go
+++ b/neo4j/internal/bolt/notifications.go
@@ -28,7 +28,10 @@ func checkNotificationFiltering(
 	bolt idb.Connection,
 ) error {
 	if notificationConfig.MinSev == notifications.DefaultLevel &&
-		!notificationConfig.DisCats.DisablesNone() && len(notificationConfig.DisCats.DisabledCategories()) == 0 &&
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
+		!notificationConfig.DisCats.DisablesNone() &&
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
+		len(notificationConfig.DisCats.DisabledCategories()) == 0 &&
 		!notificationConfig.DisClas.DisablesNone() && len(notificationConfig.DisClas.DisabledClassifications()) == 0 {
 		return nil
 	}

--- a/neo4j/internal/connector/connector.go
+++ b/neo4j/internal/connector/connector.go
@@ -71,7 +71,8 @@ func (c *Connector) Connect(
 	}()
 
 	notificationConfig := db.NotificationConfig{
-		MinSev:  c.Config.NotificationsMinSeverity,
+		MinSev: c.Config.NotificationsMinSeverity,
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 		DisCats: c.Config.NotificationsDisabledCategories,
 		DisClas: c.Config.NotificationsDisabledClassifications,
 	}

--- a/neo4j/internal/db/connection.go
+++ b/neo4j/internal/db/connection.go
@@ -60,7 +60,8 @@ type TxConfig struct {
 }
 
 type NotificationConfig struct {
-	MinSev  notifications.NotificationMinimumSeverityLevel
+	MinSev notifications.NotificationMinimumSeverityLevel
+	//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 	DisCats notifications.NotificationDisabledCategories
 	DisClas notifications.NotificationDisabledClassifications
 }
@@ -74,10 +75,13 @@ func (n *NotificationConfig) ToMeta(meta map[string]any, version db.ProtocolVers
 	if version.Major >= 6 || (version.Major == 5 && version.Minor >= 5) {
 		disabledKey = "notifications_disabled_classifications"
 	}
+	//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 	if n.DisCats.DisablesNone() || n.DisClas.DisablesNone() {
 		meta[disabledKey] = make([]string, 0)
 	} else {
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 		if len(n.DisCats.DisabledCategories()) > 0 {
+			//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 			meta[disabledKey] = n.DisCats.DisabledCategories()
 		}
 		if len(n.DisClas.DisabledClassifications()) > 0 {

--- a/neo4j/internal/errorutil/bolt.go
+++ b/neo4j/internal/errorutil/bolt.go
@@ -92,15 +92,23 @@ func IsFatalDuringDiscovery(err error) bool {
 		return true
 	}
 	if err, ok := err.(*idb.Neo4jError); ok {
+		//lint:ignore SA1019 Code is supported for error handling
 		if err.Code == "Neo.ClientError.Database.DatabaseNotFound" ||
+			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Transaction.InvalidBookmark" ||
+			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Transaction.InvalidBookmarkMixture" ||
+			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Statement.TypeError" ||
+			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Statement.ArgumentError" ||
+			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Request.Invalid" {
 			return true
 		}
+		//lint:ignore SA1019 Code is supported for error handling
 		if strings.HasPrefix(err.Code, "Neo.ClientError.Security.") &&
+			//lint:ignore SA1019 Code is supported for error handling
 			err.Code != "Neo.ClientError.Security.AuthorizationExpired" {
 			return true
 		}

--- a/neo4j/internal/errorutil/errors.go
+++ b/neo4j/internal/errorutil/errors.go
@@ -81,7 +81,9 @@ func WrapError(err error) error {
 	case *ConnectionWriteTimeout:
 		return &ConnectivityError{Inner: err}
 	case *db.Neo4jError:
+		//lint:ignore SA1019 Code is supported for error handling
 		if e.Code == "Neo.ClientError.Security.TokenExpired" {
+			//lint:ignore SA1019 Code and Msg are supported for error handling
 			return &TokenExpiredError{Code: e.Code, Message: e.Msg, cause: e}
 		}
 	}
@@ -128,16 +130,21 @@ func (e *TokenExpiredError) Error() string {
 }
 
 func PolyfillGqlError(dberr *db.Neo4jError) {
+	//lint:ignore SA1019 Code is supported for error handling
 	if dberr.Code == "" {
+		//lint:ignore SA1019 Code is supported for error handling
 		dberr.Code = unknownNeo4jCode
 	}
+	//lint:ignore SA1019 Msg is supported for error handling
 	if dberr.Msg == "" {
+		//lint:ignore SA1019 Msg is supported for error handling
 		dberr.Msg = unknownMessage
 	}
 	if dberr.GqlStatus == "" {
 		dberr.GqlStatus = unknownGqlStatus
 	}
 	if dberr.GqlStatusDescription == "" {
+		//lint:ignore SA1019 Msg is supported for error handling
 		dberr.GqlStatusDescription = fmt.Sprintf("%s %s", unknownGqlStatusDescription, dberr.Msg)
 	}
 	// Ensure diagnostic record exists or fill missing keys

--- a/neo4j/internal/notifications/notifications.go
+++ b/neo4j/internal/notifications/notifications.go
@@ -65,13 +65,16 @@ func newUnknownInformationResultGqlStatusObject() *db.GqlStatusObject {
 
 // ToNotification returns a db.Notification that corresponds to the given db.GqlStatusObject.
 // It maps fields from the status to their respective notification fields.
+//
+//lint:ignore SA1019 db.Notification is supported for backward compatibility
 func ToNotification(gqlStatusObject db.GqlStatusObject) *db.Notification {
+	//lint:ignore SA1019 db.Notification is supported for backward compatibility
 	return &db.Notification{
-		//lint:ignore SA1019 Code is supported at least until 6.0
+		//lint:ignore SA1019 Code is supported for backward compatibility
 		Code: gqlStatusObject.Code,
-		//lint:ignore SA1019 Title is supported at least until 6.0
+		//lint:ignore SA1019 Title is supported for backward compatibility
 		Title: gqlStatusObject.Title,
-		//lint:ignore SA1019 Description is supported at least until 6.0
+		//lint:ignore SA1019 Description is supported for backward compatibility
 		Description: gqlStatusObject.Description,
 		Position:    gqlStatusObject.Position,
 		Severity:    gqlStatusObject.Severity,
@@ -81,6 +84,8 @@ func ToNotification(gqlStatusObject db.GqlStatusObject) *db.Notification {
 
 // ToGqlStatusObject returns a db.GqlStatusObject that corresponds to the given db.Notification.
 // It maps fields from the notification to their respective status fields.
+//
+//lint:ignore SA1019 db.Notification is supported for backward compatibility
 func ToGqlStatusObject(notification db.Notification) *db.GqlStatusObject {
 	var defaultStatus *db.GqlStatusObject
 	if notification.Severity == string(notifications.Warning) {

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -507,6 +507,7 @@ func (p *Pool) Return(ctx context.Context, c idb.Connection) {
 }
 
 func (p *Pool) OnNeo4jError(ctx context.Context, connection idb.Connection, error *db.Neo4jError) error {
+	//lint:ignore SA1019 Code is supported for error handling
 	if error.Code == "Neo.ClientError.Security.AuthorizationExpired" {
 		serverName := connection.ServerName()
 		p.serversMut.Lock()
@@ -516,6 +517,7 @@ func (p *Pool) OnNeo4jError(ctx context.Context, connection idb.Connection, erro
 			c.ResetAuth()
 		})
 	}
+	//lint:ignore SA1019 Code is supported for error handling
 	if error.Code == "Neo.TransientError.General.DatabaseUnavailable" {
 		p.deactivate(ctx, connection.ServerName())
 	}

--- a/neo4j/notifications/notifications.go
+++ b/neo4j/notifications/notifications.go
@@ -17,10 +17,9 @@
 
 package notifications
 
+// Deprecated: Use NotificationClassification instead. This will be removed in a future release.
 type NotificationCategory string
 
-// NotificationClassification is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 type NotificationClassification = NotificationCategory
 
 const (
@@ -58,13 +57,12 @@ const (
 	InformationLevel NotificationMinimumSeverityLevel = "INFORMATION"
 )
 
+// Deprecated: Use NotificationDisabledClassifications instead. This will be removed in a future release.
 type NotificationDisabledCategories struct {
 	categories []NotificationCategory
 	none       bool
 }
 
-// NotificationDisabledClassifications is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 type NotificationDisabledClassifications struct {
 	classifications []NotificationClassification
 	none            bool
@@ -72,56 +70,52 @@ type NotificationDisabledClassifications struct {
 
 // DisableCategories creates a NotificationDisabledCategories that disables the given categories.
 // Can be used for NotificationsDisabledCategories of config.Config and config.SessionConfig.
+//
+// Deprecated: Use DisableClassifications instead. This will be removed in a future release.
 func DisableCategories(value ...NotificationCategory) NotificationDisabledCategories {
 	return NotificationDisabledCategories{value, false}
 }
 
 // DisableClassifications creates a NotificationDisabledClassifications that disables the given classifications.
 // Can be used for NotificationsDisabledClassifications of config.Config and config.SessionConfig.
-//
-// DisableClassifications is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 func DisableClassifications(value ...NotificationClassification) NotificationDisabledClassifications {
 	return NotificationDisabledClassifications{value, false}
 }
 
 // DisableNoCategories creates a NotificationDisabledCategories that enables all categories.
 // Can be used for NotificationsDisabledCategories of config.Config and neo4j.SessionConfig.
+//
+// Deprecated: Use DisableNoClassifications instead. This will be removed in a future release.
 func DisableNoCategories() NotificationDisabledCategories {
 	return NotificationDisabledCategories{nil, true}
 }
 
 // DisableNoClassifications creates a NotificationDisabledClassifications that enables all classifications.
 // Can be used for NotificationsDisabledClassifications of config.Config and neo4j.SessionConfig.
-//
-// DisableNoClassifications is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 func DisableNoClassifications() NotificationDisabledClassifications {
 	return NotificationDisabledClassifications{nil, true}
 }
 
 // DisablesNone returns true if all categories are enabled.
+//
+// Deprecated: Use NotificationDisabledClassifications.DisablesNone instead. This will be removed in a future release.
 func (n *NotificationDisabledCategories) DisablesNone() bool {
 	return n.none
 }
 
 // DisablesNone returns true if all classifications are enabled.
-//
-// DisablesNone is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 func (n *NotificationDisabledClassifications) DisablesNone() bool {
 	return n.none
 }
 
 // DisabledCategories returns the categories that are disabled.
+//
+// Deprecated: Use NotificationDisabledClassifications.DisabledClassifications instead. This will be removed in a future release.
 func (n *NotificationDisabledCategories) DisabledCategories() []NotificationCategory {
 	return n.categories
 }
 
 // DisabledClassifications returns the classifications that are disabled.
-//
-// DisabledClassifications is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 func (n *NotificationDisabledClassifications) DisabledClassifications() []NotificationClassification {
 	return n.classifications
 }

--- a/neo4j/notifications_examples_test.go
+++ b/neo4j/notifications_examples_test.go
@@ -30,6 +30,7 @@ func ExampleConfig_disableNoCategories() {
 	ctx := context.Background()
 	driver, err := NewDriver(getUrl(), getAuth(), func(config *config.Config) {
 		// makes the server return all notification categories
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 		config.NotificationsDisabledCategories = notifications.DisableNoCategories()
 	})
 	handleError(err)
@@ -54,6 +55,7 @@ func ExampleSessionConfig_disableNoCategories() {
 	session := driver.NewSession(ctx, SessionConfig{
 		// makes the server return all notification categories
 		// this overrides the driver level configuration of the same name
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 		NotificationsDisabledCategories: notifications.DisableNoCategories(),
 	})
 
@@ -74,6 +76,7 @@ func ExampleConfig_disableSomeCategories() {
 	ctx := context.Background()
 	driver, err := NewDriver(getUrl(), getAuth(), func(config *config.Config) {
 		// makes the server return all notification categories but deprecations
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 		config.NotificationsDisabledCategories = notifications.DisableCategories(notifications.Deprecation)
 	})
 	handleError(err)
@@ -99,6 +102,7 @@ func ExampleSessionConfig_disableSomeCategories() {
 	session := driver.NewSession(ctx, SessionConfig{
 		// makes the server return all notification categories but deprecations
 		// this overrides the driver level configuration of the same name
+		//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 		NotificationsDisabledCategories: notifications.DisableCategories(notifications.Deprecation),
 	})
 

--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -74,6 +74,8 @@ type ResultSummary interface {
 	Profile() ProfiledPlan
 	// Notifications returns a slice of notifications produced while executing the statement.
 	// The list will be empty if no notifications produced while executing the statement.
+	//
+	// Deprecated: Use GqlStatusObjects() instead. This will be removed in a future release.
 	Notifications() []Notification
 	// GqlStatusObjects returns a slice of GqlStatusObjects that arose when executing the query.
 	//
@@ -86,8 +88,6 @@ type ResultSummary interface {
 	//   - A "warning" (``01xxx``) has precedence over a success.
 	//   - A "success" (``00xxx``) has precedence over anything informational (``03xxx``).
 	//
-	// GqlStatusObjects is part of the GQL compliant notifications preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
 	GqlStatusObjects() []GqlStatusObject
 	// ResultAvailableAfter returns the time it took for the server to make the result available for consumption.
 	// Since 5.0, this returns a negative duration if the server has not sent the corresponding statistic.
@@ -224,6 +224,8 @@ type ProfiledPlan interface {
 // Notification represents notifications generated when executing a statement.
 // A notification can be visualized in a client pinpointing problems or other information about the statement.
 // Contrary to failures or errors, notifications do not affect the execution of the statement.
+//
+// Deprecated: Use GqlStatusObject instead. This will be removed in a future release.
 type Notification interface {
 	// Code returns a notification code for the discovered issue of this notification.
 	Code() string
@@ -234,10 +236,6 @@ type Notification interface {
 	// Position returns the position in the statement where this notification points to.
 	// Not all notifications have a unique position to point to and in that case the position would be set to nil.
 	Position() InputPosition
-	// Severity returns the severity level of this notification.
-	//
-	// Deprecated: please use SeverityLevel (or RawSeverityLevel) instead. Severity will be removed in 6.0.
-	Severity() string
 	// RawSeverityLevel returns the unmapped severity level of this notification.
 	// This is useful when the driver cannot interpret the severity level returned by the server
 	// In that case, SeverityLevel returns UnknownSeverity while RawSeverityLevel returns the raw string
@@ -253,15 +251,13 @@ type Notification interface {
 	// Category returns the mapped category of this notification.
 	// If the category is not a known value, Category returns notifications.Unknown
 	// Call RawCategory to get access to the raw string value
+	//lint:ignore SA1019 NotificationCategory is supported for backward compatibility
 	Category() notifications.NotificationCategory
 }
 
 // GqlStatusObject represents a GqlStatusObject generated when executing a statement.
 // A GqlStatusObject can be visualized in a client pinpointing problems or other information about the statement.
 // Contrary to failures or errors, GqlStatusObjects do not affect the execution of the statement.
-//
-// GqlStatusObject is part of the GQL compliant notifications preview feature
-// (see README on what it means in terms of support and compatibility guarantees)
 type GqlStatusObject interface {
 	// GqlStatus returns the GQLSTATUS.
 	// The following GQLSTATUS codes denote codes that the driver will use for
@@ -625,6 +621,7 @@ func calculateGqlStatusWeight(gqlStatusObject GqlStatusObject) int {
 }
 
 type notification struct {
+	//lint:ignore SA1019 db.Notification is supported for backward compatibility
 	notification *db.Notification
 }
 
@@ -663,6 +660,7 @@ func (n *notification) RawCategory() string {
 	return n.notification.Category
 }
 
+//lint:ignore SA1019 NotificationCategory is supported for backward compatibility
 func (n *notification) Category() notifications.NotificationCategory {
 	switch n.notification.Category {
 	case "HINT":

--- a/neo4j/resultsummary_test.go
+++ b/neo4j/resultsummary_test.go
@@ -49,6 +49,7 @@ func TestNotifications(st *testing.T) {
 		Line:   2,
 		Column: 3,
 	}
+	//lint:ignore SA1019 db.Notification is supported for backward compatibility
 	notif1 := db.Notification{
 		Code:        "code1",
 		Title:       "title1",
@@ -56,6 +57,7 @@ func TestNotifications(st *testing.T) {
 		Severity:    "sev1",
 		Position:    &pos1,
 	}
+	//lint:ignore SA1019 db.Notification is supported for backward compatibility
 	notif2 := db.Notification{
 		Code:        "code2",
 		Title:       "title2",
@@ -66,6 +68,7 @@ func TestNotifications(st *testing.T) {
 
 	summary := resultSummary{
 		sum: &db.Summary{
+			//lint:ignore SA1019 db.Notification is supported for backward compatibility
 			Notifications: []db.Notification{notif1, notif2},
 		},
 	}

--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -166,12 +166,12 @@ type SessionConfig struct {
 	// By default, the driver's settings are used.
 	// Else, this option overrides the driver's settings.
 	// Disabling categories allows the server to skip analysis for those, which can speed up query execution.
+	//
+	// Deprecated: Use NotificationsDisabledClassifications instead. This will be removed in a future release.
+	//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
 	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
 	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.
-	//
-	// NotificationsDisabledClassifications is part of the GQL compliant notifications preview feature
-	// (see README on what it means in terms of support and compatibility guarantees)
 	NotificationsDisabledClassifications notifications.NotificationDisabledClassifications
 	// Auth is used to overwrite the authentication information for the session.
 	// This requires the server to support re-authentication on the protocol level.

--- a/neo4j/session.go
+++ b/neo4j/session.go
@@ -170,8 +170,10 @@ type SessionConfig struct {
 	// Deprecated: Use NotificationsDisabledClassifications instead. This will be removed in a future release.
 	//lint:ignore SA1019 NotificationDisabledCategories is supported for backward compatibility
 	NotificationsDisabledCategories notifications.NotificationDisabledCategories
-	// NotificationsDisabledClassifications is identical to NotificationsDisabledCategories.
-	// This alternative is provided for a consistent naming with neo4j.GqlStatusObject Classification.
+	// NotificationsDisabledClassifications defines the classifications of notifications the server should not send.
+	// By default, the driver's settings are used.
+	// Else, this option overrides the driver's settings.
+	// Disabling classifications allows the server to skip analysis for those, which can speed up query execution.
 	NotificationsDisabledClassifications notifications.NotificationDisabledClassifications
 	// Auth is used to overwrite the authentication information for the session.
 	// This requires the server to support re-authentication on the protocol level.

--- a/neo4j/test-integration/bookmark_test.go
+++ b/neo4j/test-integration/bookmark_test.go
@@ -390,9 +390,11 @@ func TestBookmark(outer *testing.T) {
 			neo4jErr := err.(*neo4j.Neo4jError)
 			if server.Version.GreaterThan(V4) {
 				// The error is not retryable since it is on the wrong format
+				//lint:ignore SA1019 Code is supported for error handling
 				assertEquals(t, neo4jErr.Code, "Neo.ClientError.Transaction.InvalidBookmark")
 			} else {
 				assertTrue(t, neo4jErr.IsRetriableTransient())
+				//lint:ignore SA1019 Msg is supported for error handling
 				assertStringContains(t, neo4jErr.Msg, "not up to the requested version")
 			}
 		})

--- a/neo4j/test-integration/session_test.go
+++ b/neo4j/test-integration/session_test.go
@@ -111,6 +111,7 @@ func TestSession(outer *testing.T) {
 			assertNil(t, result)
 			neo4jErr, isNeo4jErr := err.(*neo4j.Neo4jError)
 			assertTrue(t, isNeo4jErr)
+			//lint:ignore SA1019 Classification is supported for error handling
 			assertEquals(t, neo4jErr.Classification(), "ClientError")
 		})
 
@@ -124,6 +125,7 @@ func TestSession(outer *testing.T) {
 				//Expect(err).To(BeArithmeticError())
 				neo4jErr, isNeo4jErr := err.(*neo4j.Neo4jError)
 				assertTrue(t, isNeo4jErr)
+				//lint:ignore SA1019 Classification is supported for error handling
 				assertEquals(t, neo4jErr.Classification(), "ClientError")
 				return
 			}
@@ -131,6 +133,7 @@ func TestSession(outer *testing.T) {
 			summary, err = result.Consume(ctx)
 			neo4jErr, isNeo4jErr := err.(*neo4j.Neo4jError)
 			assertTrue(t, isNeo4jErr)
+			//lint:ignore SA1019 Classification is supported for error handling
 			assertEquals(t, neo4jErr.Classification(), "ClientError")
 			//Expect(err).To(BeArithmeticError())
 			assertNil(t, summary)
@@ -138,6 +141,7 @@ func TestSession(outer *testing.T) {
 			assertFalse(t, result.Next(ctx))
 			neo4jErr, isNeo4jErr = err.(*neo4j.Neo4jError)
 			assertTrue(t, isNeo4jErr)
+			//lint:ignore SA1019 Classification is supported for error handling
 			assertEquals(t, neo4jErr.Classification(), "ClientError")
 			//Expect(result.Err()).To(BeArithmeticError())
 		})
@@ -282,6 +286,7 @@ func TestSession(outer *testing.T) {
 			assertNil(t, result)
 			neo4jErr, isNeo4jErr := err.(*neo4j.Neo4jError)
 			assertTrue(t, isNeo4jErr)
+			//lint:ignore SA1019 Classification is supported for error handling
 			assertEquals(t, neo4jErr.Classification(), "ClientError")
 
 			result, err = session.Run(ctx, "RETURN 1", nil)
@@ -519,6 +524,8 @@ func TestSession(outer *testing.T) {
 			// Up to db to determine when error occurs
 			if err != nil {
 				dbErr := err.(*db.Neo4jError)
+				//lint:ignore SA1019 Msg is supported for error handling
+				//lint:ignore SA1019 Msg is supported for error handling
 				assertStringContains(t, dbErr.Msg, "terminated")
 				return
 			}
@@ -528,6 +535,7 @@ func TestSession(outer *testing.T) {
 			// has been terminated. For some reason this should not be considered transient
 			// by the IsTransientError.
 			dbErr := err.(*db.Neo4jError)
+			//lint:ignore SA1019 Msg is supported for error handling
 			assertStringContains(t, dbErr.Msg, "terminated")
 			//Expect(err).To(BeTransientError(nil, ContainSubstring("terminated")))
 		})
@@ -545,6 +553,7 @@ func TestSession(outer *testing.T) {
 			_, err := session3.ExecuteWrite(ctx, updateNodeWork(ctx, t, "WriteTransactionTxTimeOut", map[string]any{"id": 2}), neo4j.WithTxTimeout(1*time.Second))
 			assertNotNil(t, err)
 			dbErr := err.(*db.Neo4jError)
+			//lint:ignore SA1019 Msg is supported for error handling
 			assertStringContains(t, dbErr.Msg, "terminated")
 			//Expect(err).To(BeTransientError(nil, ContainSubstring("terminated")))
 		})

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -232,6 +232,7 @@ func (b *backend) writeError(err error) {
 		code = tokenErr.Code
 	}
 	if neo4j.IsNeo4jError(err) {
+		//lint:ignore SA1019 Code is supported for error handling
 		code = err.(*db.Neo4jError).Code
 	}
 	isDriverError := isHydrationError ||
@@ -246,6 +247,7 @@ func (b *backend) writeError(err error) {
 		var gqlDiagnosticRecord map[string]any
 		var cause *db.Neo4jError
 		if neo4jError, ok := err.(*neo4j.Neo4jError); ok {
+			//lint:ignore SA1019 Msg is supported for error handling
 			msg = neo4jError.Msg
 			gqlStatus = neo4jError.GqlStatus
 			gqlStatusDescription = neo4jError.GqlStatusDescription
@@ -297,6 +299,7 @@ func (b *backend) serializeGqlErrorCause(cause *db.Neo4jError) map[string]any {
 		return nil
 	}
 	return map[string]any{"name": "GqlError", "data": map[string]any{
+		//lint:ignore SA1019 Msg is supported for error handling
 		"msg":               cause.Msg,
 		"gqlStatus":         cause.GqlStatus,
 		"statusDescription": cause.GqlStatusDescription,
@@ -672,9 +675,11 @@ func (b *backend) handleRequest(req map[string]any) {
 			if data["notificationsDisabledCategories"] != nil {
 				notiDisCats := data["notificationsDisabledCategories"].([]any)
 				if len(notiDisCats) == 0 {
+					//lint:ignore SA1019 DisableNoCategories is supported for backward compatibility
 					c.NotificationsDisabledCategories = notifications.DisableNoCategories()
 				} else {
 					cats := convertSlice(notiDisCats, anyToNotificationCategory)
+					//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 					c.NotificationsDisabledCategories = notifications.DisableCategories(cats...)
 				}
 			}
@@ -886,9 +891,11 @@ func (b *backend) handleRequest(req map[string]any) {
 		if data["notificationsDisabledCategories"] != nil {
 			notiDisCats := data["notificationsDisabledCategories"].([]any)
 			if len(notiDisCats) == 0 {
+				//lint:ignore SA1019 DisableNoCategories is supported for backward compatibility
 				sessionConfig.NotificationsDisabledCategories = notifications.DisableNoCategories()
 			} else {
 				cats := convertSlice(notiDisCats, anyToNotificationCategory)
+				//lint:ignore SA1019 DisableCategories is supported for backward compatibility
 				sessionConfig.NotificationsDisabledCategories = notifications.DisableCategories(cats...)
 			}
 		}
@@ -1233,7 +1240,8 @@ func (b *backend) handleRequest(req map[string]any) {
 						"id":                 id,
 						"authTokenManagerId": managerId,
 						"auth":               serializeAuth(token),
-						"errorCode":          error.Code,
+						//lint:ignore SA1019 Code is supported for error handling
+						"errorCode": error.Code,
 					})
 				for b.process() {
 					if handled, ok := b.resolvedHandleSecurityException[id]; ok {
@@ -1569,6 +1577,7 @@ func serializeRecord(record *neo4j.Record) map[string]any {
 	return data
 }
 
+//lint:ignore SA1019 Notification is supported for backward compatibility
 func serializeNotifications(slice []neo4j.Notification, version db.ProtocolVersion) []map[string]any {
 	if slice == nil {
 		if version.Major == 5 && version.Minor >= 5 {
@@ -1664,6 +1673,7 @@ func serializeSummary(summary neo4j.ResultSummary) map[string]any {
 			"text":       summary.Query().Text(),
 			"parameters": serializeParameters(summary.Query().Parameters()),
 		},
+		//lint:ignore SA1019 Notifications is supported for backward compatibility
 		"notifications":    serializeNotifications(summary.Notifications(), protocolVersion),
 		"gqlStatusObjects": serializeGqlStatusObjects(summary.GqlStatusObjects()),
 		"plan":             serializePlan(summary.Plan()),
@@ -1893,7 +1903,9 @@ func convertInitialBookmarks(bookmarks []any) neo4j.Bookmarks {
 	return result
 }
 
+//lint:ignore SA1019 NotificationCategory is supported for backward compatibility
 func anyToNotificationCategory(v any) notifications.NotificationCategory {
+	//lint:ignore SA1019 NotificationCategory is supported for backward compatibility
 	return notifications.NotificationCategory(v.(string))
 }
 


### PR DESCRIPTION
Deprecations:

* Driver
`NotificationsDisabledCategories` field (use `NotificationsDisabledClassifications` instead)


* ~~Neo4jError~~ Reverted by #680 
~~`Code` field (use `GqlStatus` instead)~~
~~`Msg` field (use `GqlStatusDescription` instead)~~
~~`Title()` function (Use `GqlStatusDescription` instead)~~
~~`Category()` function (Use `GqlClassification` instead)~~
~~`Classification()` function (use `GqlClassification` instead)~~

* Summary
`Notification` struct (use `GqlStatusObject` instead)

* Notifications
`NotificationCategory` (use `NotificationClassification` instead)
`NotificationDisabledCategories` struct (use `NotificationDisabledClassifications` instead)
`DisableCategories` function (use `DisableClassifications` instead)
`DisableNoCategories` function (use `DisableNoClassifications` instead)
`NotificationDisabledCategories.DisablesNone` function (use `NotificationDisabledClassifications.DisablesNone` instead)
`DisabledCategories` function (use `DisabledClassifications` instead)

* ResultSummary
`Notifications()` function (use `GqlStatusObjects()` instead)
`Notification` interface (use `GqlStatusObject` instead)

* Session
`NotificationsDisabledCategories` field (use `NotificationsDisabledClassifications` instead)