### PR TITLE
Update README and MIGRATION_GUIDE for v6

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -72,6 +72,7 @@ These types have been aliased:
   `neo4j/dbtype.Point2D` and `neo4j/dbtype.Point3D` (see more details below)
 * All temporal types are aliased from `neo4j` to their equivalent
   in `neo4j/dbtype`
+* `Vector` is aliased from `neo4j` to `neo4j/dbtype.Vector[T]`
 
 ## Spatial types
 
@@ -168,6 +169,16 @@ The four different errors are:
 * `TransactionExecutionLimit`, indicates that a retryable transaction failed due
   to a timeout or other resource limit reached. The struct contains a list 
   of errors where each error represents a failed transaction attempt.
+
+### GQL-compliant errors
+
+Starting with 5.26.0, `Neo4jError` includes GQL-compliant error information for better error handling:
+
+* `GqlStatus` - GQL-compliant error code
+* `GqlStatusDescription` - Standard description for the GQL status code  
+* `GqlClassification` - High-level error classification (CLIENT_ERROR, DATABASE_ERROR, TRANSIENT_ERROR, UNKNOWN)
+* `GqlDiagnosticRecord` - Additional diagnostic information
+* `GqlCause` - Underlying error that caused the current error
 
 ## Error handling
 
@@ -399,3 +410,48 @@ creation of the following happened:
 Explicit transactions can now be committed once, or rolled back once.
 Any further call to commit / roll back will cause an `UsageError` to be 
 returned.
