### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/benchkit-backend/workload.go
+++ b/benchkit-backend/workload.go
@@ -43,7 +43,7 @@ type workload struct {
 
 type workloadQuery struct {
 	Text       string                 `json:"text"`
-	Parameters map[string]interface{} `json:"parameters"`
+	Parameters map[string]any `json:"parameters"`
 }
 
 const (


### PR DESCRIPTION
Replace `interface{}` with `any` (Go 1.18+ alias).

Fixes `benchkit-backend/workload.go`.