### PR TITLE
Remove deprecations from Neo4jError

### DIFF
--- a/neo4j/auth/auth.go
+++ b/neo4j/auth/auth.go
@@ -86,7 +86,6 @@ func (m *neo4jAuthTokenManager) GetAuthToken(ctx context.Context) (auth.Token, e
 }
 
 func (m *neo4jAuthTokenManager) HandleSecurityException(ctx context.Context, token auth.Token, securityException *db.Neo4jError) (bool, error) {
-	//lint:ignore SA1019 Code is supported for security exception handling
 	if !m.handledSecurityCodes.Contains(securityException.Code) {
 		return false, nil
 	}

--- a/neo4j/db/errors.go
+++ b/neo4j/db/errors.go
@@ -44,12 +44,8 @@ const (
 // Neo4jError is created when the database server fails to fulfill a request.
 type Neo4jError struct {
 	// Code is the Neo4j-specific error code, to be deprecated in favor of GqlStatus.
-	//
-	// Deprecated: Use GqlStatus instead. This will be removed in a future release.
 	Code string
 	// Msg is the specific error message describing the failure.
-	//
-	// Deprecated: Use GqlStatusDescription instead. This will be removed in a future release.
 	Msg string
 	// GqlStatus is the error code compliant with the GQL specification.
 	GqlStatus string
@@ -74,19 +70,16 @@ func (e *Neo4jError) Error() string {
 	return fmt.Sprintf("Neo4jError: %s (%s)", e.Code, e.Msg)
 }
 
-// Deprecated: Use GqlClassification instead. This will be removed in a future release.
 func (e *Neo4jError) Classification() string {
 	e.parse()
 	return e.classification
 }
 
-// Deprecated: Use GqlClassification instead. This will be removed in a future release.
 func (e *Neo4jError) Category() string {
 	e.parse()
 	return e.category
 }
 
-// Deprecated: Use GqlStatusDescription for error information instead. This will be removed in a future release.
 func (e *Neo4jError) Title() string {
 	e.parse()
 	return e.title

--- a/neo4j/driver.go
+++ b/neo4j/driver.go
@@ -441,11 +441,8 @@ func (d *driver) VerifyAuthentication(ctx context.Context, auth *AuthToken) (err
 		return &InvalidAuthenticationError{inner: tokenExpiredError}
 	}
 	if neo4jError, ok := err.(*Neo4jError); ok {
-		//lint:ignore SA1019 Code is supported for authentication error detection
 		if neo4jError.Code == "Neo.ClientError.Security.CredentialsExpired" ||
-			//lint:ignore SA1019 Code is supported for authentication error detection
 			neo4jError.Code == "Neo.ClientError.Security.Forbidden" ||
-			//lint:ignore SA1019 Code is supported for authentication error detection
 			neo4jError.Code == "Neo.ClientError.Security.Unauthorized" {
 			return &InvalidAuthenticationError{inner: neo4jError}
 		}

--- a/neo4j/internal/bolt/bolt3.go
+++ b/neo4j/internal/bolt/bolt3.go
@@ -183,7 +183,6 @@ func (b *bolt3) receiveSuccess(ctx context.Context) *success {
 	case *db.Neo4jError:
 		b.state = bolt3_failed
 		b.err = message
-		//lint:ignore SA1019 Classification is supported for error handling
 		if message.Classification() == "ClientError" {
 			// These could include potentially large cypher statement, only log to debug
 			b.log.Debugf(log.Bolt3, b.logId, "%s", message)
@@ -668,7 +667,6 @@ func (b *bolt3) receiveNext(ctx context.Context) (*db.Record, *db.Summary, error
 		b.currStream.err = b.err
 		b.currStream = nil
 		b.state = bolt3_failed
-		//lint:ignore SA1019 Classification is supported for error handling
 		if message.Classification() == "ClientError" {
 			// These could include potentially large cypher statement, only log to debug
 			b.log.Debugf(log.Bolt3, b.logId, "%s", message)
@@ -795,7 +793,6 @@ func (b *bolt3) GetRoutingTable(ctx context.Context,
 	if err != nil {
 		// Give a better error
 		dbError, isDbError := err.(*db.Neo4jError)
-		//lint:ignore SA1019 Code is supported for error handling
 		if isDbError && dbError.Code == "Neo.ClientError.Procedure.ProcedureNotFound" {
 			return nil, &db.FeatureNotSupportedError{Server: b.serverName, Feature: "routing", Reason: "requires cluster setup"}
 		}

--- a/neo4j/internal/bolt/bolt4.go
+++ b/neo4j/internal/bolt/bolt4.go
@@ -212,7 +212,6 @@ func (b *bolt4) setError(err error, fatal bool) {
 
 	// Do not log big cypher statements as errors
 	neo4jErr, casted := err.(*db.Neo4jError)
-	//lint:ignore SA1019 Classification is supported for error handling
 	if casted && neo4jErr.Classification() == "ClientError" {
 		b.log.Debugf(log.Bolt4, b.logId, "%s", err)
 	} else if wasDead {
@@ -1203,6 +1202,5 @@ func (b *bolt4) extractSummary(success *success, stream *stream) *db.Summary {
 
 func isFatalError(err *db.Neo4jError) bool {
 	// Treat expired auth as fatal so that pool is cleaned up of old connections
-	//lint:ignore SA1019 Code is supported for error handling
 	return err != nil && err.Code == "Status.Security.AuthorizationExpired"
 }

--- a/neo4j/internal/bolt/bolt5.go
+++ b/neo4j/internal/bolt/bolt5.go
@@ -223,7 +223,6 @@ func (b *bolt5) setError(err error, fatal bool) {
 
 	// Do not log big cypher statements as errors
 	neo4jErr, casted := err.(*db.Neo4jError)
-	//lint:ignore SA1019 Classification is supported for error handling
 	if casted && neo4jErr.Classification() == "ClientError" {
 		b.log.Debugf(log.Bolt5, b.logId, "%s", err)
 	} else if wasDead {

--- a/neo4j/internal/bolt/bolt6.go
+++ b/neo4j/internal/bolt/bolt6.go
@@ -218,7 +218,6 @@ func (b *bolt6) setError(err error, fatal bool) {
 
 	// Do not log big cypher statements as errors
 	neo4jErr, casted := err.(*db.Neo4jError)
-	//lint:ignore SA1019 Classification is supported for error handling
 	if casted && neo4jErr.Classification() == "ClientError" {
 		b.log.Debugf(log.Bolt6, b.logId, "%s", err)
 	} else if wasDead {

--- a/neo4j/internal/bolt/bolt_logging.go
+++ b/neo4j/internal/bolt/bolt_logging.go
@@ -120,9 +120,7 @@ type loggableFailure db.Neo4jError
 
 func (f loggableFailure) String() string {
 	return serializeTrace(map[string]any{
-		//lint:ignore SA1019 Code is supported for logging
-		"code": f.Code,
-		//lint:ignore SA1019 Msg is supported for logging
+		"code":    f.Code,
 		"message": f.Msg,
 	})
 }

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -205,10 +205,8 @@ func (h *hydrator) failure(n uint32, isNestedError bool) *db.Neo4jError {
 		case "neo4j_code":
 			fallthrough
 		case "code":
-			//lint:ignore SA1019 Code is supported for backward compatibility
 			dberr.Code = h.unp.String()
 		case "message":
-			//lint:ignore SA1019 Msg is supported for backward compatibility
 			dberr.Msg = h.unp.String()
 		case "diagnostic_record":
 			dberr.GqlDiagnosticRecord = h.amap()

--- a/neo4j/internal/errorutil/bolt.go
+++ b/neo4j/internal/errorutil/bolt.go
@@ -92,23 +92,15 @@ func IsFatalDuringDiscovery(err error) bool {
 		return true
 	}
 	if err, ok := err.(*idb.Neo4jError); ok {
-		//lint:ignore SA1019 Code is supported for error handling
 		if err.Code == "Neo.ClientError.Database.DatabaseNotFound" ||
-			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Transaction.InvalidBookmark" ||
-			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Transaction.InvalidBookmarkMixture" ||
-			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Statement.TypeError" ||
-			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Statement.ArgumentError" ||
-			//lint:ignore SA1019 Code is supported for error handling
 			err.Code == "Neo.ClientError.Request.Invalid" {
 			return true
 		}
-		//lint:ignore SA1019 Code is supported for error handling
 		if strings.HasPrefix(err.Code, "Neo.ClientError.Security.") &&
-			//lint:ignore SA1019 Code is supported for error handling
 			err.Code != "Neo.ClientError.Security.AuthorizationExpired" {
 			return true
 		}

--- a/neo4j/internal/errorutil/errors.go
+++ b/neo4j/internal/errorutil/errors.go
@@ -81,9 +81,7 @@ func WrapError(err error) error {
 	case *ConnectionWriteTimeout:
 		return &ConnectivityError{Inner: err}
 	case *db.Neo4jError:
-		//lint:ignore SA1019 Code is supported for error handling
 		if e.Code == "Neo.ClientError.Security.TokenExpired" {
-			//lint:ignore SA1019 Code and Msg are supported for error handling
 			return &TokenExpiredError{Code: e.Code, Message: e.Msg, cause: e}
 		}
 	}
@@ -130,21 +128,16 @@ func (e *TokenExpiredError) Error() string {
 }
 
 func PolyfillGqlError(dberr *db.Neo4jError) {
-	//lint:ignore SA1019 Code is supported for error handling
 	if dberr.Code == "" {
-		//lint:ignore SA1019 Code is supported for error handling
 		dberr.Code = unknownNeo4jCode
 	}
-	//lint:ignore SA1019 Msg is supported for error handling
 	if dberr.Msg == "" {
-		//lint:ignore SA1019 Msg is supported for error handling
 		dberr.Msg = unknownMessage
 	}
 	if dberr.GqlStatus == "" {
 		dberr.GqlStatus = unknownGqlStatus
 	}
 	if dberr.GqlStatusDescription == "" {
-		//lint:ignore SA1019 Msg is supported for error handling
 		dberr.GqlStatusDescription = fmt.Sprintf("%s %s", unknownGqlStatusDescription, dberr.Msg)
 	}
 	// Ensure diagnostic record exists or fill missing keys

--- a/neo4j/internal/pool/pool.go
+++ b/neo4j/internal/pool/pool.go
@@ -507,7 +507,6 @@ func (p *Pool) Return(ctx context.Context, c idb.Connection) {
 }
 
 func (p *Pool) OnNeo4jError(ctx context.Context, connection idb.Connection, error *db.Neo4jError) error {
-	//lint:ignore SA1019 Code is supported for error handling
 	if error.Code == "Neo.ClientError.Security.AuthorizationExpired" {
 		serverName := connection.ServerName()
 		p.serversMut.Lock()
@@ -517,7 +516,6 @@ func (p *Pool) OnNeo4jError(ctx context.Context, connection idb.Connection, erro
 			c.ResetAuth()
 		})
 	}
-	//lint:ignore SA1019 Code is supported for error handling
 	if error.Code == "Neo.TransientError.General.DatabaseUnavailable" {
 		p.deactivate(ctx, connection.ServerName())
 	}

--- a/neo4j/test-integration/bookmark_test.go
+++ b/neo4j/test-integration/bookmark_test.go
@@ -390,11 +390,9 @@ func TestBookmark(outer *testing.T) {
 			neo4jErr := err.(*neo4j.Neo4jError)
 			if server.Version.GreaterThan(V4) {
 				// The error is not retryable since it is on the wrong format
-				//lint:ignore SA1019 Code is supported for error handling
 				assertEquals(t, neo4jErr.Code, "Neo.ClientError.Transaction.InvalidBookmark")
 			} else {
 				assertTrue(t, neo4jErr.IsRetriableTransient())
-				//lint:ignore SA1019 Msg is supported for error handling
 				assertStringContains(t, neo4jErr.Msg, "not up to the requested version")
 			}
 		})

--- a/neo4j/test-integration/session_test.go
+++ b/neo4j/test-integration/session_test.go
@@ -111,7 +111,6 @@ func TestSession(outer *testing.T) {
 			assertNil(t, result)
 			neo4jErr, isNeo4jErr := err.(*neo4j.Neo4jError)
 			assertTrue(t, isNeo4jErr)
-			//lint:ignore SA1019 Classification is supported for error handling
 			assertEquals(t, neo4jErr.Classification(), "ClientError")
 		})
 
@@ -125,7 +124,6 @@ func TestSession(outer *testing.T) {
 				//Expect(err).To(BeArithmeticError())
 				neo4jErr, isNeo4jErr := err.(*neo4j.Neo4jError)
 				assertTrue(t, isNeo4jErr)
-				//lint:ignore SA1019 Classification is supported for error handling
 				assertEquals(t, neo4jErr.Classification(), "ClientError")
 				return
 			}
@@ -133,7 +131,6 @@ func TestSession(outer *testing.T) {
 			summary, err = result.Consume(ctx)
 			neo4jErr, isNeo4jErr := err.(*neo4j.Neo4jError)
 			assertTrue(t, isNeo4jErr)
-			//lint:ignore SA1019 Classification is supported for error handling
 			assertEquals(t, neo4jErr.Classification(), "ClientError")
 			//Expect(err).To(BeArithmeticError())
 			assertNil(t, summary)
@@ -141,7 +138,6 @@ func TestSession(outer *testing.T) {
 			assertFalse(t, result.Next(ctx))
 			neo4jErr, isNeo4jErr = err.(*neo4j.Neo4jError)
 			assertTrue(t, isNeo4jErr)
-			//lint:ignore SA1019 Classification is supported for error handling
 			assertEquals(t, neo4jErr.Classification(), "ClientError")
 			//Expect(result.Err()).To(BeArithmeticError())
 		})
@@ -286,7 +282,6 @@ func TestSession(outer *testing.T) {
 			assertNil(t, result)
 			neo4jErr, isNeo4jErr := err.(*neo4j.Neo4jError)
 			assertTrue(t, isNeo4jErr)
-			//lint:ignore SA1019 Classification is supported for error handling
 			assertEquals(t, neo4jErr.Classification(), "ClientError")
 
 			result, err = session.Run(ctx, "RETURN 1", nil)
@@ -524,8 +519,6 @@ func TestSession(outer *testing.T) {
 			// Up to db to determine when error occurs
 			if err != nil {
 				dbErr := err.(*db.Neo4jError)
-				//lint:ignore SA1019 Msg is supported for error handling
-				//lint:ignore SA1019 Msg is supported for error handling
 				assertStringContains(t, dbErr.Msg, "terminated")
 				return
 			}
@@ -535,7 +528,6 @@ func TestSession(outer *testing.T) {
 			// has been terminated. For some reason this should not be considered transient
 			// by the IsTransientError.
 			dbErr := err.(*db.Neo4jError)
-			//lint:ignore SA1019 Msg is supported for error handling
 			assertStringContains(t, dbErr.Msg, "terminated")
 			//Expect(err).To(BeTransientError(nil, ContainSubstring("terminated")))
 		})
@@ -553,7 +545,6 @@ func TestSession(outer *testing.T) {
 			_, err := session3.ExecuteWrite(ctx, updateNodeWork(ctx, t, "WriteTransactionTxTimeOut", map[string]any{"id": 2}), neo4j.WithTxTimeout(1*time.Second))
 			assertNotNil(t, err)
 			dbErr := err.(*db.Neo4jError)
-			//lint:ignore SA1019 Msg is supported for error handling
 			assertStringContains(t, dbErr.Msg, "terminated")
 			//Expect(err).To(BeTransientError(nil, ContainSubstring("terminated")))
 		})

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -232,7 +232,6 @@ func (b *backend) writeError(err error) {
 		code = tokenErr.Code
 	}
 	if neo4j.IsNeo4jError(err) {
-		//lint:ignore SA1019 Code is supported for error handling
 		code = err.(*db.Neo4jError).Code
 	}
 	isDriverError := isHydrationError ||
@@ -247,7 +246,6 @@ func (b *backend) writeError(err error) {
 		var gqlDiagnosticRecord map[string]any
 		var cause *db.Neo4jError
 		if neo4jError, ok := err.(*neo4j.Neo4jError); ok {
-			//lint:ignore SA1019 Msg is supported for error handling
 			msg = neo4jError.Msg
 			gqlStatus = neo4jError.GqlStatus
 			gqlStatusDescription = neo4jError.GqlStatusDescription
@@ -299,7 +297,6 @@ func (b *backend) serializeGqlErrorCause(cause *db.Neo4jError) map[string]any {
 		return nil
 	}
 	return map[string]any{"name": "GqlError", "data": map[string]any{
-		//lint:ignore SA1019 Msg is supported for error handling
 		"msg":               cause.Msg,
 		"gqlStatus":         cause.GqlStatus,
 		"statusDescription": cause.GqlStatusDescription,
@@ -1240,8 +1237,7 @@ func (b *backend) handleRequest(req map[string]any) {
 						"id":                 id,
 						"authTokenManagerId": managerId,
 						"auth":               serializeAuth(token),
-						//lint:ignore SA1019 Code is supported for error handling
-						"errorCode": error.Code,
+						"errorCode":          error.Code,
 					})
 				for b.process() {
 					if handled, ok := b.resolvedHandleSecurityException[id]; ok {


### PR DESCRIPTION
More work is required internally before these can be deprecated with appropriate replacements.