+
+## 6.0 breaking changes
+
+### 5.x deprecation removals
+
+Every deprecated element in 5.x has been removed from 6.0. This includes:
+
+#### Structs
+* `neo4j.Config` (replaced by `config.Config` since 5.8.0)
+
+#### Types  
+* `neo4j.ServerAddressResolver` (replaced by `config.ServerAddressResolver` since 5.8.0)
+* `neo4j.LogLevel` (replaced by `log.Level` since 5.17.0)
+* `neo4j.ERROR`, `neo4j.WARNING`, `neo4j.INFO`, `neo4j.DEBUG` (replaced by `log.ERROR`, `log.WARNING`, `log.INFO`, `log.DEBUG` since 5.17.0)
+* `log.Console`, `log.Void` (replaced by `log.ToConsole`, `log.ToVoid` since 5.17.0)
+* All notification types (replaced by `notifications.*` equivalents since 5.23.0)
+
+#### Functions / Methods
+* `neo4j.NewDriver` (replaced by `neo4j.NewDriverWithContext` since 5.0.0)
+* `neo4j.Single`, `neo4j.SingleT` (replaced by `neo4j.SingleWithContext`, `neo4j.SingleTWithContext` since 5.0.0)
+* `neo4j.Collect`, `neo4j.CollectT` (replaced by `neo4j.CollectWithContext`, `neo4j.CollectTWithContext` since 5.0.0)
+* `neo4j.ConsoleLogger`, `neo4j.ConsoleBoltLogger` (replaced by `log.ToConsole`, `log.BoltToConsole` since 5.17.0)
+
+#### Interfaces
+* `neo4j.Driver` (replaced by `neo4j.DriverWithContext` since 5.0.0)
+* `neo4j.Session` (replaced by `neo4j.SessionWithContext` since 5.0.0)
+* `neo4j.Transaction` (replaced by `neo4j.ExplicitTransaction` since 5.0.0)
+* `neo4j.TransactionWork` (replaced by `neo4j.ManagedTransactionWork` since 5.0.0)
+* `neo4j.Result` (replaced by `neo4j.ResultWithContext` since 5.0.0)
+* `neo4j.ServerAddress` (replaced by `config.ServerAddress` since 5.8.0)
+
+#### Struct fields
+* `neo4j.Config#RootCAs` (replaced by `neo4j.Config#TlsConfig` since 5.0.0)
+
+### Context-aware API evolution
+
+Starting with v5, the driver introduced context-aware APIs with `*WithContext` suffixes (e.g., `neo4j.NewDriverWithContext`, `neo4j.DriverWithContext`). In v6, the original API names now include context support by default, making the `*WithContext` variants redundant.
+
+The `*WithContext` APIs are now deprecated in v6 and will be removed in v7.0. This provides a clean, context-aware API without the `WithContext` suffix.
+
+### Go version requirement
+
+The minimum Go version requirement has been updated to Go 1.24 for v6.0.
+
+For a complete list of all breaking changes, see the [planned breaking changes discussion](https://github.com/neo4j/neo4j-go-driver/discussions/456).

--- a/README.md
+++ b/README.md
@@ -151,9 +151,6 @@ func (i *Item) String() string {
 
 ## Server/Driver compatibility
 
-Starting with 5.0, the Neo4j Drivers will be moving to a monthly release cadence.
-A minor version will be released on the last Friday of each month so as to maintain versioning consistency with the core product (Neo4j DBMS) which has also moved to a monthly cadence.
-
 As a policy, patch versions will not be released except on rare occasions.
 Bug fixes and updates will go into the latest minor version and users should upgrade to that.
 Driver upgrades within a major version will never contain breaking API changes.
@@ -166,9 +163,10 @@ See also: https://neo4j.com/developer/kb/neo4j-supported-versions/
 You just need to use `neo4j` as the URL scheme and set host of the URL to one of your core members of the cluster.
 
 ```go
-if driver, err = neo4j.NewDriver("neo4j://localhost:7687", neo4j.BasicAuth("username", "password", "")); err != nil {
-	return err // handle error
-}
+driver, err := neo4j.NewDriver(
+    "neo4j://localhost:7687",
+    neo4j.BasicAuth("username", "password", ""),
+)
 ```
 
 There are a few points that need to be highlighted:
@@ -228,6 +226,7 @@ The mapping between Cypher types and the types used by this driver (to represent
 |         Node | neo4j.Node         |
 | Relationship | neo4j.Relationship |
 |         Path | neo4j.Path         |
+|       Vector | neo4j.Vector[T]    |
 
 ### Spatial Types - Point
 
@@ -290,6 +289,39 @@ Note:
 * When `neo4j.OffsetTime` is converted into `time.Time` or constructed through `OffsetTimeOf(time.Time)`, its `Location` is given a fixed name of `Offset` (i.e. assigned `time.FixedZone("Offset", offsetTime.offset)`).
 * When `time.Time` values are sent/received through the driver, if its `Zone()` returns a name of `Offset` the value is stored with its offset value and with its zone name otherwise.
 
+### Vector Types
+
+Vector types are introduced in Bolt 6.0 and represent an ordered collection of homogeneous numeric values.
+
+The mapping between Cypher Vector types and the types used by this driver:
+
+|  Cypher Type | Driver Type        |
+|-------------:|:-------------------|
+|       Vector | neo4j.Vector[T]    |
+
+Vector supports the following element types:
+
+| Element Type | Go Type |
+|-------------:|:-------|
+|       int8   | int8    |
+|       int16  | int16   |
+|       int32  | int32   |
+|       int64  | int64   |
+|       float32| float32 |
+|       float64| float64 |
+
+You can create a Vector value using:
+
+```go
+vec := neo4j.Vector[float64]{1.0, 2.0, 3.0, 4.0, 5.0}
+
+```
+
+Receiving a vector value as driver type:
+```go
+vecValue := record.Values[0].(neo4j.Vector[float64])
+```
+
 ## Logging
 
 Logging at the driver level can be configured by setting `Log` field of `config.Config` through configuration functions that can be passed to `neo4j.NewDriver` function.
@@ -301,17 +333,9 @@ For simplicity, we provide a predefined console logger which can be constructed 
 A simple code snippet that will enable console logging is as follows;
 
 ```go
-useConsoleLogger := func(level log.Level) func(config *config.Config) {
-	return func(config *config.Config) {
-		config.Log = log.ToConsole(level)
-	}
-}
-
-// Construct a new driver
-if driver, err = neo4j.NewDriver(uri, neo4j.BasicAuth(username, password, ""), useConsoleLogger(log.ERROR)); err != nil {
-	return err
-}
-defer driver.Close()
+driver, err := neo4j.NewDriver(uri, neo4j.BasicAuth(username, password, ""), func(config *config.Config) {
+    config.Log = log.ToConsole(log.ERROR)
+})
 ```
 
 ### Custom Logger
@@ -341,11 +365,11 @@ For simplicity, we provide a predefined console logger which can be constructed 
 ```go
 boltLogger := log.BoltToConsole()
 
-# for ExecuteQuery
+// for ExecuteQuery
 result, err := neo4j.ExecuteQuery(ctx, driver, query, params, transformer, neo4j.ExecuteQueryWithBoltLogger(boltLogger))
 
-# for the regular session APIs (session.Run, session.BeginTransaction, session.ExecuteRead, session.ExecuteWrite)
-session := driver.NewSession(neo4j.SessionConfig{BoltLogger: boltLogger})
+// for the regular session APIs (session.Run, session.BeginTransaction, session.ExecuteRead, session.ExecuteWrite)
+session := driver.NewSession(ctx, neo4j.SessionConfig{BoltLogger: boltLogger})
 ```
 
 ### Custom Bolt Logger
@@ -368,7 +392,7 @@ driver.
 
 ### Prerequisites
 
-The Go driver on this branch requires at least Go 1.18 and relies on [Go
+The Go driver on this branch requires at least Go 1.24 and relies on [Go
 modules](https://go.dev/ref/mod) for dependency resolution.
 
 ### Unit Testing


### PR DESCRIPTION
Closes DRIVERS-57

- Added information regarding `Vector` type, `GQL` errors, breaking changes, and context-aware API updates to `MIGRATION_GUIDE`.
- Fixed code examples and mentioned Go version bump.