### PR TITLE
Add GqlStatus Finder Functions

### DIFF
--- a/neo4j/db/errors.go
+++ b/neo4j/db/errors.go
@@ -150,6 +150,24 @@ func (e *Neo4jError) MarkRetriable() {
 	e.retriable = true
 }
 
+// ContainsGqlStatus returns whether there is an error with the given GQLSTATUS in this GQL error chain,
+// beginning the search from this exception.
+func (e *Neo4jError) ContainsGqlStatus(gqlStatus string) bool {
+	return e.FindByGqlStatus(gqlStatus) != nil
+}
+
+// FindByGqlStatus finds the first Neo4jError that has the given GQLSTATUS in this GQL error chain,
+// beginning the search from this exception.
+// Returns nil if no error with the specified GQLSTATUS is found.
+func (e *Neo4jError) FindByGqlStatus(gqlStatus string) *Neo4jError {
+	for cur := e; cur != nil; cur = cur.GqlCause {
+		if cur.GqlStatus == gqlStatus {
+			return cur
+		}
+	}
+	return nil
+}
+
 type FeatureNotSupportedError struct {
 	Server  string
 	Feature string

--- a/neo4j/db/errors_test.go
+++ b/neo4j/db/errors_test.go
@@ -17,6 +17,7 @@
 package db
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -71,4 +72,80 @@ func TestErrorReclassification(outer *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGqlStatusFinders(outer *testing.T) {
+	outer.Parallel()
+
+	testCases := []struct {
+		name      string
+		error     *Neo4jError
+		gqlStatus string
+		contains  bool
+	}{
+		// Single error cases
+		{"single error match", buildSingleError("01N00"), "01N00", true},
+		{"single error no match", buildSingleError("01N00"), "99N99", false},
+		{"nil error", nil, "01N00", false},
+		{"empty gqlStatus", buildSingleError("01N00"), "", false},
+
+		// Error chain cases
+		{"chain of 1 error - find first", buildErrorChain(1), "error0", true},
+		{"chain of 1 error - not found", buildErrorChain(1), "notfound", false},
+		{"chain of 3 errors - find first", buildErrorChain(3), "error0", true},
+		{"chain of 3 errors - find middle", buildErrorChain(3), "error1", true},
+		{"chain of 3 errors - find last", buildErrorChain(3), "error2", true},
+		{"chain of 3 errors - not found", buildErrorChain(3), "notfound", false},
+		{"chain of 10 errors - find first", buildErrorChain(10), "error0", true},
+		{"chain of 10 errors - find middle", buildErrorChain(10), "error5", true},
+		{"chain of 10 errors - find last", buildErrorChain(10), "error9", true},
+		{"chain of 10 errors - not found", buildErrorChain(10), "notfound", false},
+	}
+
+	for _, tc := range testCases {
+		outer.Run(tc.name, func(t *testing.T) {
+			// Test ContainsGqlStatus
+			contains := tc.error.ContainsGqlStatus(tc.gqlStatus)
+			if contains != tc.contains {
+				t.Errorf("ContainsGqlStatus(%q) = %v, expected %v", tc.gqlStatus, contains, tc.contains)
+			}
+
+			// Test FindByGqlStatus
+			found := tc.error.FindByGqlStatus(tc.gqlStatus)
+			if tc.contains {
+				if found == nil {
+					t.Errorf("FindByGqlStatus(%q) = nil, expected non-nil", tc.gqlStatus)
+				} else if found.GqlStatus != tc.gqlStatus {
+					t.Errorf("FindByGqlStatus(%q) returned error with GqlStatus %q, expected %q", tc.gqlStatus, found.GqlStatus, tc.gqlStatus)
+				}
+			} else {
+				if found != nil {
+					t.Errorf("FindByGqlStatus(%q) = %v, expected nil", tc.gqlStatus, found)
+				}
+			}
+		})
+	}
+}
+
+func buildSingleError(gqlStatus string) *Neo4jError {
+	return &Neo4jError{
+		GqlStatus: gqlStatus,
+	}
+}
+
+func buildErrorChain(length int) *Neo4jError {
+	var current *Neo4jError
+
+	// Build chain from last to first (error0 -> error1 -> error2)
+	for i := length - 1; i >= 0; i-- {
+		error := &Neo4jError{
+			GqlStatus: fmt.Sprintf("error%d", i),
+		}
+		if current != nil {
+			error.GqlCause = current
+		}
+		current = error
+	}
+
+	return current
 }


### PR DESCRIPTION
Closes DRIVERS-72

Add `GQLSTATUS` finder methods to `Neo4jError`.

Adds two methods to check for specific `GQLSTATUS` codes in error chains:

- `ContainsGqlStatus(gqlStatus string) bool`
- `FindByGqlStatus(gqlStatus string) *Neo4jError`