### PR TITLE
Add object mapping for query results (preview)

### DIFF
--- a/neo4j/internal/mapping/mapping.go
+++ b/neo4j/internal/mapping/mapping.go
@@ -180,11 +180,11 @@ func assign(dst reflect.Value, raw any) error {
 	if raw == nil {
 		return nil
 	}
-	if dst.Kind() == reflect.Ptr {
+	for dst.Kind() == reflect.Ptr {
 		if dst.IsNil() {
 			dst.Set(reflect.New(dst.Type().Elem()))
 		}
-		return assign(dst.Elem(), raw)
+		dst = dst.Elem()
 	}
 	sv := reflect.ValueOf(raw)
 	dt := dst.Type()

--- a/neo4j/internal/mapping/mapping.go
+++ b/neo4j/internal/mapping/mapping.go
@@ -69,8 +69,9 @@ func StructAsMap(v any) (map[string]any, bool) {
 	return out, true
 }
 
-// fieldByIndex walks index from v through pointer embeds. With alloc it allocates
-// nil embeds (false if one is unexported/unsettable); without, it stops false at the first nil.
+// fieldByIndex walks index from v to the target field, following pointer embeds.
+// With alloc it allocates nil embeds, returning false if one is unexported (and
+// so unsettable). Without alloc it returns false at the first nil embed.
 func fieldByIndex(v reflect.Value, index []int, alloc bool) (reflect.Value, bool) {
 	for _, i := range index {
 		if v.Kind() == reflect.Ptr {

--- a/neo4j/internal/mapping/mapping.go
+++ b/neo4j/internal/mapping/mapping.go
@@ -200,9 +200,9 @@ func assign(dst reflect.Value, raw any) error {
 		}
 		return structFromMap(dst, props)
 	case reflect.Slice:
-		return assignSlice(dst, raw)
+		return assignSlice(dst, sv)
 	case reflect.Map:
-		return assignMap(dst, raw)
+		return assignMap(dst, sv)
 	default:
 		st := sv.Type()
 		dt := dst.Type()
@@ -221,10 +221,9 @@ func assign(dst reflect.Value, raw any) error {
 }
 
 // assignSlice builds a fresh slice so the mapped value never aliases the record.
-func assignSlice(dst reflect.Value, raw any) error {
-	sv := reflect.ValueOf(raw)
+func assignSlice(dst, sv reflect.Value) error {
 	if sv.Kind() != reflect.Slice {
-		return typeError(dst.Type(), raw)
+		return typeError(dst.Type(), sv.Interface())
 	}
 	out := reflect.MakeSlice(dst.Type(), sv.Len(), sv.Len())
 	for i := 0; i < sv.Len(); i++ {
@@ -237,17 +236,16 @@ func assignSlice(dst reflect.Value, raw any) error {
 }
 
 // assignMap builds a fresh map so the mapped value never aliases the record.
-func assignMap(dst reflect.Value, raw any) error {
-	sv := reflect.ValueOf(raw)
+func assignMap(dst, sv reflect.Value) error {
 	if sv.Kind() != reflect.Map {
-		return typeError(dst.Type(), raw)
+		return typeError(dst.Type(), sv.Interface())
 	}
 	dt := dst.Type()
 	out := reflect.MakeMapWithSize(dt, sv.Len())
 	for iter := sv.MapRange(); iter.Next(); {
 		key := iter.Key()
 		if !key.Type().AssignableTo(dt.Key()) {
-			return typeError(dt, raw)
+			return typeError(dt, sv.Interface())
 		}
 		val := reflect.New(dt.Elem()).Elem()
 		if err := assign(val, iter.Value().Interface()); err != nil {

--- a/neo4j/internal/mapping/mapping.go
+++ b/neo4j/internal/mapping/mapping.go
@@ -187,9 +187,9 @@ func assign(dst reflect.Value, raw any) error {
 		dst = dst.Elem()
 	}
 	sv := reflect.ValueOf(raw)
-	dt := dst.Type()
 	switch dst.Kind() {
 	case reflect.Struct:
+		dt := dst.Type()
 		if sv.Type().AssignableTo(dt) {
 			dst.Set(sv) // driver-native struct, e.g. time.Time or a dbtype value
 			return nil
@@ -204,12 +204,14 @@ func assign(dst reflect.Value, raw any) error {
 	case reflect.Map:
 		return assignMap(dst, raw)
 	default:
+		st := sv.Type()
+		dt := dst.Type()
 		switch {
-		case sv.Type().AssignableTo(dt):
+		case st.AssignableTo(dt):
 			dst.Set(sv)
 		case isNumeric(dst.Kind()) && isNumeric(sv.Kind()):
 			return assignNumeric(dst, sv)
-		case sv.Kind() == dst.Kind() && sv.Type().ConvertibleTo(dt):
+		case sv.Kind() == dst.Kind() && st.ConvertibleTo(dt):
 			dst.Set(sv.Convert(dt)) // named type over the same primitive kind
 		default:
 			return typeError(dt, raw)

--- a/neo4j/internal/mapping/mapping.go
+++ b/neo4j/internal/mapping/mapping.go
@@ -241,17 +241,16 @@ func assignMap(dst, sv reflect.Value) error {
 		return typeError(dst.Type(), sv.Interface())
 	}
 	dt := dst.Type()
+	if !sv.Type().Key().AssignableTo(dt.Key()) {
+		return typeError(dt, sv.Interface())
+	}
 	out := reflect.MakeMapWithSize(dt, sv.Len())
 	for iter := sv.MapRange(); iter.Next(); {
-		key := iter.Key()
-		if !key.Type().AssignableTo(dt.Key()) {
-			return typeError(dt, sv.Interface())
-		}
 		val := reflect.New(dt.Elem()).Elem()
 		if err := assign(val, iter.Value().Interface()); err != nil {
 			return err
 		}
-		out.SetMapIndex(key, val)
+		out.SetMapIndex(iter.Key(), val)
 	}
 	dst.Set(out)
 	return nil

--- a/neo4j/internal/mapping/mapping.go
+++ b/neo4j/internal/mapping/mapping.go
@@ -22,6 +22,7 @@ package mapping
 
 import (
 	"fmt"
+	"math/bits"
 	"reflect"
 	"strings"
 	"sync"
@@ -257,8 +258,8 @@ func assignMap(dst, sv reflect.Value) error {
 	return nil
 }
 
-// assignNumeric converts between numeric kinds, erroring on overflow rather than
-// silently wrapping; a float is never coerced into an integer field.
+// assignNumeric converts between numeric kinds, returning an error rather than
+// silently losing range or precision. A float is never coerced into an integer.
 func assignNumeric(dst, src reflect.Value) error {
 	switch {
 	case src.CanInt():
@@ -275,6 +276,9 @@ func assignNumeric(dst, src reflect.Value) error {
 			}
 			dst.SetUint(uint64(n))
 		case dst.CanFloat():
+			if !intFitsFloat(n, dst.Type().Bits()) {
+				return precisionError(dst.Type(), n)
+			}
 			dst.SetFloat(float64(n))
 		}
 	case src.CanFloat():
@@ -285,11 +289,31 @@ func assignNumeric(dst, src reflect.Value) error {
 		if dst.OverflowFloat(f) {
 			return overflowError(dst.Type(), f)
 		}
+		if dst.Type().Bits() < src.Type().Bits() && float64(float32(f)) != f {
+			return precisionError(dst.Type(), f)
+		}
 		dst.SetFloat(f)
 	default:
 		return typeError(dst.Type(), src.Interface())
 	}
 	return nil
+}
+
+// intFitsFloat reports whether n is exactly representable in a float of the given
+// bit size; the mantissa holds 24 significant bits for float32, 53 for float64.
+func intFitsFloat(n int64, floatBits int) bool {
+	if n == 0 {
+		return true
+	}
+	u := uint64(n)
+	if n < 0 {
+		u = uint64(-n)
+	}
+	mantissa := 53
+	if floatBits == 32 {
+		mantissa = 24
+	}
+	return bits.Len64(u)-bits.TrailingZeros64(u) <= mantissa
 }
 
 func propsOf(raw any) (map[string]any, bool) {
@@ -309,6 +333,10 @@ func typeError(dst reflect.Type, raw any) error {
 
 func overflowError(dst reflect.Type, v any) error {
 	return fmt.Errorf("value %v is out of range for %s", v, dst)
+}
+
+func precisionError(dst reflect.Type, v any) error {
+	return fmt.Errorf("value %v cannot be represented exactly as %s", v, dst)
 }
 
 func isNumeric(k reflect.Kind) bool {

--- a/neo4j/internal/mapping/mapping.go
+++ b/neo4j/internal/mapping/mapping.go
@@ -276,7 +276,7 @@ func assignNumeric(dst, src reflect.Value) error {
 			}
 			dst.SetUint(uint64(n))
 		case dst.CanFloat():
-			if !intFitsFloat(n, dst.Type().Bits()) {
+			if !intFitsFloat(n, dst.Type()) {
 				return precisionError(dst.Type(), n)
 			}
 			dst.SetFloat(float64(n))
@@ -299,19 +299,24 @@ func assignNumeric(dst, src reflect.Value) error {
 	return nil
 }
 
-// intFitsFloat reports whether n is exactly representable in a float of the given
-// bit size; the mantissa holds 24 significant bits for float32, 53 for float64.
-func intFitsFloat(n int64, floatBits int) bool {
+// intFitsFloat reports whether n is exactly representable in floatType. Known
+// widths use their mantissa bit count; any other falls back to an exact round-trip.
+func intFitsFloat(n int64, floatType reflect.Type) bool {
 	if n == 0 {
 		return true
+	}
+	var mantissa int
+	switch floatType.Bits() {
+	case 32:
+		mantissa = 24
+	case 64:
+		mantissa = 53
+	default:
+		return reflect.ValueOf(n).Convert(floatType).Convert(reflect.TypeFor[int64]()).Int() == n
 	}
 	u := uint64(n)
 	if n < 0 {
 		u = uint64(-n)
-	}
-	mantissa := 53
-	if floatBits == 32 {
-		mantissa = 24
 	}
 	return bits.Len64(u)-bits.TrailingZeros64(u) <= mantissa
 }

--- a/neo4j/internal/mapping/mapping.go
+++ b/neo4j/internal/mapping/mapping.go
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-// Package mapping converts a user struct into the map[string]any shape the bolt
-// layer expects for Cypher parameters. Nested struct values are returned as-is;
-// the bolt layer re-enters this package for each one.
+// Package mapping converts between user structs and the map[string]any shape the
+// bolt layer uses. StructAsMap flattens a struct into Cypher parameters;
+// MapToStruct is the reverse, filling a struct from a result map.
 package mapping
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -55,7 +56,7 @@ func StructAsMap(v any) (map[string]any, bool) {
 	fields := fieldsOf(rv.Type())
 	out := make(map[string]any, len(fields))
 	for _, f := range fields {
-		fv, ok := fieldByIndex(rv, f.index)
+		fv, ok := fieldByIndex(rv, f.index, false)
 		if !ok {
 			// Field is reachable only through a nil pointer embed.
 			continue
@@ -68,13 +69,16 @@ func StructAsMap(v any) (map[string]any, bool) {
 	return out, true
 }
 
-// fieldByIndex walks index from v, dereferencing pointer embeds. It reports
-// false if a nil pointer is hit mid-path.
-func fieldByIndex(v reflect.Value, index []int) (reflect.Value, bool) {
+// fieldByIndex walks index from v through pointer embeds. With alloc it allocates
+// nil embeds (false if one is unexported/unsettable); without, it stops false at the first nil.
+func fieldByIndex(v reflect.Value, index []int, alloc bool) (reflect.Value, bool) {
 	for _, i := range index {
 		if v.Kind() == reflect.Ptr {
 			if v.IsNil() {
-				return reflect.Value{}, false
+				if !alloc || !v.CanSet() {
+					return reflect.Value{}, false
+				}
+				v.Set(reflect.New(v.Type().Elem()))
 			}
 			v = v.Elem()
 		}
@@ -125,6 +129,226 @@ func buildFields(t reflect.Type, indexPath []int) []fieldInfo {
 		out = append(out, fieldInfo{name: name, index: idx, omitEmpty: omitEmpty})
 	}
 	return out
+}
+
+// entity is satisfied by dbtype.Node and dbtype.Relationship; declared locally
+// to avoid a dbtype import.
+type entity interface{ GetProperties() map[string]any }
+
+var decodeCache sync.Map // map[reflect.Type]map[string]fieldInfo
+
+// MapToStruct fills dest, a non-nil pointer to a struct, from src, using the same
+// neo4j tags as StructAsMap. Unmatched keys and null values leave zero values;
+// a node, relationship, or map value fills a nested struct.
+func MapToStruct(src map[string]any, dest any) error {
+	v := reflect.ValueOf(dest)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("destination must be a non-nil pointer, got %T", dest)
+	}
+	v = v.Elem()
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("destination must point to a struct, got %s", v.Kind())
+	}
+	return structFromMap(v, src)
+}
+
+func structFromMap(v reflect.Value, src map[string]any) error {
+	for name, f := range decodeFieldsOf(v.Type()) {
+		raw, ok := src[name]
+		if !ok || raw == nil {
+			continue
+		}
+		fv, ok := fieldByIndex(v, f.index, true)
+		if !ok {
+			// Field is reachable only through an unexported nil pointer embed.
+			continue
+		}
+		if err := assign(fv, raw); err != nil {
+			return fmt.Errorf("property %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func assign(dst reflect.Value, raw any) error {
+	if raw == nil {
+		return nil
+	}
+	if dst.Kind() == reflect.Ptr {
+		if dst.IsNil() {
+			dst.Set(reflect.New(dst.Type().Elem()))
+		}
+		return assign(dst.Elem(), raw)
+	}
+	sv := reflect.ValueOf(raw)
+	dt := dst.Type()
+	switch dst.Kind() {
+	case reflect.Struct:
+		if sv.Type().AssignableTo(dt) {
+			dst.Set(sv) // driver-native struct, e.g. time.Time or a dbtype value
+			return nil
+		}
+		props, ok := propsOf(raw)
+		if !ok {
+			return typeError(dt, raw)
+		}
+		return structFromMap(dst, props)
+	case reflect.Slice:
+		return assignSlice(dst, raw)
+	case reflect.Map:
+		return assignMap(dst, raw)
+	default:
+		switch {
+		case sv.Type().AssignableTo(dt):
+			dst.Set(sv)
+		case isNumeric(dst.Kind()) && isNumeric(sv.Kind()):
+			return assignNumeric(dst, sv)
+		case sv.Kind() == dst.Kind() && sv.Type().ConvertibleTo(dt):
+			dst.Set(sv.Convert(dt)) // named type over the same primitive kind
+		default:
+			return typeError(dt, raw)
+		}
+		return nil
+	}
+}
+
+// assignSlice builds a fresh slice so the mapped value never aliases the record.
+func assignSlice(dst reflect.Value, raw any) error {
+	sv := reflect.ValueOf(raw)
+	if sv.Kind() != reflect.Slice {
+		return typeError(dst.Type(), raw)
+	}
+	out := reflect.MakeSlice(dst.Type(), sv.Len(), sv.Len())
+	for i := 0; i < sv.Len(); i++ {
+		if err := assign(out.Index(i), sv.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	dst.Set(out)
+	return nil
+}
+
+// assignMap builds a fresh map so the mapped value never aliases the record.
+func assignMap(dst reflect.Value, raw any) error {
+	sv := reflect.ValueOf(raw)
+	if sv.Kind() != reflect.Map {
+		return typeError(dst.Type(), raw)
+	}
+	dt := dst.Type()
+	out := reflect.MakeMapWithSize(dt, sv.Len())
+	for iter := sv.MapRange(); iter.Next(); {
+		key := iter.Key()
+		if !key.Type().AssignableTo(dt.Key()) {
+			return typeError(dt, raw)
+		}
+		val := reflect.New(dt.Elem()).Elem()
+		if err := assign(val, iter.Value().Interface()); err != nil {
+			return err
+		}
+		out.SetMapIndex(key, val)
+	}
+	dst.Set(out)
+	return nil
+}
+
+// assignNumeric converts between numeric kinds, erroring on overflow rather than
+// silently wrapping; a float is never coerced into an integer field.
+func assignNumeric(dst, src reflect.Value) error {
+	switch {
+	case src.CanInt():
+		n := src.Int()
+		switch {
+		case dst.CanInt():
+			if dst.OverflowInt(n) {
+				return overflowError(dst.Type(), n)
+			}
+			dst.SetInt(n)
+		case dst.CanUint():
+			if n < 0 || dst.OverflowUint(uint64(n)) {
+				return overflowError(dst.Type(), n)
+			}
+			dst.SetUint(uint64(n))
+		case dst.CanFloat():
+			dst.SetFloat(float64(n))
+		}
+	case src.CanFloat():
+		if !dst.CanFloat() {
+			return typeError(dst.Type(), src.Interface())
+		}
+		f := src.Float()
+		if dst.OverflowFloat(f) {
+			return overflowError(dst.Type(), f)
+		}
+		dst.SetFloat(f)
+	default:
+		return typeError(dst.Type(), src.Interface())
+	}
+	return nil
+}
+
+func propsOf(raw any) (map[string]any, bool) {
+	switch v := raw.(type) {
+	case map[string]any:
+		return v, true
+	case entity:
+		return v.GetProperties(), true
+	default:
+		return nil, false
+	}
+}
+
+func typeError(dst reflect.Type, raw any) error {
+	return fmt.Errorf("cannot assign %T to %s", raw, dst)
+}
+
+func overflowError(dst reflect.Type, v any) error {
+	return fmt.Errorf("value %v is out of range for %s", v, dst)
+}
+
+func isNumeric(k reflect.Kind) bool {
+	switch k {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+// decodeFieldsOf indexes fields by property name, resolving field-promotion
+// shadowing: the shallowest name wins, an equal-depth tie is dropped.
+func decodeFieldsOf(t reflect.Type) map[string]fieldInfo {
+	if cached, ok := decodeCache.Load(t); ok {
+		return cached.(map[string]fieldInfo)
+	}
+	groups := make(map[string][]fieldInfo)
+	for _, f := range fieldsOf(t) {
+		groups[f.name] = append(groups[f.name], f)
+	}
+	byName := make(map[string]fieldInfo, len(groups))
+	for name, fs := range groups {
+		winner, ambiguous := fs[0], false
+		for _, f := range fs[1:] {
+			switch {
+			case len(f.index) < len(winner.index):
+				winner, ambiguous = f, false // shallower: outright winner
+			case len(f.index) == len(winner.index):
+				ambiguous = true // same depth: ambiguous
+			}
+		}
+		if !ambiguous {
+			byName[name] = winner
+		}
+	}
+	decodeCache.Store(t, byName)
+	return byName
 }
 
 func parseTag(tag string) (name string, omitEmpty bool) {

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -586,6 +586,17 @@ func TestMapToStructErrors(t *testing.T) {
 			t.Fatalf("error should name the field and the value types, got: %q", got)
 		}
 	})
+	t.Run("does not coerce integer into uintptr", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ Foo uintptr }
+		err := MapToStruct(map[string]any{"Foo": int64(123456)}, &w)
+		if err == nil {
+			t.Fatal("expected error for uintptr field")
+		}
+		if got := err.Error(); !strings.Contains(got, `"Foo"`) || !strings.Contains(got, "int") || !strings.Contains(got, "uintptr") {
+			t.Fatalf("error should name the field and both types, got: %q", got)
+		}
+	})
 	t.Run("nested error reports the property path", func(t *testing.T) {
 		t.Parallel()
 		var w struct{ Inner movie }

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -352,6 +352,16 @@ func TestMapToStruct(t *testing.T) {
 			want: &withScalarPointer{Name: &name},
 		},
 		{
+			name: "null leaves a struct pointer field nil",
+			src:  map[string]any{"Inner": nil},
+			want: &withPointer{Inner: nil},
+		},
+		{
+			name: "null leaves a scalar pointer field nil",
+			src:  map[string]any{"Name": nil},
+			want: &withScalarPointer{Name: nil},
+		},
+		{
 			name: "scalar slice",
 			src:  map[string]any{"Tags": []any{"a", "b"}},
 			want: &withSlice{Tags: []string{"a", "b"}},

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -564,6 +564,28 @@ func TestMapToStructErrors(t *testing.T) {
 			t.Fatal("expected precision error for float64 into float32")
 		}
 	})
+	t.Run("map with wrong key type", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ Scores map[int]int }
+		err := MapToStruct(map[string]any{"Scores": map[string]any{"key": int64(1)}}, &w)
+		if err == nil {
+			t.Fatal("expected error for wrong map key type")
+		}
+		if got := err.Error(); !strings.Contains(got, `"Scores"`) || !strings.Contains(got, "map[string]interface") || !strings.Contains(got, "map[int]int") {
+			t.Fatalf("error should name the field and both map types, got: %q", got)
+		}
+	})
+	t.Run("map with wrong value type", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ Scores map[string]string }
+		err := MapToStruct(map[string]any{"Scores": map[string]any{"key": int64(1)}}, &w)
+		if err == nil {
+			t.Fatal("expected error for wrong map value type")
+		}
+		if got := err.Error(); !strings.Contains(got, `"Scores"`) || !strings.Contains(got, "int") || !strings.Contains(got, "string") {
+			t.Fatalf("error should name the field and the value types, got: %q", got)
+		}
+	})
 	t.Run("nested error reports the property path", func(t *testing.T) {
 		t.Parallel()
 		var w struct{ Inner movie }

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -240,6 +240,9 @@ func TestMapToStruct(t *testing.T) {
 	type withSlice struct {
 		Tags []string
 	}
+	type withSliceUntyped struct {
+		Things []any
+	}
 	type withPointerSlice struct {
 		Cast []*movie
 	}
@@ -365,6 +368,16 @@ func TestMapToStruct(t *testing.T) {
 			name: "scalar slice",
 			src:  map[string]any{"Tags": []any{"a", "b"}},
 			want: &withSlice{Tags: []string{"a", "b"}},
+		},
+		{
+			name: "typed slice coerces into an untyped slice field",
+			src:  map[string]any{"Things": []string{"a", "b"}},
+			want: &withSliceUntyped{Things: []any{"a", "b"}},
+		},
+		{
+			name: "mixed slice maps into an untyped slice field",
+			src:  map[string]any{"Things": []any{"a", "b", int64(123)}},
+			want: &withSliceUntyped{Things: []any{"a", "b", int64(123)}},
 		},
 		{
 			name: "slice of struct pointers",

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -484,6 +484,26 @@ func TestMapToStructFloatMantissaBoundary(t *testing.T) {
 			t.Fatalf("N = %v, want 9007199254740991", w.N)
 		}
 	})
+	t.Run("largest exact negative integer for float32", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N float32 }
+		if err := MapToStruct(map[string]any{"N": int64(-(1<<24 - 1))}, &w); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w.N != -16777215 {
+			t.Fatalf("N = %v, want -16777215", w.N)
+		}
+	})
+	t.Run("largest exact negative integer for float64", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N float64 }
+		if err := MapToStruct(map[string]any{"N": int64(-(1<<53 - 1))}, &w); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w.N != -9007199254740991 {
+			t.Fatalf("N = %v, want -9007199254740991", w.N)
+		}
+	})
 }
 
 func TestMapToStructErrors(t *testing.T) {

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -644,6 +644,37 @@ func TestMapToStructDropsAmbiguousField(t *testing.T) {
 	}
 }
 
+func TestMapToStructAllNumericTypes(t *testing.T) {
+	t.Parallel()
+	type nums struct {
+		I   int
+		I8  int8
+		I16 int16
+		I32 int32
+		I64 int64
+		U   uint
+		U8  uint8
+		U16 uint16
+		U32 uint32
+		U64 uint64
+		F32 float32
+		F64 float64
+	}
+	src := map[string]any{
+		"I": int64(1), "I8": int64(2), "I16": int64(3), "I32": int64(4), "I64": int64(5),
+		"U": int64(6), "U8": int64(7), "U16": int64(8), "U32": int64(9), "U64": int64(10),
+		"F32": float64(1.5), "F64": float64(2.5),
+	}
+	want := nums{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1.5, 2.5}
+	var got nums
+	if err := MapToStruct(src, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
 func TestDecodeFieldsOfCachesPerType(t *testing.T) {
 	t.Parallel()
 	type cached struct {

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -230,6 +230,12 @@ func TestMapToStruct(t *testing.T) {
 	type withTypedMap struct {
 		Scores map[string]int
 	}
+	type withMapAnyKey struct {
+		Scores map[any]int
+	}
+	type withMapUntyped struct {
+		Scores map[any]any
+	}
 	type status string
 	type withNamed struct {
 		State status
@@ -348,6 +354,16 @@ func TestMapToStruct(t *testing.T) {
 			name: "typed map converts its values",
 			src:  map[string]any{"Scores": map[string]any{"a": int64(1), "b": int64(2)}},
 			want: &withTypedMap{Scores: map[string]int{"a": 1, "b": 2}},
+		},
+		{
+			name: "typed map converts its keys",
+			src:  map[string]any{"Scores": map[string]any{"a": int64(1), "b": int64(2)}},
+			want: &withMapAnyKey{Scores: map[any]int{"a": 1, "b": 2}},
+		},
+		{
+			name: "typed map converts keys and values into an untyped map",
+			src:  map[string]any{"Scores": map[string]any{"a": int64(1), "b": int64(2)}},
+			want: &withMapUntyped{Scores: map[any]any{"a": int64(1), "b": int64(2)}},
 		},
 		{
 			name: "scalar pointer field is allocated",

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -618,6 +618,32 @@ func TestMapToStructDoesNotAliasSource(t *testing.T) {
 	})
 }
 
+func TestMapToStructDropsAmbiguousField(t *testing.T) {
+	t.Parallel()
+	type a struct {
+		X string `neo4j:"x"`
+	}
+	type b struct {
+		X string `neo4j:"x"`
+	}
+	type ambiguous struct {
+		a
+		b
+		Y string `neo4j:"y"`
+	}
+	var got ambiguous
+	if err := MapToStruct(map[string]any{"x": "dropped", "y": "kept"}, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// x is promoted from both a and b at the same depth, so it is ambiguous and skipped.
+	if got.a.X != "" || got.b.X != "" {
+		t.Fatalf("ambiguous field should be skipped, got a.X=%q b.X=%q", got.a.X, got.b.X)
+	}
+	if got.Y != "kept" {
+		t.Fatalf("Y = %q, want %q", got.Y, "kept")
+	}
+}
+
 func TestDecodeFieldsOfCachesPerType(t *testing.T) {
 	t.Parallel()
 	type cached struct {

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -487,11 +487,11 @@ func TestMapToStructErrors(t *testing.T) {
 			t.Fatal("expected error for pointer to non-struct")
 		}
 	})
-	t.Run("type mismatch", func(t *testing.T) {
+	t.Run("does not parse numeric strings", func(t *testing.T) {
 		t.Parallel()
 		var m movie
-		if err := MapToStruct(map[string]any{"Released": "not-a-number"}, &m); err == nil {
-			t.Fatal("expected error for type mismatch")
+		if err := MapToStruct(map[string]any{"Released": "1999"}, &m); err == nil {
+			t.Fatal("expected error; a numeric string must not be parsed into an integer")
 		}
 	})
 	t.Run("scalar into struct field", func(t *testing.T) {

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -19,6 +19,7 @@ package mapping
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -194,6 +195,417 @@ func TestStructAsMap(t *testing.T) {
 				t.Fatalf("StructAsMap mismatch\nwant: %#v\n got: %#v", c.want, got)
 			}
 		})
+	}
+}
+
+// fakeNode stands in for dbtype.Node/Relationship: it satisfies the propertied
+// interface so MapToStruct maps its properties into a nested struct field.
+type fakeNode struct{ props map[string]any }
+
+func (n fakeNode) GetProperties() map[string]any { return n.props }
+
+func TestMapToStruct(t *testing.T) {
+	type movie struct {
+		Title    string
+		Released int64
+	}
+	type tagged struct {
+		Title string `neo4j:"title"`
+		Skip  string `neo4j:"-"`
+	}
+	type withNumeric struct {
+		Count   int
+		Rating  float64
+		Rating2 float32
+		Small   int32
+		Unsent  uint
+	}
+	type scalars struct {
+		Active bool
+		Blob   []byte
+	}
+	type withMap struct {
+		Meta map[string]any
+	}
+	type withTypedMap struct {
+		Scores map[string]int
+	}
+	type status string
+	type withNamed struct {
+		State status
+	}
+	type withScalarPointer struct {
+		Name *string
+	}
+	type withSlice struct {
+		Tags []string
+	}
+	type withPointerSlice struct {
+		Cast []*movie
+	}
+	type withNestedSlice struct {
+		Cast []movie
+	}
+	type withNested struct {
+		Inner movie
+	}
+	type withPointer struct {
+		Inner *movie
+	}
+	type withTime struct {
+		At time.Time
+	}
+	type base struct{ ID string }
+	type embedded struct {
+		base
+		Name string
+	}
+	type Base struct{ ID string }
+	type pointerEmbedded struct {
+		*Base
+		Name string
+	}
+	type innerNamed struct{ Name string }
+	type outerNamed struct {
+		innerNamed
+		Name string
+	}
+	type withAny struct {
+		V any
+	}
+
+	name := "Trinity"
+
+	cases := []struct {
+		name string
+		src  map[string]any
+		want any // pointer to expected struct
+	}{
+		{
+			name: "scalar fields by name",
+			src:  map[string]any{"Title": "The Matrix", "Released": int64(1999)},
+			want: &movie{Title: "The Matrix", Released: 1999},
+		},
+		{
+			name: "empty source leaves struct zero",
+			src:  map[string]any{},
+			want: &movie{},
+		},
+		{
+			name: "nil source leaves struct zero",
+			src:  nil,
+			want: &movie{},
+		},
+		{
+			name: "tag renames and dash skips",
+			src:  map[string]any{"title": "Speed", "Skip": "ignored"},
+			want: &tagged{Title: "Speed"},
+		},
+		{
+			name: "missing key leaves zero value",
+			src:  map[string]any{"Title": "Heat"},
+			want: &movie{Title: "Heat"},
+		},
+		{
+			name: "null value leaves zero value",
+			src:  map[string]any{"Title": "Heat", "Released": nil},
+			want: &movie{Title: "Heat"},
+		},
+		{
+			name: "extra key is ignored",
+			src:  map[string]any{"Title": "Heat", "Released": int64(1995), "extra": "x"},
+			want: &movie{Title: "Heat", Released: 1995},
+		},
+		{
+			name: "numeric conversion from bolt int64/float64",
+			src:  map[string]any{"Count": int64(3), "Rating": float64(4.5), "Rating2": float64(1.5), "Small": int64(7), "Unsent": int64(9)},
+			want: &withNumeric{Count: 3, Rating: 4.5, Rating2: 1.5, Small: 7, Unsent: 9},
+		},
+		{
+			name: "integer widens into a float field",
+			src:  map[string]any{"Rating": int64(5)},
+			want: &withNumeric{Rating: 5},
+		},
+		{
+			name: "bool and byte-slice fields",
+			src:  map[string]any{"Active": true, "Blob": []byte{1, 2, 3}},
+			want: &scalars{Active: true, Blob: []byte{1, 2, 3}},
+		},
+		{
+			name: "map field assigned verbatim",
+			src:  map[string]any{"Meta": map[string]any{"k": int64(1)}},
+			want: &withMap{Meta: map[string]any{"k": int64(1)}},
+		},
+		{
+			name: "named type over string is converted",
+			src:  map[string]any{"State": "active"},
+			want: &withNamed{State: status("active")},
+		},
+		{
+			name: "typed map converts its values",
+			src:  map[string]any{"Scores": map[string]any{"a": int64(1), "b": int64(2)}},
+			want: &withTypedMap{Scores: map[string]int{"a": 1, "b": 2}},
+		},
+		{
+			name: "scalar pointer field is allocated",
+			src:  map[string]any{"Name": "Trinity"},
+			want: &withScalarPointer{Name: &name},
+		},
+		{
+			name: "scalar slice",
+			src:  map[string]any{"Tags": []any{"a", "b"}},
+			want: &withSlice{Tags: []string{"a", "b"}},
+		},
+		{
+			name: "slice of struct pointers",
+			src:  map[string]any{"Cast": []any{map[string]any{"Title": "A"}, map[string]any{"Title": "B"}}},
+			want: &withPointerSlice{Cast: []*movie{{Title: "A"}, {Title: "B"}}},
+		},
+		{
+			name: "slice of nested structs from maps",
+			src:  map[string]any{"Cast": []any{map[string]any{"Title": "A", "Released": int64(1)}, map[string]any{"Title": "B"}}},
+			want: &withNestedSlice{Cast: []movie{{Title: "A", Released: 1}, {Title: "B"}}},
+		},
+		{
+			name: "nested struct from map",
+			src:  map[string]any{"Inner": map[string]any{"Title": "Nested", "Released": int64(2)}},
+			want: &withNested{Inner: movie{Title: "Nested", Released: 2}},
+		},
+		{
+			name: "nested struct from node properties",
+			src:  map[string]any{"Inner": fakeNode{props: map[string]any{"Title": "FromNode", "Released": int64(3)}}},
+			want: &withNested{Inner: movie{Title: "FromNode", Released: 3}},
+		},
+		{
+			name: "time.Time field assigned as-is",
+			src:  map[string]any{"At": time.Unix(1700000000, 0).UTC()},
+			want: &withTime{At: time.Unix(1700000000, 0).UTC()},
+		},
+		{
+			name: "pointer field is allocated",
+			src:  map[string]any{"Inner": map[string]any{"Title": "Ptr"}},
+			want: &withPointer{Inner: &movie{Title: "Ptr"}},
+		},
+		{
+			name: "anonymous embedded struct is populated",
+			src:  map[string]any{"ID": "1", "Name": "Alice"},
+			want: &embedded{base: base{ID: "1"}, Name: "Alice"},
+		},
+		{
+			name: "nil pointer embed is allocated",
+			src:  map[string]any{"ID": "1", "Name": "Alice"},
+			want: &pointerEmbedded{Base: &Base{ID: "1"}, Name: "Alice"},
+		},
+		{
+			name: "outer field shadows embedded field of the same name",
+			src:  map[string]any{"Name": "outer"},
+			want: &outerNamed{Name: "outer"},
+		},
+		{
+			name: "any field takes value verbatim",
+			src:  map[string]any{"V": []any{int64(1), "two"}},
+			want: &withAny{V: []any{int64(1), "two"}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := reflect.New(reflect.TypeOf(c.want).Elem()).Interface()
+			if err := MapToStruct(c.src, got); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("MapToStruct mismatch\nwant: %#v\n got: %#v", c.want, got)
+			}
+		})
+	}
+}
+
+func TestMapToStructErrors(t *testing.T) {
+	t.Parallel()
+	type movie struct {
+		Title    string
+		Released int64
+	}
+
+	t.Run("non-pointer destination", func(t *testing.T) {
+		t.Parallel()
+		if err := MapToStruct(map[string]any{}, movie{}); err == nil {
+			t.Fatal("expected error for non-pointer destination")
+		}
+	})
+	t.Run("nil pointer destination", func(t *testing.T) {
+		t.Parallel()
+		if err := MapToStruct(map[string]any{}, (*movie)(nil)); err == nil {
+			t.Fatal("expected error for nil pointer destination")
+		}
+	})
+	t.Run("pointer to non-struct", func(t *testing.T) {
+		t.Parallel()
+		var s string
+		if err := MapToStruct(map[string]any{}, &s); err == nil {
+			t.Fatal("expected error for pointer to non-struct")
+		}
+	})
+	t.Run("type mismatch", func(t *testing.T) {
+		t.Parallel()
+		var m movie
+		if err := MapToStruct(map[string]any{"Released": "not-a-number"}, &m); err == nil {
+			t.Fatal("expected error for type mismatch")
+		}
+	})
+	t.Run("scalar into struct field", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ Inner movie }
+		if err := MapToStruct(map[string]any{"Inner": "scalar"}, &w); err == nil {
+			t.Fatal("expected error mapping scalar into struct field")
+		}
+	})
+	t.Run("scalar into slice field", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ Nums []int }
+		if err := MapToStruct(map[string]any{"Nums": "notaslice"}, &w); err == nil {
+			t.Fatal("expected error mapping scalar into slice field")
+		}
+	})
+	t.Run("type mismatch in slice element", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ Nums []int }
+		if err := MapToStruct(map[string]any{"Nums": []any{int64(1), "two"}}, &w); err == nil {
+			t.Fatal("expected error for bad slice element")
+		}
+	})
+	t.Run("scalar into map field", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ Meta map[string]any }
+		if err := MapToStruct(map[string]any{"Meta": "scalar"}, &w); err == nil {
+			t.Fatal("expected error mapping scalar into map field")
+		}
+	})
+	t.Run("integer overflows target width", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N int32 }
+		if err := MapToStruct(map[string]any{"N": int64(3000000000)}, &w); err == nil {
+			t.Fatal("expected overflow error for int64 into int32")
+		}
+	})
+	t.Run("negative integer into unsigned", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N uint32 }
+		if err := MapToStruct(map[string]any{"N": int64(-1)}, &w); err == nil {
+			t.Fatal("expected error for negative into unsigned")
+		}
+	})
+	t.Run("float into integer field", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N int }
+		if err := MapToStruct(map[string]any{"N": float64(3.9)}, &w); err == nil {
+			t.Fatal("expected error mapping float into integer field")
+		}
+	})
+	t.Run("nested error reports the property path", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ Inner movie }
+		err := MapToStruct(map[string]any{"Inner": map[string]any{"Released": "nope"}}, &w)
+		if err == nil {
+			t.Fatal("expected error for bad nested property")
+		}
+		if got := err.Error(); !strings.Contains(got, "Inner") || !strings.Contains(got, "Released") {
+			t.Fatalf("error should name the property path, got: %q", got)
+		}
+	})
+}
+
+func TestMapToStructPointerTarget(t *testing.T) {
+	t.Parallel()
+	type movie struct{ Title string }
+	var out *movie
+	if err := MapToStruct(map[string]any{"Title": "The Matrix"}, &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == nil || out.Title != "The Matrix" {
+		t.Fatalf("pointer target not allocated/populated: %#v", out)
+	}
+}
+
+// unexportedBase is embedded by pointer to reproduce the case where a nil
+// unexported pointer embed cannot be allocated.
+type unexportedBase struct {
+	Secret string `neo4j:"secret"`
+}
+
+func TestMapToStructIgnoresUnexportedField(t *testing.T) {
+	t.Parallel()
+	type withUnexported struct {
+		Name   string
+		secret string
+	}
+	var got withUnexported
+	if err := MapToStruct(map[string]any{"Name": "n", "secret": "s"}, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "n" || got.secret != "" {
+		t.Fatalf("got %#v, want Name=n and empty secret", got)
+	}
+}
+
+func TestMapToStructSkipsUnallocatableEmbed(t *testing.T) {
+	t.Parallel()
+	type withEmbed struct {
+		*unexportedBase
+		Name string `neo4j:"name"`
+	}
+	var got withEmbed
+	// Must not panic on the nil unexported *unexportedBase embed.
+	if err := MapToStruct(map[string]any{"name": "Alice", "secret": "x"}, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "Alice" {
+		t.Fatalf("Name = %q, want %q", got.Name, "Alice")
+	}
+	if got.unexportedBase != nil {
+		t.Fatalf("unexported pointer embed should stay nil, got %#v", got.unexportedBase)
+	}
+}
+
+func TestMapToStructDoesNotAliasSource(t *testing.T) {
+	t.Parallel()
+	t.Run("slice", func(t *testing.T) {
+		t.Parallel()
+		src := []any{"a", "b"}
+		var got struct{ Tags []any }
+		if err := MapToStruct(map[string]any{"Tags": src}, &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got.Tags[0] = "mutated"
+		if src[0] != "a" {
+			t.Fatalf("mapping aliased the source slice: src[0] = %v", src[0])
+		}
+	})
+	t.Run("map", func(t *testing.T) {
+		t.Parallel()
+		src := map[string]any{"k": "v"}
+		var got struct{ Meta map[string]any }
+		if err := MapToStruct(map[string]any{"Meta": src}, &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got.Meta["k"] = "mutated"
+		if src["k"] != "v" {
+			t.Fatalf("mapping aliased the source map: src[k] = %v", src["k"])
+		}
+	})
+}
+
+func TestDecodeFieldsOfCachesPerType(t *testing.T) {
+	t.Parallel()
+	type cached struct {
+		Name string
+	}
+	first := decodeFieldsOf(reflect.TypeOf(cached{}))
+	second := decodeFieldsOf(reflect.TypeOf(cached{}))
+	if reflect.ValueOf(first).Pointer() != reflect.ValueOf(second).Pointer() {
+		t.Fatal("decodeFieldsOf should return the cached map for the same type")
 	}
 }
 

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -461,6 +461,31 @@ func TestMapToStruct(t *testing.T) {
 	}
 }
 
+func TestMapToStructFloatMantissaBoundary(t *testing.T) {
+	t.Parallel()
+	// Largest integer each float represents exactly; pins the lower mantissa boundary.
+	t.Run("largest exact integer for float32", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N float32 }
+		if err := MapToStruct(map[string]any{"N": int64(1<<24 - 1)}, &w); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w.N != 16777215 {
+			t.Fatalf("N = %v, want 16777215", w.N)
+		}
+	})
+	t.Run("largest exact integer for float64", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N float64 }
+		if err := MapToStruct(map[string]any{"N": int64(1<<53 - 1)}, &w); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w.N != 9007199254740991 {
+			t.Fatalf("N = %v, want 9007199254740991", w.N)
+		}
+	})
+}
+
 func TestMapToStructErrors(t *testing.T) {
 	t.Parallel()
 	type movie struct {
@@ -543,10 +568,10 @@ func TestMapToStructErrors(t *testing.T) {
 			t.Fatal("expected error mapping float into integer field")
 		}
 	})
-	t.Run("integer loses precision as float32", func(t *testing.T) {
+	t.Run("integer just past the float32 mantissa loses precision", func(t *testing.T) {
 		t.Parallel()
 		var w struct{ N float32 }
-		if err := MapToStruct(map[string]any{"N": int64(1<<25 + 1)}, &w); err == nil {
+		if err := MapToStruct(map[string]any{"N": int64(1<<24 + 1)}, &w); err == nil {
 			t.Fatal("expected precision error for int64 into float32")
 		}
 	})

--- a/neo4j/internal/mapping/mapping_test.go
+++ b/neo4j/internal/mapping/mapping_test.go
@@ -504,6 +504,27 @@ func TestMapToStructErrors(t *testing.T) {
 			t.Fatal("expected error mapping float into integer field")
 		}
 	})
+	t.Run("integer loses precision as float32", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N float32 }
+		if err := MapToStruct(map[string]any{"N": int64(1<<25 + 1)}, &w); err == nil {
+			t.Fatal("expected precision error for int64 into float32")
+		}
+	})
+	t.Run("integer loses precision as float64", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N float64 }
+		if err := MapToStruct(map[string]any{"N": int64(1<<53 + 1)}, &w); err == nil {
+			t.Fatal("expected precision error for int64 into float64")
+		}
+	})
+	t.Run("float loses precision as float32", func(t *testing.T) {
+		t.Parallel()
+		var w struct{ N float32 }
+		if err := MapToStruct(map[string]any{"N": float64(0.1)}, &w); err == nil {
+			t.Fatal("expected precision error for float64 into float32")
+		}
+	})
 	t.Run("nested error reports the property path", func(t *testing.T) {
 		t.Parallel()
 		var w struct{ Inner movie }

--- a/neo4j/mapping.go
+++ b/neo4j/mapping.go
@@ -35,6 +35,9 @@ import (
 // Slice and map fields are copied; a node or relationship's properties are not,
 // so a mapped value may still share that data with the record.
 //
+// Fields promoted from embedded structs follow encoding/json's rules: a
+// shallower field shadows a deeper one, and a same-depth tie is skipped.
+//
 // As is part of the Object Mapping preview feature (see README on what it means
 // in terms of support and compatibility guarantees).
 func As[T any](record *Record) (T, error) {

--- a/neo4j/mapping.go
+++ b/neo4j/mapping.go
@@ -29,6 +29,9 @@ import (
 // A record with a single node, relationship, or map column maps that value's
 // properties; otherwise its columns map by name.
 //
+// Numeric properties are converted to the field's type; a conversion that would
+// lose range or precision returns an error instead of silently truncating.
+//
 // As is part of the Object Mapping preview feature (see README on what it means
 // in terms of support and compatibility guarantees).
 func As[T any](record *Record) (T, error) {

--- a/neo4j/mapping.go
+++ b/neo4j/mapping.go
@@ -32,8 +32,8 @@ import (
 // Numeric properties are converted to the field's type; a conversion that would
 // lose range or precision returns an error instead of silently truncating.
 //
-// Slice and map fields are copied; a node or relationship's properties are not,
-// so a mapped value may share that data with the record.
+// Slice and map fields are recursively copied; a node or relationship's
+// properties are not, so a mapped value may share that data with the record.
 //
 // Fields promoted from embedded structs follow encoding/json's rules: a
 // shallower field shadows a deeper one, and a same-depth tie is skipped.

--- a/neo4j/mapping.go
+++ b/neo4j/mapping.go
@@ -66,13 +66,13 @@ func SingleAs[T any](ctx context.Context, result Result) (T, error) {
 // CollectRecordsAs is part of the Object Mapping preview feature (see README on
 // what it means in terms of support and compatibility guarantees).
 func CollectRecordsAs[T any](records []*Record) ([]T, error) {
-	out := make([]T, len(records))
-	for i, record := range records {
+	out := make([]T, 0, len(records))
+	for _, record := range records {
 		v, err := As[T](record)
 		if err != nil {
 			return nil, err
 		}
-		out[i] = v
+		out = append(out, v)
 	}
 	return out, nil
 }

--- a/neo4j/mapping.go
+++ b/neo4j/mapping.go
@@ -32,6 +32,9 @@ import (
 // Numeric properties are converted to the field's type; a conversion that would
 // lose range or precision returns an error instead of silently truncating.
 //
+// Slice and map fields are copied; a node or relationship's properties are not,
+// so a mapped value may still share that data with the record.
+//
 // As is part of the Object Mapping preview feature (see README on what it means
 // in terms of support and compatibility guarantees).
 func As[T any](record *Record) (T, error) {

--- a/neo4j/mapping.go
+++ b/neo4j/mapping.go
@@ -33,7 +33,7 @@ import (
 // lose range or precision returns an error instead of silently truncating.
 //
 // Slice and map fields are copied; a node or relationship's properties are not,
-// so a mapped value may still share that data with the record.
+// so a mapped value may share that data with the record.
 //
 // Fields promoted from embedded structs follow encoding/json's rules: a
 // shallower field shadows a deeper one, and a same-depth tie is skipped.

--- a/neo4j/mapping.go
+++ b/neo4j/mapping.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package neo4j
+
+import (
+	"context"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/mapping"
+)
+
+// As maps record into a value of type T, a struct or pointer to one, using the
+// neo4j struct tags: `neo4j:"name"` renames a field, `neo4j:"-"` skips it.
+// Missing or null properties leave zero values and extra properties are ignored.
+// A record with a single node, relationship, or map column maps that value's
+// properties; otherwise its columns map by name.
+//
+// As is part of the Object Mapping preview feature (see README on what it means
+// in terms of support and compatibility guarantees).
+func As[T any](record *Record) (T, error) {
+	var out T
+	if record == nil {
+		return out, &UsageError{Message: "cannot map a nil record"}
+	}
+	if err := mapping.MapToStruct(sourceOf(record), &out); err != nil {
+		return *new(T), err
+	}
+	return out, nil
+}
+
+// CollectAs maps every remaining record in result into a slice of T. It is
+// shorthand for CollectT(ctx, result, As[T]); see As for the mapping rules.
+//
+// CollectAs is part of the Object Mapping preview feature (see README on what it
+// means in terms of support and compatibility guarantees).
+func CollectAs[T any](ctx context.Context, result Result) ([]T, error) {
+	return CollectT(ctx, result, As[T])
+}
+
+// SingleAs maps the single remaining record in result into a value of type T. It
+// is shorthand for SingleT(ctx, result, As[T]); see As for the mapping rules.
+//
+// SingleAs is part of the Object Mapping preview feature (see README on what it
+// means in terms of support and compatibility guarantees).
+func SingleAs[T any](ctx context.Context, result Result) (T, error) {
+	return SingleT(ctx, result, As[T])
+}
+
+// CollectRecordsAs maps a slice of records, such as EagerResult.Records, into a
+// slice of T; see As for the mapping rules.
+//
+// CollectRecordsAs is part of the Object Mapping preview feature (see README on
+// what it means in terms of support and compatibility guarantees).
+func CollectRecordsAs[T any](records []*Record) ([]T, error) {
+	out := make([]T, len(records))
+	for i, record := range records {
+		v, err := As[T](record)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+// sourceOf picks the map As decodes from: a lone node, relationship, or map
+// column is unwrapped to its properties; otherwise the record's columns are used.
+func sourceOf(record *Record) map[string]any {
+	if len(record.Keys) == 1 {
+		switch v := record.Values[0].(type) {
+		case map[string]any:
+			return v
+		case Entity: // Node or Relationship
+			return v.GetProperties()
+		}
+	}
+	return record.AsMap()
+}

--- a/neo4j/mapping_example_test.go
+++ b/neo4j/mapping_example_test.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package neo4j_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
+)
+
+func ExampleAs() {
+	ctx := context.Background()
+	driver, err := createDriver()
+	handleError(err)
+	defer handleClose(ctx, driver)
+	session := driver.NewSession(ctx, neo4j.SessionConfig{})
+	defer handleClose(ctx, session)
+
+	type Movie struct {
+		Title    string `neo4j:"title"`
+		Released int64  `neo4j:"released"`
+	}
+
+	result, err := session.Run(ctx, "MATCH (m:Movie {title: $title}) RETURN m", map[string]any{"title": "The Matrix"})
+	handleError(err)
+	record, err := result.Single(ctx)
+	handleError(err)
+
+	// The record holds a single node column, so As maps its properties onto the
+	// struct fields named by the neo4j tags.
+	movie, err := neo4j.As[Movie](record)
+	handleError(err)
+	fmt.Println(movie.Title)
+}
+
+func ExampleCollectAs() {
+	ctx := context.Background()
+	driver, err := createDriver()
+	handleError(err)
+	defer handleClose(ctx, driver)
+	session := driver.NewSession(ctx, neo4j.SessionConfig{})
+	defer handleClose(ctx, session)
+
+	type Movie struct {
+		Title    string `neo4j:"title"`
+		Released int64  `neo4j:"released"`
+	}
+
+	result, err := session.Run(ctx, "MATCH (m:Movie) RETURN m", nil)
+	handleError(err)
+
+	movies, err := neo4j.CollectAs[Movie](ctx, result)
+	handleError(err)
+	fmt.Printf("mapped %d movies\n", len(movies))
+}
+
+func ExampleSingleAs() {
+	ctx := context.Background()
+	driver, err := createDriver()
+	handleError(err)
+	defer handleClose(ctx, driver)
+	session := driver.NewSession(ctx, neo4j.SessionConfig{})
+	defer handleClose(ctx, session)
+
+	type Movie struct {
+		Title    string `neo4j:"title"`
+		Released int64  `neo4j:"released"`
+	}
+
+	result, err := session.Run(ctx, "MATCH (m:Movie {title: $title}) RETURN m", map[string]any{"title": "The Matrix"})
+	handleError(err)
+
+	movie, err := neo4j.SingleAs[Movie](ctx, result)
+	handleError(err)
+	fmt.Println(movie.Title)
+}
+
+func ExampleCollectRecordsAs() {
+	ctx := context.Background()
+	driver, err := createDriver()
+	handleError(err)
+	defer handleClose(ctx, driver)
+
+	type Movie struct {
+		Title    string `neo4j:"title"`
+		Released int64  `neo4j:"released"`
+	}
+
+	result, err := neo4j.ExecuteQuery(ctx, driver, "MATCH (m:Movie) RETURN m", nil, neo4j.EagerResultTransformer)
+	handleError(err)
+
+	// ExecuteQuery returns eager records; CollectRecordsAs maps them in one call.
+	movies, err := neo4j.CollectRecordsAs[Movie](result.Records)
+	handleError(err)
+	fmt.Printf("mapped %d movies\n", len(movies))
+}

--- a/neo4j/mapping_example_test.go
+++ b/neo4j/mapping_example_test.go
@@ -37,14 +37,19 @@ func ExampleAs() {
 		Released int64  `neo4j:"released"`
 	}
 
-	result, err := session.Run(ctx, "MATCH (m:Movie {title: $title}) RETURN m", map[string]any{"title": "The Matrix"})
-	handleError(err)
-	record, err := result.Single(ctx)
-	handleError(err)
-
 	// The record holds a single node column, so As maps its properties onto the
 	// struct fields named by the neo4j tags.
-	movie, err := neo4j.As[Movie](record)
+	movie, err := neo4j.ExecuteRead(ctx, session, func(tx neo4j.ManagedTransaction) (Movie, error) {
+		result, err := tx.Run(ctx, "MATCH (m:Movie {title: $title}) RETURN m", map[string]any{"title": "The Matrix"})
+		if err != nil {
+			return Movie{}, err
+		}
+		record, err := result.Single(ctx)
+		if err != nil {
+			return Movie{}, err
+		}
+		return neo4j.As[Movie](record)
+	})
 	handleError(err)
 	fmt.Println(movie.Title)
 }
@@ -62,10 +67,13 @@ func ExampleCollectAs() {
 		Released int64  `neo4j:"released"`
 	}
 
-	result, err := session.Run(ctx, "MATCH (m:Movie) RETURN m", nil)
-	handleError(err)
-
-	movies, err := neo4j.CollectAs[Movie](ctx, result)
+	movies, err := neo4j.ExecuteRead(ctx, session, func(tx neo4j.ManagedTransaction) ([]Movie, error) {
+		result, err := tx.Run(ctx, "MATCH (m:Movie) RETURN m", nil)
+		if err != nil {
+			return nil, err
+		}
+		return neo4j.CollectAs[Movie](ctx, result)
+	})
 	handleError(err)
 	fmt.Printf("mapped %d movies\n", len(movies))
 }
@@ -83,10 +91,13 @@ func ExampleSingleAs() {
 		Released int64  `neo4j:"released"`
 	}
 
-	result, err := session.Run(ctx, "MATCH (m:Movie {title: $title}) RETURN m", map[string]any{"title": "The Matrix"})
-	handleError(err)
-
-	movie, err := neo4j.SingleAs[Movie](ctx, result)
+	movie, err := neo4j.ExecuteRead(ctx, session, func(tx neo4j.ManagedTransaction) (Movie, error) {
+		result, err := tx.Run(ctx, "MATCH (m:Movie {title: $title}) RETURN m", map[string]any{"title": "The Matrix"})
+		if err != nil {
+			return Movie{}, err
+		}
+		return neo4j.SingleAs[Movie](ctx, result)
+	})
 	handleError(err)
 	fmt.Println(movie.Title)
 }

--- a/neo4j/mapping_test.go
+++ b/neo4j/mapping_test.go
@@ -78,6 +78,17 @@ func TestAs(t *testing.T) {
 			t.Fatalf("As[*person] = %#v, want %#v", got, &alice)
 		}
 	})
+	t.Run("multi-hop pointer target is allocated", func(t *testing.T) {
+		t.Parallel()
+		rec := &db.Record{Keys: []string{"p"}, Values: []any{Node{Props: props}}}
+		got, err := As[**person](rec)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || **got != alice {
+			t.Fatalf("As[**person] = %#v, want %#v", got, &alice)
+		}
+	})
 	t.Run("nil record returns a usage error", func(t *testing.T) {
 		t.Parallel()
 		_, err := As[person](nil)

--- a/neo4j/mapping_test.go
+++ b/neo4j/mapping_test.go
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package neo4j
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
+	idb "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/db"
+	. "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/testutil"
+)
+
+type person struct {
+	Name string `neo4j:"name"`
+	Age  int64  `neo4j:"age"`
+}
+
+func TestAs(t *testing.T) {
+	t.Parallel()
+	props := map[string]any{"name": "Alice", "age": int64(30)}
+	alice := person{Name: "Alice", Age: 30}
+
+	t.Run("single node column unwraps to its properties", func(t *testing.T) {
+		t.Parallel()
+		rec := &db.Record{Keys: []string{"p"}, Values: []any{Node{Props: props}}}
+		got, err := As[person](rec)
+		assertMapped(t, got, err, alice)
+	})
+	t.Run("single relationship column unwraps to its properties", func(t *testing.T) {
+		t.Parallel()
+		rec := &db.Record{Keys: []string{"r"}, Values: []any{Relationship{Props: props}}}
+		got, err := As[person](rec)
+		assertMapped(t, got, err, alice)
+	})
+	t.Run("single map column unwraps directly", func(t *testing.T) {
+		t.Parallel()
+		rec := &db.Record{Keys: []string{"m"}, Values: []any{props}}
+		got, err := As[person](rec)
+		assertMapped(t, got, err, alice)
+	})
+	t.Run("multiple columns map by name", func(t *testing.T) {
+		t.Parallel()
+		rec := &db.Record{Keys: []string{"name", "age"}, Values: []any{"Alice", int64(30)}}
+		got, err := As[person](rec)
+		assertMapped(t, got, err, alice)
+	})
+	t.Run("single scalar column maps by column name", func(t *testing.T) {
+		t.Parallel()
+		rec := &db.Record{Keys: []string{"name"}, Values: []any{"Alice"}}
+		got, err := As[person](rec)
+		assertMapped(t, got, err, person{Name: "Alice"})
+	})
+	t.Run("pointer target is allocated", func(t *testing.T) {
+		t.Parallel()
+		rec := &db.Record{Keys: []string{"p"}, Values: []any{Node{Props: props}}}
+		got, err := As[*person](rec)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil || *got != alice {
+			t.Fatalf("As[*person] = %#v, want %#v", got, &alice)
+		}
+	})
+	t.Run("nil record returns a usage error", func(t *testing.T) {
+		t.Parallel()
+		_, err := As[person](nil)
+		if _, ok := err.(*UsageError); !ok {
+			t.Fatalf("expected *UsageError, got %T", err)
+		}
+	})
+	t.Run("mapping error is propagated", func(t *testing.T) {
+		t.Parallel()
+		rec := &db.Record{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"age": "thirty"}}}}
+		if _, err := As[person](rec); err == nil {
+			t.Fatal("expected error for type mismatch")
+		}
+	})
+}
+
+func TestCollectAs(t *testing.T) {
+	t.Parallel()
+	result := recordResult(
+		&db.Record{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"name": "Alice", "age": int64(30)}}}},
+		&db.Record{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"name": "Bob", "age": int64(40)}}}},
+	)
+	got, err := CollectAs[person](context.Background(), result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []person{{Name: "Alice", Age: 30}, {Name: "Bob", Age: 40}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CollectAs = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectAsPropagatesMappingError(t *testing.T) {
+	t.Parallel()
+	result := recordResult(
+		&db.Record{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"age": "thirty"}}}},
+	)
+	if _, err := CollectAs[person](context.Background(), result); err == nil {
+		t.Fatal("expected mapping error to propagate")
+	}
+}
+
+func TestCollectRecordsAs(t *testing.T) {
+	t.Parallel()
+	records := []*db.Record{
+		{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"name": "Alice", "age": int64(30)}}}},
+		{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"name": "Bob", "age": int64(40)}}}},
+	}
+	got, err := CollectRecordsAs[person](records)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []person{{Name: "Alice", Age: 30}, {Name: "Bob", Age: 40}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CollectRecordsAs = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectRecordsAsPropagatesMappingError(t *testing.T) {
+	t.Parallel()
+	records := []*db.Record{
+		{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"age": "thirty"}}}},
+	}
+	if _, err := CollectRecordsAs[person](records); err == nil {
+		t.Fatal("expected mapping error to propagate")
+	}
+}
+
+func TestSingleAs(t *testing.T) {
+	t.Parallel()
+	result := recordResult(
+		&db.Record{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"name": "Alice", "age": int64(30)}}}},
+	)
+	got, err := SingleAs[person](context.Background(), result)
+	assertMapped(t, got, err, person{Name: "Alice", Age: 30})
+}
+
+func TestSingleAsErrorsWithoutExactlyOneRecord(t *testing.T) {
+	t.Parallel()
+	result := recordResult(
+		&db.Record{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"name": "Alice"}}}},
+		&db.Record{Keys: []string{"p"}, Values: []any{Node{Props: map[string]any{"name": "Bob"}}}},
+	)
+	if _, err := SingleAs[person](context.Background(), result); err == nil {
+		t.Fatal("expected error when more than one record is present")
+	}
+}
+
+func assertMapped(t *testing.T, got person, err error, want person) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("mapped = %#v, want %#v", got, want)
+	}
+}
+
+// recordResult builds a Result that streams the given records followed by a
+// summary, matching what CollectAs and SingleAs consume.
+func recordResult(records ...*db.Record) Result {
+	nexts := make([]Next, 0, len(records)+1)
+	for _, r := range records {
+		nexts = append(nexts, Next{Record: r})
+	}
+	nexts = append(nexts, Next{Summary: &idb.Summary{}})
+	conn := &ConnFake{Nexts: nexts}
+	return newResult(conn, idb.StreamHandle(0), "", map[string]any{}, &transactionState{}, nil)
+}

