### PR TITLE
[4.4] Add .semgrepignore

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,8 @@
+:include .gitignore
+
+/benchmark/
+/neo4j/**/*_test.go
+/neo4j/test-integration/
+/test-stress/
+/testkit/
+/testkit-backend/


### PR DESCRIPTION
Closes: DRIVERS-211

Backport of https://github.com/neo4j/neo4j-go-driver/pull/688