### PR TITLE
Correct EagerResult field name in ExecuteQuery example

### DIFF
--- a/neo4j/driver.go
+++ b/neo4j/driver.go
@@ -527,7 +527,7 @@ func (d *driver) VerifyAuthentication(ctx context.Context, auth *AuthToken) (err
 //		summary, _ := result.Consume(ctx)
 //		return &neo4j.EagerResult{
 //			Keys:    keys,
-//			Rows: records,
+//			Records: records,
 //			Summary: summary,
 //		}, nil
 //	})


### PR DESCRIPTION
Closes: DRIVERS-486