--- a/neo4j/test-integration/mapping_test.go
+++ b/neo4j/test-integration/mapping_test.go
@@ -166,6 +166,33 @@ func TestObjectMapping(outer *testing.T) {
 		assertFalse(t, events[0].At.Equal(events[1].At)) // genuinely two different instants
 	})
 
+	outer.Run("maps a small graph of nodes and relationships", func(t *testing.T) {
+		type actor struct {
+			Name string `neo4j:"name"`
+		}
+		type role struct {
+			Character string `neo4j:"character"`
+		}
+		type credit struct {
+			Actor actor  `neo4j:"actor"`
+			Role  role   `neo4j:"role"`
+			Movie string `neo4j:"movie"`
+		}
+		cleanup(t)
+		result, err := session.Run(ctx,
+			"CREATE (:OMTest {name: 'Keanu'})-[:ACTED_IN {character: 'Neo'}]->(:OMTest {title: 'The Matrix'})", nil)
+		assertNil(t, err)
+		_, err = result.Consume(ctx)
+		assertNil(t, err)
+
+		result, err = session.Run(ctx,
+			"MATCH (a:OMTest)-[r:ACTED_IN]->(m:OMTest) RETURN a AS actor, r AS role, m.title AS movie", nil)
+		assertNil(t, err)
+		got, err := neo4j.SingleAs[credit](ctx, result)
+		assertNil(t, err)
+		assertEquals(t, got, credit{Actor: actor{Name: "Keanu"}, Role: role{Character: "Neo"}, Movie: "The Matrix"})
+	})
+
 	outer.Run("type mismatch returns an error", func(t *testing.T) {
 		cleanup(t)
 		create(t, omPerson{Name: "Alice", Age: 30})

--- a/neo4j/test-integration/mapping_test.go
+++ b/neo4j/test-integration/mapping_test.go
@@ -141,6 +141,31 @@ func TestObjectMapping(outer *testing.T) {
 		assertEquals(t, got, movie{Title: "Heat", Director: director{Name: "Mann"}})
 	})
 
+	outer.Run("DST-ambiguous local time round-trips both instants", func(t *testing.T) {
+		type event struct {
+			Name string    `neo4j:"name"`
+			At   time.Time `neo4j:"at"`
+		}
+		berlin, err := time.LoadLocation("Europe/Berlin")
+		assertNil(t, err)
+		// On 2025-10-26 the Berlin clock falls back, so 02:30 local occurs twice.
+		pre := time.Date(2025, 10, 26, 0, 30, 0, 0, time.UTC).In(berlin)  // 02:30 CEST (UTC+2)
+		post := time.Date(2025, 10, 26, 1, 30, 0, 0, time.UTC).In(berlin) // 02:30 CET (UTC+1)
+
+		cleanup(t)
+		create(t, event{Name: "post", At: post})
+		create(t, event{Name: "pre", At: pre})
+
+		result, err := session.Run(ctx, "MATCH (n:OMTest) RETURN n ORDER BY n.name", nil)
+		assertNil(t, err)
+		events, err := neo4j.CollectAs[event](ctx, result)
+		assertNil(t, err)
+		assertEquals(t, len(events), 2)
+		assertTrue(t, events[0].At.Equal(post))
+		assertTrue(t, events[1].At.Equal(pre))
+		assertFalse(t, events[0].At.Equal(events[1].At)) // genuinely two different instants
+	})
+
 	outer.Run("type mismatch returns an error", func(t *testing.T) {
 		cleanup(t)
 		create(t, omPerson{Name: "Alice", Age: 30})

--- a/neo4j/test-integration/mapping_test.go
+++ b/neo4j/test-integration/mapping_test.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/test-integration/dbserver"
+)
+
+type omPerson struct {
+	Name string `neo4j:"name"`
+	Age  int64  `neo4j:"age"`
+}
+
+// TestObjectMapping round-trips through a real server: nodes are created from a
+// struct via the input mapping and read back through the output mapping.
+func TestObjectMapping(outer *testing.T) {
+	if testing.Short() {
+		outer.Skip()
+	}
+
+	ctx := context.Background()
+	server := dbserver.GetDbServer(ctx)
+	driver := server.Driver()
+	defer func() { _ = driver.Close(ctx) }()
+	session := driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer func() { _ = session.Close(ctx) }()
+
+	cleanup := func(t *testing.T) {
+		result, err := session.Run(ctx, "MATCH (n:OMTest) DETACH DELETE n", nil)
+		assertNil(t, err)
+		_, err = result.Consume(ctx)
+		assertNil(t, err)
+	}
+	create := func(t *testing.T, props any) {
+		result, err := session.Run(ctx, "CREATE (n:OMTest) SET n = $props", map[string]any{"props": props})
+		assertNil(t, err)
+		_, err = result.Consume(ctx)
+		assertNil(t, err)
+	}
+	defer cleanup(outer)
+
+	outer.Run("CollectAs maps a node column into structs", func(t *testing.T) {
+		cleanup(t)
+		create(t, omPerson{Name: "Alice", Age: 30})
+		create(t, omPerson{Name: "Bob", Age: 40})
+
+		result, err := session.Run(ctx, "MATCH (n:OMTest) RETURN n ORDER BY n.name", nil)
+		assertNil(t, err)
+		people, err := neo4j.CollectAs[omPerson](ctx, result)
+		assertNil(t, err)
+		assertEquals(t, len(people), 2)
+		assertEquals(t, people[0], omPerson{Name: "Alice", Age: 30})
+		assertEquals(t, people[1], omPerson{Name: "Bob", Age: 40})
+	})
+
+	outer.Run("SingleAs maps a single node", func(t *testing.T) {
+		cleanup(t)
+		create(t, omPerson{Name: "Alice", Age: 30})
+
+		result, err := session.Run(ctx, "MATCH (n:OMTest) RETURN n", nil)
+		assertNil(t, err)
+		person, err := neo4j.SingleAs[omPerson](ctx, result)
+		assertNil(t, err)
+		assertEquals(t, person, omPerson{Name: "Alice", Age: 30})
+	})
+
+	outer.Run("As maps scalar columns by name", func(t *testing.T) {
+		cleanup(t)
+		create(t, omPerson{Name: "Alice", Age: 30})
+
+		result, err := session.Run(ctx, "MATCH (n:OMTest) RETURN n.name AS name, n.age AS age", nil)
+		assertNil(t, err)
+		record, err := result.Single(ctx)
+		assertNil(t, err)
+		person, err := neo4j.As[omPerson](record)
+		assertNil(t, err)
+		assertEquals(t, person, omPerson{Name: "Alice", Age: 30})
+	})
+
+	outer.Run("CollectRecordsAs maps ExecuteQuery results", func(t *testing.T) {
+		cleanup(t)
+		create(t, omPerson{Name: "Alice", Age: 30})
+
+		result, err := neo4j.ExecuteQuery(ctx, driver, "MATCH (n:OMTest) RETURN n", nil, neo4j.EagerResultTransformer)
+		assertNil(t, err)
+		people, err := neo4j.CollectRecordsAs[omPerson](result.Records)
+		assertNil(t, err)
+		assertEquals(t, len(people), 1)
+		assertEquals(t, people[0], omPerson{Name: "Alice", Age: 30})
+	})
+
+	outer.Run("time.Time property round-trips", func(t *testing.T) {
+		type event struct {
+			Name string    `neo4j:"name"`
+			At   time.Time `neo4j:"at"`
+		}
+		cleanup(t)
+		at := time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC)
+		create(t, event{Name: "launch", At: at})
+
+		result, err := session.Run(ctx, "MATCH (n:OMTest) RETURN n", nil)
+		assertNil(t, err)
+		got, err := neo4j.SingleAs[event](ctx, result)
+		assertNil(t, err)
+		assertEquals(t, got.Name, "launch")
+		assertTrue(t, got.At.Equal(at))
+	})
+
+	outer.Run("nested map maps into a nested struct", func(t *testing.T) {
+		type director struct {
+			Name string `neo4j:"name"`
+		}
+		type movie struct {
+			Title    string   `neo4j:"title"`
+			Director director `neo4j:"director"`
+		}
+		result, err := session.Run(ctx, "RETURN {title: 'Heat', director: {name: 'Mann'}} AS m", nil)
+		assertNil(t, err)
+		got, err := neo4j.SingleAs[movie](ctx, result)
+		assertNil(t, err)
+		assertEquals(t, got, movie{Title: "Heat", Director: director{Name: "Mann"}})
+	})
+
+	outer.Run("type mismatch returns an error", func(t *testing.T) {
+		cleanup(t)
+		create(t, omPerson{Name: "Alice", Age: 30})
+
+		type bad struct {
+			Age string `neo4j:"age"` // age is stored as an integer
+		}
+		result, err := session.Run(ctx, "MATCH (n:OMTest) RETURN n", nil)
+		assertNil(t, err)
+		_, err = neo4j.SingleAs[bad](ctx, result)
+		assertNotNil(t, err)
+	})
+}

--- a/neo4j/test-integration/mapping_test.go
+++ b/neo4j/test-integration/mapping_test.go
@@ -163,7 +163,7 @@ func TestObjectMapping(outer *testing.T) {
 		assertEquals(t, len(events), 2)
 		assertTrue(t, events[0].At.Equal(post))
 		assertTrue(t, events[1].At.Equal(pre))
-		assertFalse(t, events[0].At.Equal(events[1].At)) // genuinely two different instants
+		assertFalse(t, events[0].At.Equal(events[1].At))
 	})
 
 	outer.Run("maps a small graph of nodes and relationships", func(t *testing.T) {

--- a/neo4j/test-integration/mapping_test.go
+++ b/neo4j/test-integration/mapping_test.go
@@ -141,29 +141,28 @@ func TestObjectMapping(outer *testing.T) {
 		assertEquals(t, got, movie{Title: "Heat", Director: director{Name: "Mann"}})
 	})
 
-	outer.Run("DST-ambiguous local time round-trips both instants", func(t *testing.T) {
+	outer.Run("zoned datetimes with DST offsets round-trip", func(t *testing.T) {
 		type event struct {
 			Name string    `neo4j:"name"`
 			At   time.Time `neo4j:"at"`
 		}
 		berlin, err := time.LoadLocation("Europe/Berlin")
 		assertNil(t, err)
-		// On 2025-10-26 the Berlin clock falls back, so 02:30 local occurs twice.
-		pre := time.Date(2025, 10, 26, 0, 30, 0, 0, time.UTC).In(berlin)  // 02:30 CEST (UTC+2)
-		post := time.Date(2025, 10, 26, 1, 30, 0, 0, time.UTC).In(berlin) // 02:30 CET (UTC+1)
+		// Berlin is CEST (UTC+2) in summer and CET (UTC+1) in winter.
+		summer := time.Date(2025, 7, 1, 12, 0, 0, 0, berlin)
+		winter := time.Date(2025, 1, 1, 12, 0, 0, 0, berlin)
 
 		cleanup(t)
-		create(t, event{Name: "post", At: post})
-		create(t, event{Name: "pre", At: pre})
+		create(t, event{Name: "summer", At: summer})
+		create(t, event{Name: "winter", At: winter})
 
 		result, err := session.Run(ctx, "MATCH (n:OMTest) RETURN n ORDER BY n.name", nil)
 		assertNil(t, err)
 		events, err := neo4j.CollectAs[event](ctx, result)
 		assertNil(t, err)
 		assertEquals(t, len(events), 2)
-		assertTrue(t, events[0].At.Equal(post))
-		assertTrue(t, events[1].At.Equal(pre))
-		assertFalse(t, events[0].At.Equal(events[1].At))
+		assertTrue(t, events[0].At.Equal(summer))
+		assertTrue(t, events[1].At.Equal(winter))
 	})
 
 	outer.Run("maps a small graph of nodes and relationships", func(t *testing.T) {


### PR DESCRIPTION
Closes: DRIVERS-103

Adds the output side of object mapping (preview): query results map into user structs, reversing the struct-parameter mapping from #695. 

Fields follow the same `neo4j` tags (`neo4j:"name"` renames, `neo4j:"-"` skips). A record with a single node, relationship, or map column maps that value's properties directly; otherwise columns map by name. Missing or null properties leave zero values, unmatched properties are ignored.

Entry points: 
- `As[T]` (one record)
- `CollectAs[T]` / `SingleAs[T]` (streamed `Result`)
- `CollectRecordsAs[T]` (`ExecuteQuery`'s `EagerResult.Records`)

## Usage

```go
type Movie struct {
    Title    string `neo4j:"title"`
    Released int64  `neo4j:"released"`
}

result, err := session.Run(ctx, "MATCH (m:Movie) RETURN m", nil)
if err != nil {
    return err
}
movies, err := neo4j.CollectAs[Movie](ctx, result)
```

## Before / after

**As** - one record:
```go
// before
node, _, err := neo4j.GetRecordValue[neo4j.Node](record, "m")
if err != nil {
    return err
}
movie := Movie{Title: node.Props["title"].(string), Released: node.Props["released"].(int64)}

// after
movie, err := neo4j.As[Movie](record)
```

**CollectAs** - every record in a Result:
```go
// before
movies, err := neo4j.CollectT(ctx, result, func(r *neo4j.Record) (Movie, error) {
    n, _, err := neo4j.GetRecordValue[neo4j.Node](r, "m")
    if err != nil {
        return Movie{}, err
    }
    return Movie{Title: n.Props["title"].(string), Released: n.Props["released"].(int64)}, nil
})

// after
movies, err := neo4j.CollectAs[Movie](ctx, result)
```

**SingleAs** - the single record in a Result:
```go
// before
movie, err := neo4j.SingleT(ctx, result, func(r *neo4j.Record) (Movie, error) {
    n, _, err := neo4j.GetRecordValue[neo4j.Node](r, "m")
    if err != nil {
        return Movie{}, err
    }
    return Movie{Title: n.Props["title"].(string), Released: n.Props["released"].(int64)}, nil
})

// after
movie, err := neo4j.SingleAs[Movie](ctx, result)
```

**CollectRecordsAs** - ExecuteQuery's eager records:
```go
// before
res, err := neo4j.ExecuteQuery(ctx, driver, cypher, params, neo4j.EagerResultTransformer)
if err != nil {
    return err
}
movies := make([]Movie, len(res.Records))
for i, r := range res.Records {
    n, _, err := neo4j.GetRecordValue[neo4j.Node](r, "m")
    if err != nil {
        return err
    }
    movies[i] = Movie{Title: n.Props["title"].(string), Released: n.Props["released"].(int64)}
}

// after
res, err := neo4j.ExecuteQuery(ctx, driver, cypher, params, neo4j.EagerResultTransformer)
if err != nil {
    return err
}
movies, err := neo4j.CollectRecordsAs[Movie](res.Records)
```
