### PR TITLE
Update deprecation comments for Id, StartId and EndId

### DIFF
--- a/neo4j/dbtype/graph.go
+++ b/neo4j/dbtype/graph.go
@@ -19,7 +19,7 @@
 package dbtype
 
 type Entity interface {
-	// Deprecated: GetId is deprecated and will be removed in 6.0. Use GetElementId instead.
+	// Deprecated: GetId is deprecated. Use GetElementId instead.
 	GetId() int64
 	GetElementId() string
 	GetProperties() map[string]any
@@ -27,7 +27,7 @@ type Entity interface {
 
 // Node represents a node in the neo4j graph database
 type Node struct {
-	// Deprecated: Id is deprecated and will be removed in 6.0. Use ElementId instead.
+	// Deprecated: Id is deprecated. Use ElementId instead.
 	Id        int64          // Id of this Node.
 	ElementId string         // ElementId of this Node.
 	Labels    []string       // Labels attached to this Node.
@@ -48,13 +48,13 @@ func (n Node) GetProperties() map[string]any {
 
 // Relationship represents a relationship in the neo4j graph database
 type Relationship struct {
-	// Deprecated: Id is deprecated and will be removed in 6.0. Use ElementId instead.
+	// Deprecated: Id is deprecated. Use ElementId instead.
 	Id        int64  // Id of this Relationship.
 	ElementId string // ElementId of this Relationship.
-	// Deprecated: StartId is deprecated and will be removed in 6.0. Use StartElementId instead.
+	// Deprecated: StartId is deprecated. Use StartElementId instead.
 	StartId        int64  // Id of the start Node of this Relationship.
 	StartElementId string // ElementId of the start Node of this Relationship.
-	// Deprecated: EndId is deprecated and will be removed in 6.0. Use EndElementId instead.
+	// Deprecated: EndId is deprecated. Use EndElementId instead.
 	EndId        int64          // Id of the end Node of this Relationship.
 	EndElementId string         // ElementId of the end Node of this Relationship.
 	Type         string         // Type of this Relationship.

--- a/neo4j/internal/bolt/hydrator.go
+++ b/neo4j/internal/bolt/hydrator.go
@@ -556,13 +556,13 @@ func (h *hydrator) node(num uint32) any {
 	}
 	n := dbtype.Node{}
 	h.unp.Next()
-	//lint:ignore SA1019 Id is supported at least until 6.0
+	//lint:ignore SA1019 Id is supported for backward compatibility
 	n.Id = h.unp.Int()
 	h.unp.Next()
 	n.Labels = h.strings()
 	h.unp.Next()
 	n.Props = h.amap()
-	//lint:ignore SA1019 Id is supported at least until 6.0
+	//lint:ignore SA1019 Id is supported for backward compatibility
 	n.ElementId = fmt.Sprintf("%d", n.Id)
 	return n
 }
@@ -574,7 +574,7 @@ func (h *hydrator) nodeWithElementId(num uint32) any {
 	}
 	n := dbtype.Node{}
 	h.unp.Next()
-	//lint:ignore SA1019 Id is supported at least until 6.0
+	//lint:ignore SA1019 Id is supported for backward compatibility
 	n.Id = h.unp.Int()
 	h.unp.Next()
 	n.Labels = h.strings()
@@ -592,23 +592,23 @@ func (h *hydrator) relationship(n uint32) any {
 	}
 	r := dbtype.Relationship{}
 	h.unp.Next()
-	//lint:ignore SA1019 Id is supported at least until 6.0
+	//lint:ignore SA1019 Id is supported for backward compatibility
 	r.Id = h.unp.Int()
 	h.unp.Next()
-	//lint:ignore SA1019 StartId is supported at least until 6.0
+	//lint:ignore SA1019 StartId is supported for backward compatibility
 	r.StartId = h.unp.Int()
 	h.unp.Next()
-	//lint:ignore SA1019 EndId is supported at least until 6.0
+	//lint:ignore SA1019 EndId is supported for backward compatibility
 	r.EndId = h.unp.Int()
 	h.unp.Next()
 	r.Type = h.unp.String()
 	h.unp.Next()
 	r.Props = h.amap()
-	//lint:ignore SA1019 Id is supported at least until 6.0
+	//lint:ignore SA1019 Id is supported for backward compatibility
 	r.ElementId = fmt.Sprintf("%d", r.Id)
-	//lint:ignore SA1019 StartId is supported at least until 6.0
+	//lint:ignore SA1019 StartId is supported for backward compatibility
 	r.StartElementId = fmt.Sprintf("%d", r.StartId)
-	//lint:ignore SA1019 EndId is supported at least until 6.0
+	//lint:ignore SA1019 EndId is supported for backward compatibility
 	r.EndElementId = fmt.Sprintf("%d", r.EndId)
 	return r
 }
@@ -620,13 +620,13 @@ func (h *hydrator) relationshipWithElementId(n uint32) any {
 	}
 	r := dbtype.Relationship{}
 	h.unp.Next()
-	//lint:ignore SA1019 Id is supported at least until 6.0
+	//lint:ignore SA1019 Id is supported for backward compatibility
 	r.Id = h.unp.Int()
 	h.unp.Next()
-	//lint:ignore SA1019 StartId is supported at least until 6.0
+	//lint:ignore SA1019 StartId is supported for backward compatibility
 	r.StartId = h.unp.Int()
 	h.unp.Next()
-	//lint:ignore SA1019 EndId is supported at least until 6.0
+	//lint:ignore SA1019 EndId is supported for backward compatibility
 	r.EndId = h.unp.Int()
 	h.unp.Next()
 	r.Type = h.unp.String()
@@ -1044,20 +1044,20 @@ func parseGqlStatusObject(m map[string]any) db.GqlStatusObject {
 
 	// Backward compatibility support for older Notification API.
 	if code, ok := m["neo4j_code"].(string); ok {
-		//lint:ignore SA1019 Code is supported at least until 6.0
+		//lint:ignore SA1019 Code is supported for backward compatibility
 		g.Code = code
 		g.IsNotification = true
 	}
 
 	// Backward compatibility support for older Notification API.
 	if title, ok := m["title"].(string); ok {
-		//lint:ignore SA1019 Title is supported at least until 6.0
+		//lint:ignore SA1019 Title is supported for backward compatibility
 		g.Title = title
 	}
 
 	// Backward compatibility support for older Notification API.
 	if description, ok := m["description"].(string); ok {
-		//lint:ignore SA1019 Description is supported at least until 6.0
+		//lint:ignore SA1019 Description is supported for backward compatibility
 		g.Description = description
 	}
 

--- a/neo4j/internal/bolt/path.go
+++ b/neo4j/internal/bolt/path.go
@@ -23,7 +23,7 @@ import (
 
 // Intermediate representation of part of path
 type relNode struct {
-	// Deprecated: id is deprecated and will be removed in 6.0. Use elementId instead.
+	// Deprecated: id is deprecated. Use elementId instead.
 	id        int64
 	elementId string
 	name      string
@@ -68,11 +68,11 @@ func buildPath(nodes []dbtype.Node, relNodes []*relNode, indexes []int) dbtype.P
 			Props:     reln.props,
 		}
 		if n1start {
-			//lint:ignore SA1019 Id, StartId and EndId are supported at least until 6.0
+			//lint:ignore SA1019 Id, StartId and EndId are supported for backward compatibility
 			rel.StartId, rel.EndId = n1.Id, n2.Id
 			rel.StartElementId, rel.EndElementId = n1.ElementId, n2.ElementId
 		} else {
-			//lint:ignore SA1019 Id, StartId and EndId are supported at least until 6.0
+			//lint:ignore SA1019 Id, StartId and EndId are supported for backward compatibility
 			rel.StartId, rel.EndId = n2.Id, n1.Id
 			rel.StartElementId, rel.EndElementId = n2.ElementId, n1.ElementId
 		}

--- a/neo4j/internal/bolt/path_test.go
+++ b/neo4j/internal/bolt/path_test.go
@@ -77,15 +77,15 @@ func TestBuildPath(ot *testing.T) {
 			for i, rel := range path.Relationships {
 				// Compare expected relationship
 				erel := c.path.Relationships[i]
-				//lint:ignore SA1019 Id is supported at least until 6.0
+				//lint:ignore SA1019 Id is supported for backward compatibility
 				if rel.Id != erel.Id {
 					t.Errorf("Relation %d not as expected, ids differ", i)
 				}
-				//lint:ignore SA1019 StartId is supported at least until 6.0
+				//lint:ignore SA1019 StartId is supported for backward compatibility
 				if rel.StartId != erel.StartId {
 					t.Errorf("Relation %d not as expected, start ids differ", i)
 				}
-				//lint:ignore SA1019 EndId is supported at least until 6.0
+				//lint:ignore SA1019 EndId is supported for backward compatibility
 				if rel.EndId != erel.EndId {
 					t.Errorf("Relation %d not as expected, end ids differ", i)
 				}

--- a/neo4j/test-integration/types_test.go
+++ b/neo4j/test-integration/types_test.go
@@ -256,7 +256,7 @@ func TestTypes(outer *testing.T) {
 		node := result.Record().Values[0].(neo4j.Node)
 
 		assertNotNil(t, node)
-		//lint:ignore SA1019 Id is supported at least until 6.0
+		//lint:ignore SA1019 Id is supported for backward compatibility
 		assertNotNil(t, node.Id)
 		assertEquals(t, len(node.Labels), 2)
 		assertStringsHas(t, node.Labels, "Person")
@@ -278,7 +278,7 @@ func TestTypes(outer *testing.T) {
 		manager := result.Record().Values[2].(neo4j.Node)
 
 		assertNotNil(t, employee)
-		//lint:ignore SA1019 Id is supported at least until 6.0
+		//lint:ignore SA1019 Id is supported for backward compatibility
 		assertNotNil(t, employee.Id)
 		assertEquals(t, len(employee.Labels), 2)
 		assertStringsHas(t, employee.Labels, "Person")
@@ -288,18 +288,18 @@ func TestTypes(outer *testing.T) {
 		assertMapHas(t, employee.Props, "name", "employee 1")
 
 		assertNotNil(t, worksFor)
-		//lint:ignore SA1019 Id is supported at least until 6.0
+		//lint:ignore SA1019 Id is supported for backward compatibility
 		assertNotNil(t, worksFor.Id)
-		//lint:ignore SA1019 StartId is supported at least until 6.0
+		//lint:ignore SA1019 StartId is supported for backward compatibility
 		assertEquals(t, worksFor.StartId, employee.Id)
-		//lint:ignore SA1019 EndId is supported at least until 6.0
+		//lint:ignore SA1019 EndId is supported for backward compatibility
 		assertEquals(t, worksFor.EndId, manager.Id)
 		assertEquals(t, worksFor.Type, "WORKS_FOR")
 		assertEquals(t, len(worksFor.Props), 1)
 		assertMapHas(t, worksFor.Props, "from", "2017-01-01")
 
 		assertNotNil(t, manager)
-		//lint:ignore SA1019 Id is supported at least until 6.0
+		//lint:ignore SA1019 Id is supported for backward compatibility
 		assertNotNil(t, manager.Id)
 		assertEquals(t, len(manager.Labels), 2)
 		assertStringsHas(t, manager.Labels, "Person")

--- a/testkit-backend/2cypher.go
+++ b/testkit-backend/2cypher.go
@@ -149,7 +149,7 @@ func nativeToCypher(v any) map[string]any {
 		return map[string]any{
 			"name": "Node",
 			"data": map[string]any{
-				//lint:ignore SA1019 Id is supported at least until 6.0
+				//lint:ignore SA1019 Id is supported for backward compatibility
 				"id":        nativeToCypher(x.Id),
 				"elementId": nativeToCypher(x.ElementId),
 				"labels":    nativeToCypher(x.Labels),
@@ -159,13 +159,13 @@ func nativeToCypher(v any) map[string]any {
 		return map[string]any{
 			"name": "Relationship",
 			"data": map[string]any{
-				//lint:ignore SA1019 Id is supported at least until 6.0
+				//lint:ignore SA1019 Id is supported for backward compatibility
 				"id":        nativeToCypher(x.Id),
 				"elementId": nativeToCypher(x.ElementId),
-				//lint:ignore SA1019 StartId is supported at least until 6.0
+				//lint:ignore SA1019 StartId is supported for backward compatibility
 				"startNodeId":        nativeToCypher(x.StartId),
 				"startNodeElementId": nativeToCypher(x.StartElementId),
-				//lint:ignore SA1019 EndId is supported at least until 6.0
+				//lint:ignore SA1019 EndId is supported for backward compatibility
 				"endNodeId":        nativeToCypher(x.EndId),
 				"endNodeElementId": nativeToCypher(x.EndElementId),
 				"type":             nativeToCypher(x.Type),


### PR DESCRIPTION
Closes DRIVERS-58

Driver states that `Id`, `StartId` and `EndId` WILL be removed in 6.0 which is no longer true. Update to remove this and update lint rules to be more generic.