### PR TITLE
Remove retries when a connection acquisition timeout error is triggered

### DIFF
--- a/neo4j/internal/retry/state.go
+++ b/neo4j/internal/retry/state.go
@@ -136,9 +136,9 @@ func IsRetryable(err error) bool {
 		if _, ok := connectivityErr.Inner.(*errorutil.CommitFailedDeadError); ok {
 			return false
 		}
-		return true
-	}
-	if _, ok := err.(*errorutil.PoolTimeout); ok {
+		if _, ok := connectivityErr.Inner.(*errorutil.PoolTimeout); ok {
+			return false
+		}
 		return true
 	}
 	var dbError *db.Neo4jError

--- a/neo4j/internal/retry/state_test.go
+++ b/neo4j/internal/retry/state_test.go
@@ -67,8 +67,8 @@ func TestState(outer *testing.T) {
 
 	testCases := map[string][]TStateInvocation{
 		"Retry connect": {
-			{conn: nil, err: &errorutil.PoolTimeout{}, expectContinued: true,
-				expectLastErrWasRetryable: true, expectLastErrType: &errorutil.PoolTimeout{}},
+			{conn: nil, err: &errorutil.PoolTimeout{}, expectContinued: false,
+				expectLastErrWasRetryable: false, expectLastErrType: &errorutil.PoolTimeout{}},
 		},
 		"Retry connect timeout": {
 			{conn: nil, err: dbTransientErr, expectContinued: true, freezeTime: true,


### PR DESCRIPTION
Unification task to align with other Neo4j drivers.