### PR TITLE
Deprecate StatementType in favor of QueryType for Driver unification

### DIFF
--- a/neo4j/db/summary.go
+++ b/neo4j/db/summary.go
@@ -18,14 +18,37 @@
 package db
 
 // Definitions of these should correspond to public API
+//
+// Deprecated: Use QueryType instead. This will be removed in a future release.
 type StatementType int
 
 const (
-	StatementTypeUnknown     StatementType = 0
-	StatementTypeRead        StatementType = 1
-	StatementTypeReadWrite   StatementType = 2
-	StatementTypeWrite       StatementType = 3
+	// Deprecated: Use QueryTypeUnknown instead. This will be removed in a future release.
+	StatementTypeUnknown StatementType = 0
+	// Deprecated: Use QueryTypeRead instead. This will be removed in a future release.
+	StatementTypeRead StatementType = 1
+	// Deprecated: Use QueryTypeReadWrite instead. This will be removed in a future release.
+	StatementTypeReadWrite StatementType = 2
+	// Deprecated: Use QueryTypeWrite instead. This will be removed in a future release.
+	StatementTypeWrite StatementType = 3
+	// Deprecated: Use QueryTypeSchemaWrite instead. This will be removed in a future release.
 	StatementTypeSchemaWrite StatementType = 4
+)
+
+// QueryType defines the type of the query
+type QueryType = StatementType
+
+const (
+	// QueryTypeUnknown identifies an unknown query type
+	QueryTypeUnknown QueryType = 0
+	// QueryTypeRead identifies a read query
+	QueryTypeRead QueryType = 1
+	// QueryTypeReadWrite identifies a read-write query
+	QueryTypeReadWrite QueryType = 2
+	// QueryTypeWrite identifies a write query
+	QueryTypeWrite QueryType = 3
+	// QueryTypeSchemaWrite identifies a schema-write query
+	QueryTypeSchemaWrite QueryType = 4
 )
 
 // Counter key names

--- a/neo4j/driver_test.go
+++ b/neo4j/driver_test.go
@@ -951,6 +951,10 @@ func (sum *fakeSummary) StatementType() StatementType {
 	panic("implement me")
 }
 
+func (sum *fakeSummary) QueryType() QueryType {
+	panic("implement me")
+}
+
 func (sum *fakeSummary) Counters() Counters {
 	panic("implement me")
 }

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -47,7 +47,7 @@ type success struct {
 	db           string
 	hasMore      bool
 	tlast        int64
-	qtype        db.StatementType
+	qtype        db.QueryType
 	counters     map[string]any
 	plan         *db.Plan
 	profile      *db.ProfiledPlan
@@ -263,21 +263,21 @@ func (h *hydrator) success(n uint32) *success {
 		case "t_last":
 			succ.tlast = h.unp.Int()
 		case "type":
-			statementType := h.unp.String()
-			switch statementType {
+			queryType := h.unp.String()
+			switch queryType {
 			case "r":
-				succ.qtype = db.StatementTypeRead
+				succ.qtype = db.QueryTypeRead
 			case "w":
-				succ.qtype = db.StatementTypeWrite
+				succ.qtype = db.QueryTypeWrite
 			case "rw":
-				succ.qtype = db.StatementTypeReadWrite
+				succ.qtype = db.QueryTypeReadWrite
 			case "s":
-				succ.qtype = db.StatementTypeSchemaWrite
+				succ.qtype = db.QueryTypeSchemaWrite
 			default:
 				h.setErr(&db.ProtocolError{
 					MessageType: "success",
 					Field:       "type",
-					Err:         fmt.Sprintf("unrecognized success statement type %s", statementType),
+					Err:         fmt.Sprintf("unrecognized success query type %s", queryType),
 				})
 			}
 		case "db":

--- a/neo4j/internal/bolt/hydrator_test.go
+++ b/neo4j/internal/bolt/hydrator_test.go
@@ -177,7 +177,7 @@ func TestHydrator(outer *testing.T) {
 				packer.String("db")
 				packer.String("s")
 			},
-			x: &success{tlast: 124, tfirst: -1, bookmark: "b", qtype: db.StatementTypeWrite, db: "s", qid: -1, num: 4},
+			x: &success{tlast: 124, tfirst: -1, bookmark: "b", qtype: db.QueryTypeWrite, db: "s", qid: -1, num: 4},
 		},
 		{
 			name: "Success summary with plan",
@@ -399,7 +399,7 @@ func TestHydrator(outer *testing.T) {
 				packer.String("has_more")
 				packer.Bool(false)
 			},
-			x: &success{tlast: 7, tfirst: -1, bookmark: "b1", qtype: db.StatementTypeRead, qid: -1, num: 4},
+			x: &success{tlast: 7, tfirst: -1, bookmark: "b1", qtype: db.QueryTypeRead, qid: -1, num: 4},
 		},
 		{
 			name: "Success route response",

--- a/neo4j/resultsummary.go
+++ b/neo4j/resultsummary.go
@@ -29,19 +29,47 @@ import (
 )
 
 // StatementType defines the type of the statement
+//
+// Deprecated: Use QueryType instead. This will be removed in a future release.
 type StatementType int
 
 const (
 	// StatementTypeUnknown identifies an unknown statement type
+	//
+	// Deprecated: Use QueryTypeUnknown instead. This will be removed in a future release.
 	StatementTypeUnknown StatementType = 0
 	// StatementTypeReadOnly identifies a read-only statement
+	//
+	// Deprecated: Use QueryTypeReadOnly instead. This will be removed in a future release.
 	StatementTypeReadOnly StatementType = 1
 	// StatementTypeReadWrite identifies a read-write statement
+	//
+	// Deprecated: Use QueryTypeReadWrite instead. This will be removed in a future release.
 	StatementTypeReadWrite StatementType = 2
 	// StatementTypeWriteOnly identifies a write-only statement
+	//
+	// Deprecated: Use QueryTypeWriteOnly instead. This will be removed in a future release.
 	StatementTypeWriteOnly StatementType = 3
 	// StatementTypeSchemaWrite identifies a schema-write statement
+	//
+	// Deprecated: Use QueryTypeSchemaWrite instead. This will be removed in a future release.
 	StatementTypeSchemaWrite StatementType = 4
+)
+
+// QueryType defines the type of the query
+type QueryType = StatementType
+
+const (
+	// QueryTypeUnknown identifies an unknown query type
+	QueryTypeUnknown QueryType = 0
+	// QueryTypeReadOnly identifies a read-only query
+	QueryTypeReadOnly QueryType = 1
+	// QueryTypeReadWrite identifies a read-write query
+	QueryTypeReadWrite QueryType = 2
+	// QueryTypeWriteOnly identifies a write-only query
+	QueryTypeWriteOnly QueryType = 3
+	// QueryTypeSchemaWrite identifies a schema-write query
+	QueryTypeSchemaWrite QueryType = 4
 )
 
 func (st StatementType) String() string {
@@ -65,7 +93,11 @@ type ResultSummary interface {
 	// Query returns the query that has been executed.
 	Query() Query
 	// StatementType returns type of statement that has been executed.
+	//
+	// Deprecated: Use QueryType() instead. This will be removed in a future release.
 	StatementType() StatementType
+	// QueryType returns type of query that has been executed.
+	QueryType() QueryType
 	// Counters returns statistics counts for the statement.
 	Counters() Counters
 	// Plan returns statement plan for the executed statement if available, otherwise null.
@@ -352,6 +384,10 @@ func (s *resultSummary) Query() Query {
 
 func (s *resultSummary) StatementType() StatementType {
 	return StatementType(s.sum.StmntType)
+}
+
+func (s *resultSummary) QueryType() QueryType {
+	return QueryType(s.sum.StmntType)
 }
 
 func (s *resultSummary) Text() string {

--- a/neo4j/test-integration/session_test.go
+++ b/neo4j/test-integration/session_test.go
@@ -101,7 +101,7 @@ func TestSession(outer *testing.T) {
 
 			assertFalse(t, result.Next(ctx))
 
-			assertEquals(t, summary.StatementType(), neo4j.StatementTypeReadOnly)
+			assertEquals(t, summary.QueryType(), neo4j.QueryTypeReadOnly)
 		})
 
 		inner.Run("when an invalid query is executed, it should return error", func(t *testing.T) {

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -1685,8 +1685,8 @@ func serializeSummary(summary neo4j.ResultSummary) map[string]any {
 	} else {
 		response["resultConsumedAfter"] = nil
 	}
-	if summary.StatementType() != neo4j.StatementTypeUnknown {
-		response["queryType"] = summary.StatementType().String()
+	if summary.QueryType() != neo4j.QueryTypeUnknown {
+		response["queryType"] = summary.QueryType().String()
 	} else {
 		response["queryType"] = nil
 	}


### PR DESCRIPTION
Closes DRIVERS-55

- Added `QueryType` as alias for `StatementType` in both `neo4j` and `db` packages.
- Added deprecation notices to `StatementType` and all related constants.
- Updated `ResultSummary` interface to include `QueryType()`.
- Updated internals to use `QueryType` constants.