### PR TITLE
Add client-side property encryption (preview)

### DIFF
--- a/neo4j/config/driver.go
+++ b/neo4j/config/driver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/auth"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/log"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/notifications"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/propertyencryption"
 )
 
 // A Config contains options that can be used to customize certain
@@ -216,6 +217,26 @@ type Config struct {
 	// for large data transfers. Currently, the default value is 8 KiB, but may change in the future.
 	// Set to 0 or below to disable buffering.
 	ReadBufferSize int
+	// PropertyEncryptionProfiles configures encryption of individual property values,
+	// reached through Driver.PropertyEncryption. Each profile names the key management to
+	// use, and every encrypted value records which profile produced it.
+	//
+	// Profile names must be unique, and must match on any other driver expected to decrypt
+	// those values.
+	//
+	//	c.PropertyEncryptionProfiles = []propertyencryption.Profile{
+	//		propertyencryption.EnvelopeProfile{
+	//			Name:                 "customer-pii",
+	//			EncapsulationService: keyService,
+	//			KeyRepository:        keyRepository,
+	//		},
+	//	}
+	//
+	// This is part of the property encryption preview feature (see README on what it means
+	// in terms of support and compatibility guarantees).
+	//
+	// default: no profiles
+	PropertyEncryptionProfiles []propertyencryption.Profile
 }
 
 // ServerAddressResolver is a function type that defines the resolver function used by the routing driver to

--- a/neo4j/driver.go
+++ b/neo4j/driver.go
@@ -35,6 +35,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/pool"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/router"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/log"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/propertyencryption"
 )
 
 // AccessMode defines modes that routing driver decides to which cluster member
@@ -101,6 +102,18 @@ type Driver interface {
 	// deployment
 	// Contexts terminating too early negatively affect connection pooling and degrade the driver performance.
 	GetServerInfo(ctx context.Context) (ServerInfo, error)
+	// PropertyEncryption encrypts and decrypts individual property values, configured by
+	// config.Config.PropertyEncryptionProfiles. It needs no connection and is unaffected by
+	// Close.
+	//
+	//	encrypted, err := driver.PropertyEncryption().Encrypt(ctx, propertyencryption.EncryptRequest{
+	//		Value: "078-05-1120",
+	//		Key:   propertyencryption.KeyAlias("customer-pii"),
+	//	})
+	//
+	// Property encryption is a preview feature (see README on what it means in terms of
+	// support and compatibility guarantees).
+	PropertyEncryption() *propertyencryption.Encryption
 }
 
 // DriverWithContext is an alias for Driver to maintain backward compatibility
@@ -212,6 +225,10 @@ func NewDriver(target string, auth auth.TokenManager, configurers ...func(*confi
 		configurer(d.config)
 	}
 	if err := validateAndNormaliseConfig(d.config); err != nil {
+		return nil, err
+	}
+	d.propertyEncryption, err = propertyencryption.New(d.config.PropertyEncryptionProfiles)
+	if err != nil {
 		return nil, err
 	}
 	if auth == nil {
@@ -362,10 +379,15 @@ type driver struct {
 	executeQueryBookmarkManager BookmarkManager
 	auth                        auth.TokenManager
 	cache                       *homedb.Cache
+	propertyEncryption          *propertyencryption.Encryption
 }
 
 func (d *driver) Target() url.URL {
 	return *d.target
+}
+
+func (d *driver) PropertyEncryption() *propertyencryption.Encryption {
+	return d.propertyEncryption
 }
 
 func (d *driver) NewSession(ctx context.Context, config SessionConfig) Session {

--- a/neo4j/driver_test.go
+++ b/neo4j/driver_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/router"
 	. "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/testutil"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/propertyencryption"
 )
 
 func assertNoRouter(t *testing.T, d Driver) {
@@ -778,6 +779,10 @@ func (d *driverDelegate) Close(ctx context.Context) error {
 
 func (d *driverDelegate) IsEncrypted() bool {
 	return d.delegate.IsEncrypted()
+}
+
+func (d *driverDelegate) PropertyEncryption() *propertyencryption.Encryption {
+	return d.delegate.PropertyEncryption()
 }
 
 func (d *driverDelegate) GetServerInfo(ctx context.Context) (ServerInfo, error) {

--- a/neo4j/error.go
+++ b/neo4j/error.go
@@ -24,6 +24,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/errorutil"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/retry"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/propertyencryption"
 )
 
 // IsRetryable determines whether an operation can be retried based on the error
@@ -49,6 +50,12 @@ type UsageError = errorutil.UsageError
 type ConnectivityError = errorutil.ConnectivityError
 
 type TransactionExecutionLimit = errorutil.TransactionExecutionLimit
+
+// PropertyEncryptionError is returned when a property value cannot be encrypted or decrypted.
+//
+// This is part of the property encryption preview feature (see README on what it means in
+// terms of support and compatibility guarantees).
+type PropertyEncryptionError = propertyencryption.Error
 
 type InvalidAuthenticationError struct {
 	inner error
@@ -83,6 +90,15 @@ func IsConnectivityError(err error) bool {
 // IsTransactionExecutionLimit returns true if the provided error is an instance of TransactionExecutionLimit.
 func IsTransactionExecutionLimit(err error) bool {
 	_, is := err.(*TransactionExecutionLimit)
+	return is
+}
+
+// IsPropertyEncryptionError returns true if the provided error is an instance of PropertyEncryptionError.
+//
+// This is part of the property encryption preview feature (see README on what it means in
+// terms of support and compatibility guarantees).
+func IsPropertyEncryptionError(err error) bool {
+	_, is := err.(*PropertyEncryptionError)
 	return is
 }
 

--- a/neo4j/internal/packstream/unpacker.go
+++ b/neo4j/internal/packstream/unpacker.go
@@ -62,6 +62,11 @@ func (u *Unpacker) setErr(err error) {
 	}
 }
 
+// Remaining returns the number of unconsumed bytes.
+func (u *Unpacker) Remaining() uint32 {
+	return u.len - u.off
+}
+
 func (u *Unpacker) Next() {
 	i := u.pop()
 	u.mrk = markers[i]

--- a/neo4j/internal/propertyencryption/cache.go
+++ b/neo4j/internal/propertyencryption/cache.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"container/list"
+	"sync"
+	"time"
+
+	itime "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/time"
+)
+
+// Default cache settings, per encryption profile.
+const (
+	DefaultKeyAliasCacheTTL  = 15 * time.Second
+	DefaultKeyAliasCacheSize = 100
+	DefaultKeyCacheTTL       = 15 * time.Minute
+	DefaultKeyCacheSize      = 100
+)
+
+// Cache holds at most maxSize entries for ttl each, evicting least recently used first.
+// Expiry is applied during lookups and insertions rather than by a background goroutine.
+// It is safe for concurrent use.
+type Cache[V any] struct {
+	mutex   sync.Mutex
+	ttl     time.Duration
+	maxSize int
+	entries map[string]*list.Element
+	// order holds *cacheEntry[V], most recently used at the front.
+	order *list.List
+}
+
+type cacheEntry[V any] struct {
+	key     string
+	value   V
+	expires time.Time
+}
+
+// NewCache returns a cache holding at most maxSize entries for ttl each.
+func NewCache[V any](ttl time.Duration, maxSize int) *Cache[V] {
+	return &Cache[V]{
+		ttl:     ttl,
+		maxSize: maxSize,
+		entries: make(map[string]*list.Element),
+		order:   list.New(),
+	}
+}
+
+// Get returns the value stored under key, if it is present and has not expired.
+func (c *Cache[V]) Get(key string) (V, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	element, ok := c.entries[key]
+	if !ok {
+		var zero V
+		return zero, false
+	}
+	entry := element.Value.(*cacheEntry[V])
+	if c.hasExpired(entry) {
+		c.remove(element)
+		var zero V
+		return zero, false
+	}
+	c.order.MoveToFront(element)
+	return entry.value, true
+}
+
+// Put stores value under key, replacing any existing entry and refreshing its expiry.
+func (c *Cache[V]) Put(key string, value V) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	expires := itime.Now().Add(c.ttl)
+	if element, ok := c.entries[key]; ok {
+		entry := element.Value.(*cacheEntry[V])
+		entry.value = value
+		entry.expires = expires
+		c.order.MoveToFront(element)
+		return
+	}
+
+	c.entries[key] = c.order.PushFront(&cacheEntry[V]{key: key, value: value, expires: expires})
+	c.evict()
+}
+
+// len returns the number of entries held, including any that have expired but not yet been
+// discarded.
+func (c *Cache[V]) len() int {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.order.Len()
+}
+
+// evict brings the cache back within its size limit, discarding expired entries in
+// preference to live ones.
+func (c *Cache[V]) evict() {
+	for c.order.Len() > c.maxSize {
+		oldest := c.order.Back()
+		for element := oldest; element != nil; element = element.Prev() {
+			if c.hasExpired(element.Value.(*cacheEntry[V])) {
+				oldest = element
+				break
+			}
+		}
+		c.remove(oldest)
+	}
+}
+
+func (c *Cache[V]) hasExpired(entry *cacheEntry[V]) bool {
+	return !itime.Now().Before(entry.expires)
+}
+
+func (c *Cache[V]) remove(element *list.Element) {
+	delete(c.entries, element.Value.(*cacheEntry[V]).key)
+	c.order.Remove(element)
+}

--- a/neo4j/internal/propertyencryption/cache_test.go
+++ b/neo4j/internal/propertyencryption/cache_test.go
@@ -1,0 +1,214 @@
+//go:build internal_neo4j_go_driver_time_mock
+
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	itime "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/time"
+)
+
+// The mock clock is process wide, so these tests must not run in parallel.
+
+// TestCacheStoresAndReturns covers lookup, replacement and misses.
+func TestCacheStoresAndReturns(t *testing.T) {
+	cache := NewCache[string](time.Minute, 10)
+
+	if _, ok := cache.Get("absent"); ok {
+		t.Error("an empty cache returned a value")
+	}
+
+	cache.Put("a", "first")
+	got, ok := cache.Get("a")
+	if !ok || got != "first" {
+		t.Errorf("got %q (present: %t), want %q", got, ok, "first")
+	}
+
+	cache.Put("a", "second")
+	got, _ = cache.Get("a")
+	if got != "second" {
+		t.Errorf("got %q after replacing, want %q", got, "second")
+	}
+	if cache.len() != 1 {
+		t.Errorf("replacing grew the cache to %d entries", cache.len())
+	}
+
+}
+
+// TestCacheExpiresEntries bounds how long a decapsulated key is held.
+func TestCacheExpiresEntries(t *testing.T) {
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+
+	cache := NewCache[string](DefaultKeyCacheTTL, 10)
+	cache.Put("a", "value")
+
+	itime.ForceTickTime(DefaultKeyCacheTTL - time.Nanosecond)
+	if _, ok := cache.Get("a"); !ok {
+		t.Fatal("the entry expired before its ttl elapsed")
+	}
+
+	itime.ForceTickTime(time.Nanosecond)
+	if _, ok := cache.Get("a"); ok {
+		t.Fatal("the entry survived its ttl")
+	}
+	if cache.len() != 0 {
+		t.Errorf("the expired entry was not discarded, %d remain", cache.len())
+	}
+}
+
+// TestCacheGetDoesNotExtendTheTtl checks the ttl is measured from when an entry was stored,
+// not from when it was last read.
+func TestCacheGetDoesNotExtendTheTtl(t *testing.T) {
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+
+	cache := NewCache[string](10*time.Second, 10)
+	cache.Put("a", "value")
+
+	for i := 0; i < 9; i++ {
+		itime.ForceTickTime(time.Second)
+		if _, ok := cache.Get("a"); !ok {
+			t.Fatalf("the entry expired after %d seconds", i+1)
+		}
+	}
+
+	itime.ForceTickTime(time.Second)
+	if _, ok := cache.Get("a"); ok {
+		t.Fatal("reading the entry extended its ttl past 10 seconds")
+	}
+}
+
+// TestCachePutRefreshesTheTtl checks storing an entry again restarts its ttl.
+func TestCachePutRefreshesTheTtl(t *testing.T) {
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+
+	cache := NewCache[string](10*time.Second, 10)
+	cache.Put("a", "value")
+
+	itime.ForceTickTime(9 * time.Second)
+	cache.Put("a", "value")
+
+	itime.ForceTickTime(9 * time.Second)
+	if _, ok := cache.Get("a"); !ok {
+		t.Fatal("storing the entry again did not refresh its ttl")
+	}
+}
+
+// TestCacheEvictsLeastRecentlyUsed checks eviction order once the cache is full.
+func TestCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+
+	cache := NewCache[string](time.Hour, 3)
+	cache.Put("a", "1")
+	cache.Put("b", "2")
+	cache.Put("c", "3")
+
+	// Reading "a" makes "b" the least recently used.
+	if _, ok := cache.Get("a"); !ok {
+		t.Fatal("a is missing")
+	}
+	cache.Put("d", "4")
+
+	if cache.len() != 3 {
+		t.Fatalf("the cache holds %d entries, want 3", cache.len())
+	}
+	if _, ok := cache.Get("b"); ok {
+		t.Error("b survived, it was the least recently used")
+	}
+	for _, key := range []string{"a", "c", "d"} {
+		if _, ok := cache.Get(key); !ok {
+			t.Errorf("%s was evicted", key)
+		}
+	}
+}
+
+// TestCacheEvictsExpiredBeforeLive checks an expired entry is evicted ahead of a live one.
+// The read is what makes the two orderings disagree; without it the least recently used entry
+// is also the oldest and plain eviction would pick it anyway.
+func TestCacheEvictsExpiredBeforeLive(t *testing.T) {
+	itime.ForceFreezeTime()
+	defer itime.ForceUnfreezeTime()
+
+	cache := NewCache[string](10*time.Second, 2)
+	cache.Put("stale", "1") // expires at 10s
+
+	itime.ForceTickTime(2 * time.Second)
+	cache.Put("live", "2") // expires at 12s
+
+	// Reading "stale" makes it the more recently used, so "live" is now at the least
+	// recently used end despite being the younger entry.
+	if _, ok := cache.Get("stale"); !ok {
+		t.Fatal("stale is missing")
+	}
+
+	itime.ForceTickTime(9 * time.Second) // now 11s: "stale" has expired, "live" has not
+	cache.Put("new", "3")
+
+	if cache.len() != 2 {
+		t.Fatalf("the cache holds %d entries, want 2", cache.len())
+	}
+	if _, ok := cache.Get("stale"); ok {
+		t.Error("the expired entry survived")
+	}
+	if _, ok := cache.Get("live"); !ok {
+		t.Error("the live entry was evicted in favour of an expired one")
+	}
+}
+
+// TestCacheNeverExceedsItsSize checks the size bound holds across many insertions.
+func TestCacheNeverExceedsItsSize(t *testing.T) {
+	cache := NewCache[int](time.Hour, 5)
+	for i := 0; i < 100; i++ {
+		cache.Put(fmt.Sprintf("key-%d", i), i)
+		if cache.len() > 5 {
+			t.Fatalf("the cache grew to %d entries after %d insertions", cache.len(), i+1)
+		}
+	}
+}
+
+// TestCacheIsSafeForConcurrentUse checks concurrent access under the race detector.
+func TestCacheIsSafeForConcurrentUse(t *testing.T) {
+	cache := NewCache[int](time.Hour, 16)
+
+	var waitGroup sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		waitGroup.Add(1)
+		go func(worker int) {
+			defer waitGroup.Done()
+			for i := 0; i < 500; i++ {
+				key := fmt.Sprintf("key-%d", i%32)
+				cache.Put(key, i)
+				cache.Get(key)
+				cache.len()
+			}
+		}(worker)
+	}
+	waitGroup.Wait()
+
+	if cache.len() > 16 {
+		t.Errorf("the cache holds %d entries, want at most 16", cache.len())
+	}
+}

--- a/neo4j/internal/propertyencryption/crypto.go
+++ b/neo4j/internal/propertyencryption/crypto.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+)
+
+const (
+	// KeySize is the AES key size in bytes.
+	KeySize = 32
+	// IVSize is the AES-GCM initialisation vector size in bytes.
+	IVSize = 12
+	// TagSize is the AES-GCM authentication tag size in bytes.
+	TagSize = 16
+	// keyDerivationInfo separates property encryption keys from other keys derived from the
+	// same data encryption key.
+	keyDerivationInfo = "neo4j/property-encryption/v1"
+)
+
+// ErrAuthentication reports a cipher output that failed authentication, which AES-GCM cannot
+// attribute to the wrong key, the wrong AAD, or tampering.
+var ErrAuthentication = errors.New("the encrypted value could not be authenticated, " +
+	"the key or the additional authenticated data may be wrong, or the value may have been altered")
+
+// DataKey is an AES-GCM cipher derived from a data encryption key. Derivation happens once
+// per data encryption key, keeping HKDF and the AES key schedule off the path of every call.
+type DataKey struct {
+	aead cipher.AEAD
+}
+
+// DeriveDataKey expands a data encryption key into the key used for property encryption,
+// using HKDF-SHA256 with an empty salt.
+func DeriveDataKey(dek []byte) (*DataKey, error) {
+	if len(dek) == 0 {
+		return nil, errors.New("the key encapsulation service returned an empty data encryption key")
+	}
+	derived, err := hkdf.Key(sha256.New, dek, nil, keyDerivationInfo, KeySize)
+	if err != nil {
+		return nil, fmt.Errorf("deriving the property encryption key: %w", err)
+	}
+	block, err := aes.NewCipher(derived)
+	if err != nil {
+		return nil, fmt.Errorf("preparing the property encryption cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("preparing the property encryption cipher: %w", err)
+	}
+	return &DataKey{aead: aead}, nil
+}
+
+// Seal encrypts plaintext, returning the ciphertext with the authentication tag appended.
+// aad may be empty.
+func (k *DataKey) Seal(iv, plaintext, aad []byte) ([]byte, error) {
+	if len(iv) != IVSize {
+		return nil, fmt.Errorf("the initialisation vector must be %d bytes but is %d", IVSize, len(iv))
+	}
+	return k.aead.Seal(nil, iv, plaintext, aad), nil
+}
+
+// Open authenticates and decrypts a cipher output. aad must be the bytes supplied to Seal.
+func (k *DataKey) Open(iv, cipherOutput, aad []byte) ([]byte, error) {
+	if len(iv) != IVSize {
+		return nil, fmt.Errorf("the initialisation vector must be %d bytes but is %d", IVSize, len(iv))
+	}
+	if len(cipherOutput) < TagSize {
+		return nil, fmt.Errorf("the cipher output must be at least %d bytes but is %d",
+			TagSize, len(cipherOutput))
+	}
+	plaintext, err := k.aead.Open(nil, iv, cipherOutput, aad)
+	if err != nil {
+		// Reporting which of the possible causes applies would leak information.
+		return nil, ErrAuthentication
+	}
+	return plaintext, nil
+}
+
+// NewDEK draws a fresh data encryption key.
+func NewDEK() ([]byte, error) {
+	dek := make([]byte, KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		return nil, fmt.Errorf("generating a data encryption key: %w", err)
+	}
+	return dek, nil
+}
+
+// WrapKey encapsulates a data encryption key under a local key encryption key, returning the
+// encapsulation and the initialisation vector needed to reverse it.
+//
+// The key encryption key is used directly rather than through HKDF, which the encapsulation
+// format requires for a key to remain usable across drivers.
+func WrapKey(kek, dek []byte) (encapsulation, iv []byte, err error) {
+	aead, err := localAEAD(kek)
+	if err != nil {
+		return nil, nil, err
+	}
+	iv, err = NewIV()
+	if err != nil {
+		return nil, nil, err
+	}
+	return aead.Seal(nil, iv, dek, nil), iv, nil
+}
+
+// UnwrapKey reverses WrapKey.
+func UnwrapKey(kek, encapsulation, iv []byte) ([]byte, error) {
+	aead, err := localAEAD(kek)
+	if err != nil {
+		return nil, err
+	}
+	if len(iv) != IVSize {
+		return nil, fmt.Errorf("the key encapsulation initialisation vector must be %d bytes but is %d",
+			IVSize, len(iv))
+	}
+	dek, err := aead.Open(nil, iv, encapsulation, nil)
+	if err != nil {
+		return nil, ErrAuthentication
+	}
+	return dek, nil
+}
+
+func localAEAD(kek []byte) (cipher.AEAD, error) {
+	if len(kek) != KeySize {
+		return nil, fmt.Errorf("the key encryption key must be %d bytes but is %d", KeySize, len(kek))
+	}
+	block, err := aes.NewCipher(kek)
+	if err != nil {
+		return nil, fmt.Errorf("preparing the key encapsulation cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("preparing the key encapsulation cipher: %w", err)
+	}
+	return aead, nil
+}
+
+// NewIV draws a fresh initialisation vector. AES-GCM security depends on never reusing one
+// with the same key, so the source must stay cryptographically secure.
+func NewIV() ([]byte, error) {
+	iv := make([]byte, IVSize)
+	if _, err := rand.Read(iv); err != nil {
+		return nil, fmt.Errorf("generating an initialisation vector: %w", err)
+	}
+	return iv, nil
+}

--- a/neo4j/internal/propertyencryption/crypto_test.go
+++ b/neo4j/internal/propertyencryption/crypto_test.go
@@ -1,0 +1,440 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"testing"
+)
+
+// The key material TestKit's deterministic fixtures are built with.
+const (
+	deterministicKEK = "f0de94eb5a2d4da6f17ea74b14e9e556" +
+		"d367cb22b053e01798aa2677bfcf5761"
+	deterministicEncapsulation = "9e1f562dee78c6c2d47f4378d2949774" +
+		"c3a56339b824abaf276c4ca7fcf5a8cd" +
+		"63976ae348104d6757b9e419bf9ea325"
+	deterministicKeyIV  = "P02Pc7vInYIQ7k93"
+	deterministicKeyID  = "testkit-key"
+	deterministicName   = "deterministic"
+	deterministicDEKHex = "9a108cc9bfff252dba716c60dfb3dfcc1194b03b24c1373bcf266882f3d6156b"
+)
+
+type deterministicFixture struct {
+	value     any
+	iv        string
+	aad       any
+	encrypted string
+}
+
+// TestKit's deterministic fixtures.
+var deterministicFixtures = []deterministicFixture{
+	{
+		value: true,
+		iv:    "000102030405060708090a0b",
+		encrypted: "01b6658d64657465726d696e69737469" +
+			"63cc11877fe22670d0d3433e2a9c4dd5" +
+			"fd17994b87424f4f4c45414e0100a282" +
+			"6976cc0c000102030405060708090a0b" +
+			"866b65795f69648b746573746b69742d" +
+			"6b6579",
+	},
+	{
+		value: int64(32768),
+		iv:    "0c0d0e0f1011121314151617",
+		encrypted: "01b6658d64657465726d696e69737469" +
+			"63cc153022e4a29e68285f6fddac8604" +
+			"5e26b63ba5da995087494e5445474552" +
+			"0100a2826976cc0c0c0d0e0f10111213" +
+			"14151617866b65795f69648b74657374" +
+			"6b69742d6b6579",
+	},
+	{
+		value: 3.25,
+		iv:    "18191a1b1c1d1e1f20212223",
+		encrypted: "01b6658d64657465726d696e69737469" +
+			"63cc1959a942a76621fe2aa1f2d388ab" +
+			"4e91010e4b39b48520328e9585464c4f" +
+			"41540100a2826976cc0c18191a1b1c1d" +
+			"1e1f20212223866b65795f69648b7465" +
+			"73746b69742d6b6579",
+	},
+	{
+		value: "hello world",
+		iv:    "2425262728292a2b2c2d2e2f",
+		encrypted: "01b6658d64657465726d696e69737469" +
+			"63cc1c19b0e5f67ee23e78eb73899546" +
+			"4420a6fd3626fc052501e325cee12586" +
+			"535452494e470100a2826976cc0c2425" +
+			"262728292a2b2c2d2e2f866b65795f69" +
+			"648b746573746b69742d6b6579",
+	},
+	{
+		value: []byte{0, 1, 2},
+		iv:    "303132333435363738393a3b",
+		encrypted: "01b6658d64657465726d696e69737469" +
+			"63cc1529ea2acd117b82841138917fc8" +
+			"9cdf15cb4f0d809d8542595445530100" +
+			"a2826976cc0c30313233343536373839" +
+			"3a3b866b65795f69648b746573746b69" +
+			"742d6b6579",
+	},
+	{
+		value: []any{int64(1), int64(2)},
+		iv:    "3c3d3e3f4041424344454647",
+		encrypted: "01b6658d64657465726d696e69737469" +
+			"63cc13b5011505031e789718bd92136f" +
+			"766baa191036844c4953540100a28269" +
+			"76cc0c3c3d3e3f404142434445464786" +
+			"6b65795f69648b746573746b69742d6b" +
+			"6579",
+	},
+	{
+		value: "aad-bound",
+		iv:    "48494a4b4c4d4e4f50515253",
+		aad:   "row-42",
+		encrypted: "01b6658d64657465726d696e69737469" +
+			"63cc1a3a8af0d3820a0a549d75e42e59" +
+			"6a18ff85ee74fb51dce4bc0300865354" +
+			"52494e470100a583616164cc0786726f" +
+			"772d3432d0196161645f656e636f6469" +
+			"6e675f736368656d655f6d616a6f7201" +
+			"d0196161645f656e636f64696e675f73" +
+			"6368656d655f6d696e6f7200826976cc" +
+			"0c48494a4b4c4d4e4f50515253866b65" +
+			"795f69648b746573746b69742d6b6579",
+	},
+}
+
+// TestUnwrapKeyMatchesFixture checks the local key encapsulation format, which other drivers
+// must be able to produce and consume.
+func TestUnwrapKeyMatchesFixture(t *testing.T) {
+	t.Parallel()
+
+	dek := unwrapFixtureKey(t)
+	if got := hex.EncodeToString(dek); got != deterministicDEKHex {
+		t.Fatalf("unwrapped to %s, want %s", got, deterministicDEKHex)
+	}
+}
+
+// TestWrapKeyRoundTrip covers wrapping and unwrapping a freshly generated key.
+func TestWrapKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	kek := mustHex(t, deterministicKEK)
+	dek, err := NewDEK()
+	if err != nil {
+		t.Fatalf("NewDEK returned %v", err)
+	}
+
+	encapsulation, iv, err := WrapKey(kek, dek)
+	if err != nil {
+		t.Fatalf("WrapKey returned %v", err)
+	}
+	if len(iv) != IVSize {
+		t.Errorf("iv is %d bytes, want %d", len(iv), IVSize)
+	}
+	if len(encapsulation) != KeySize+TagSize {
+		t.Errorf("encapsulation is %d bytes, want %d", len(encapsulation), KeySize+TagSize)
+	}
+
+	unwrapped, err := UnwrapKey(kek, encapsulation, iv)
+	if err != nil {
+		t.Fatalf("UnwrapKey returned %v", err)
+	}
+	if !bytes.Equal(unwrapped, dek) {
+		t.Errorf("unwrapped to %x, want %x", unwrapped, dek)
+	}
+}
+
+// TestWrapKeyRejects covers a wrong key, a wrong size and a tampered encapsulation.
+func TestWrapKeyRejects(t *testing.T) {
+	t.Parallel()
+
+	kek := mustHex(t, deterministicKEK)
+	encapsulation := mustHex(t, deterministicEncapsulation)
+	iv := mustBase64(t, deterministicKeyIV)
+
+	t.Run("short key encryption key", func(t *testing.T) {
+		t.Parallel()
+		if _, _, err := WrapKey(kek[:16], make([]byte, KeySize)); err == nil {
+			t.Fatal("WrapKey accepted a 128 bit key encryption key")
+		}
+	})
+	t.Run("wrong key encryption key", func(t *testing.T) {
+		t.Parallel()
+		wrong := append([]byte(nil), kek...)
+		wrong[0] ^= 0xff
+		_, err := UnwrapKey(wrong, encapsulation, iv)
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("UnwrapKey returned %v, want ErrAuthentication", err)
+		}
+	})
+	t.Run("tampered encapsulation", func(t *testing.T) {
+		t.Parallel()
+		tampered := append([]byte(nil), encapsulation...)
+		tampered[0] ^= 0xff
+		_, err := UnwrapKey(kek, tampered, iv)
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("UnwrapKey returned %v, want ErrAuthentication", err)
+		}
+	})
+	t.Run("wrong iv size", func(t *testing.T) {
+		t.Parallel()
+		if _, err := UnwrapKey(kek, encapsulation, iv[:8]); err == nil {
+			t.Fatal("UnwrapKey accepted an 8 byte iv")
+		}
+	})
+}
+
+// TestEncryptsToKnownBytes checks the exact bytes produced with the key and initialisation
+// vector both pinned, covering value encoding, the cipher, metadata and structure encoding.
+func TestEncryptsToKnownBytes(t *testing.T) {
+	t.Parallel()
+
+	key, err := DeriveDataKey(unwrapFixtureKey(t))
+	if err != nil {
+		t.Fatalf("DeriveDataKey returned %v", err)
+	}
+
+	for _, fixture := range deterministicFixtures {
+		t.Run(fixture.encrypted[:24], func(t *testing.T) {
+			t.Parallel()
+
+			encoded, err := EncodeValue(fixture.value)
+			if err != nil {
+				t.Fatalf("EncodeValue(%#v) returned %v", fixture.value, err)
+			}
+
+			var metadata Metadata
+			metadata.SetString(MetadataKeyID, deterministicKeyID)
+			iv := mustHex(t, fixture.iv)
+			metadata.SetBytes(MetadataIV, iv)
+
+			var aad []byte
+			if fixture.aad != nil {
+				encodedAAD, err := EncodeAAD(fixture.aad)
+				if err != nil {
+					t.Fatalf("EncodeAAD(%#v) returned %v", fixture.aad, err)
+				}
+				aad = encodedAAD.Bytes
+				metadata.SetBytes(MetadataAAD, aad)
+				metadata.SetInt(MetadataAADEncodingSchemeMajor, int64(encodedAAD.Baseline.Major))
+				metadata.SetInt(MetadataAADEncodingSchemeMinor, int64(encodedAAD.Baseline.Minor))
+			}
+
+			cipherOutput, err := key.Seal(iv, encoded.Bytes, aad)
+			if err != nil {
+				t.Fatalf("Seal returned %v", err)
+			}
+
+			got, err := EncodeEncrypted(Encrypted{
+				ProfileName:  deterministicName,
+				CipherOutput: cipherOutput,
+				TypeName:     encoded.TypeName,
+				Baseline:     encoded.Baseline,
+				Metadata:     metadata,
+			})
+			if err != nil {
+				t.Fatalf("EncodeEncrypted returned %v", err)
+			}
+			if hex.EncodeToString(got) != fixture.encrypted {
+				t.Errorf("encrypted %#v to\n%x\nwant\n%s", fixture.value, got, fixture.encrypted)
+			}
+		})
+	}
+}
+
+// TestDecryptsKnownBytes is the reverse of TestEncryptsToKnownBytes.
+func TestDecryptsKnownBytes(t *testing.T) {
+	t.Parallel()
+
+	key, err := DeriveDataKey(unwrapFixtureKey(t))
+	if err != nil {
+		t.Fatalf("DeriveDataKey returned %v", err)
+	}
+
+	for _, fixture := range deterministicFixtures {
+		t.Run(fixture.encrypted[:24], func(t *testing.T) {
+			t.Parallel()
+
+			encrypted, err := DecodeEncrypted(mustHex(t, fixture.encrypted))
+			if err != nil {
+				t.Fatalf("DecodeEncrypted returned %v", err)
+			}
+			iv, _ := encrypted.Metadata.Bytes(MetadataIV)
+			aad, _ := encrypted.Metadata.Bytes(MetadataAAD)
+
+			plaintext, err := key.Open(iv, encrypted.CipherOutput, aad)
+			if err != nil {
+				t.Fatalf("Open returned %v", err)
+			}
+			decoded, err := DecodeValue(plaintext, encrypted.TypeName, encrypted.Baseline)
+			if err != nil {
+				t.Fatalf("DecodeValue returned %v", err)
+			}
+			if !sameValue(decoded, fixture.value) {
+				t.Errorf("decrypted to %#v, want %#v", decoded, fixture.value)
+			}
+		})
+	}
+}
+
+// TestOpenRejects covers every way authentication can fail.
+func TestOpenRejects(t *testing.T) {
+	t.Parallel()
+
+	key, err := DeriveDataKey(unwrapFixtureKey(t))
+	if err != nil {
+		t.Fatalf("DeriveDataKey returned %v", err)
+	}
+	iv := mustHex(t, "000102030405060708090a0b")
+	cipherOutput, err := key.Seal(iv, []byte{0xc3}, []byte("context"))
+	if err != nil {
+		t.Fatalf("Seal returned %v", err)
+	}
+
+	t.Run("wrong aad", func(t *testing.T) {
+		t.Parallel()
+		_, err := key.Open(iv, cipherOutput, []byte("other"))
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("Open returned %v, want ErrAuthentication", err)
+		}
+	})
+	t.Run("missing aad", func(t *testing.T) {
+		t.Parallel()
+		_, err := key.Open(iv, cipherOutput, nil)
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("Open returned %v, want ErrAuthentication", err)
+		}
+	})
+	t.Run("wrong iv", func(t *testing.T) {
+		t.Parallel()
+		other := mustHex(t, "0c0d0e0f1011121314151617")
+		_, err := key.Open(other, cipherOutput, []byte("context"))
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("Open returned %v, want ErrAuthentication", err)
+		}
+	})
+	t.Run("tampered ciphertext", func(t *testing.T) {
+		t.Parallel()
+		tampered := append([]byte(nil), cipherOutput...)
+		tampered[0] ^= 0xff
+		_, err := key.Open(iv, tampered, []byte("context"))
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("Open returned %v, want ErrAuthentication", err)
+		}
+	})
+	t.Run("tampered tag", func(t *testing.T) {
+		t.Parallel()
+		tampered := append([]byte(nil), cipherOutput...)
+		tampered[len(tampered)-1] ^= 0xff
+		_, err := key.Open(iv, tampered, []byte("context"))
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("Open returned %v, want ErrAuthentication", err)
+		}
+	})
+	t.Run("wrong key", func(t *testing.T) {
+		t.Parallel()
+		other, err := DeriveDataKey([]byte("a different data encryption key!"))
+		if err != nil {
+			t.Fatalf("DeriveDataKey returned %v", err)
+		}
+		_, err = other.Open(iv, cipherOutput, []byte("context"))
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("Open returned %v, want ErrAuthentication", err)
+		}
+	})
+	t.Run("cipher output shorter than the tag", func(t *testing.T) {
+		t.Parallel()
+		if _, err := key.Open(iv, cipherOutput[:TagSize-1], nil); err == nil {
+			t.Fatal("Open accepted a cipher output with no room for a tag")
+		}
+	})
+}
+
+func TestSealRejectsWrongIVSize(t *testing.T) {
+	t.Parallel()
+
+	key, err := DeriveDataKey(unwrapFixtureKey(t))
+	if err != nil {
+		t.Fatalf("DeriveDataKey returned %v", err)
+	}
+	for _, size := range []int{0, 11, 13, 16} {
+		if _, err := key.Seal(make([]byte, size), []byte{1}, nil); err == nil {
+			t.Errorf("Seal accepted a %d byte iv", size)
+		}
+	}
+}
+
+func TestDeriveDataKeyRejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	if _, err := DeriveDataKey(nil); err == nil {
+		t.Fatal("DeriveDataKey accepted an empty data encryption key")
+	}
+}
+
+// TestNewIVIsRandom checks the initialisation vector source is not stuck, since reuse with
+// the same key breaks AES-GCM.
+func TestNewIVIsRandom(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]struct{}, 1000)
+	for i := 0; i < 1000; i++ {
+		iv, err := NewIV()
+		if err != nil {
+			t.Fatalf("NewIV returned %v", err)
+		}
+		if len(iv) != IVSize {
+			t.Fatalf("iv is %d bytes, want %d", len(iv), IVSize)
+		}
+		key := string(iv)
+		if _, repeated := seen[key]; repeated {
+			t.Fatalf("NewIV repeated %x", iv)
+		}
+		seen[key] = struct{}{}
+	}
+}
+
+func unwrapFixtureKey(t *testing.T) []byte {
+	t.Helper()
+
+	dek, err := UnwrapKey(
+		mustHex(t, deterministicKEK),
+		mustHex(t, deterministicEncapsulation),
+		mustBase64(t, deterministicKeyIV),
+	)
+	if err != nil {
+		t.Fatalf("UnwrapKey returned %v", err)
+	}
+	return dek
+}
+
+func mustBase64(t *testing.T, s string) []byte {
+	t.Helper()
+
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad test base64 %q: %v", s, err)
+	}
+	return decoded
+}

--- a/neo4j/internal/propertyencryption/decode.go
+++ b/neo4j/internal/propertyencryption/decode.go
@@ -1,0 +1,475 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/dbtype"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/packstream"
+)
+
+// MalformedError reports bytes that are not a well-formed encoding of a value.
+type MalformedError struct {
+	Message string
+}
+
+func (e *MalformedError) Error() string {
+	return e.Message
+}
+
+// errUnsupported unwinds decoding when an encoding definition is missing. DecodeValue turns
+// it into an UnsupportedType and it never reaches the caller.
+var errUnsupported = errors.New("unsupported encoding definition")
+
+// DecodeValue decodes plaintext bytes back into a Neo4j property value, using the type name
+// and baseline version recorded with the encrypted value.
+//
+// An encoding this driver cannot interpret yields a *dbtype.UnsupportedType rather than an
+// error.
+func DecodeValue(plaintext []byte, typeName string, recorded Version) (any, error) {
+	if unsupported := unsupportedBaseline(typeName, recorded); unsupported != nil {
+		return unsupported, nil
+	}
+
+	d := decoder{recorded: recorded}
+	d.unpacker.Reset(plaintext)
+	value := d.value()
+	switch {
+	case errors.Is(d.err, errUnsupported):
+		return newUnsupportedType(typeName, recorded,
+			fmt.Sprintf("the encrypted value contains %s, which this driver cannot decode "+
+				"under Bolt Value Encoding Scheme %s", d.unsupportedDetail, Implemented())), nil
+	case d.err != nil:
+		return nil, d.err
+	case d.unpacker.Err != nil:
+		return nil, &MalformedError{Message: d.unpacker.Err.Error()}
+	case d.unpacker.Remaining() > 0:
+		// The plaintext holds exactly one value.
+		return nil, &MalformedError{Message: fmt.Sprintf(
+			"%d bytes remain after the encrypted value", d.unpacker.Remaining())}
+	}
+	return value, nil
+}
+
+// unsupportedBaseline reports a *dbtype.UnsupportedType when the recorded baseline rules out
+// decoding, and nil when decoding may proceed.
+func unsupportedBaseline(typeName string, recorded Version) any {
+	implemented := Implemented()
+	if recorded.Major == implemented.Major {
+		if implemented.Minor >= recorded.Minor {
+			return nil
+		}
+		return newUnsupportedType(typeName, recorded,
+			fmt.Sprintf("the encrypted value requires Bolt Value Encoding Scheme %s but this "+
+				"driver implements %s, so the driver needs updating", recorded, implemented))
+	}
+	if recorded.Major > implemented.Major {
+		return newUnsupportedType(typeName, recorded,
+			fmt.Sprintf("the encrypted value requires Bolt Value Encoding Scheme %s, which is "+
+				"newer than the %s implemented by this driver, so the driver needs updating",
+				recorded, implemented))
+	}
+	return newUnsupportedType(typeName, recorded,
+		fmt.Sprintf("the encrypted value requires Bolt Value Encoding Scheme %s, which this "+
+			"driver no longer supports", recorded))
+}
+
+func newUnsupportedType(typeName string, recorded Version, message string) *dbtype.UnsupportedType {
+	return &dbtype.UnsupportedType{
+		Name: typeName,
+		MinimumProtocolVersion: db.ProtocolVersion{
+			Major: recorded.Major,
+			Minor: recorded.Minor,
+		},
+		Message: &message,
+	}
+}
+
+type decoder struct {
+	unpacker          packstream.Unpacker
+	recorded          Version
+	err               error
+	unsupportedDetail string
+}
+
+func (d *decoder) setErr(err error) {
+	if d.err == nil {
+		d.err = err
+	}
+}
+
+func (d *decoder) malformed(format string, args ...any) {
+	d.setErr(&MalformedError{Message: fmt.Sprintf(format, args...)})
+}
+
+// unsupported abandons decoding because detail has no applicable encoding definition.
+func (d *decoder) unsupported(format string, args ...any) {
+	if d.err == nil {
+		d.unsupportedDetail = fmt.Sprintf(format, args...)
+		d.err = errUnsupported
+	}
+}
+
+// require checks the encoding definition for typeName is no newer than the recorded
+// baseline, since a newer one would not match the bytes as written.
+func (d *decoder) require(typeName string) bool {
+	baseline, ok := typeBaselines[typeName]
+	if !ok {
+		d.unsupported("the %s type", typeName)
+		return false
+	}
+	if !d.recorded.atLeast(baseline) {
+		d.unsupported("a %s encoded under scheme %s", typeName, baseline)
+		return false
+	}
+	return true
+}
+
+func (d *decoder) value() any {
+	if d.err != nil {
+		return nil
+	}
+	d.unpacker.Next()
+	switch d.unpacker.Curr {
+	case packstream.PackedInt:
+		if !d.require(TypeInteger) {
+			return nil
+		}
+		return d.unpacker.Int()
+	case packstream.PackedFloat:
+		if !d.require(TypeFloat) {
+			return nil
+		}
+		return d.unpacker.Float()
+	case packstream.PackedStr:
+		if !d.require(TypeString) {
+			return nil
+		}
+		return d.unpacker.String()
+	case packstream.PackedByteArray:
+		if !d.require(TypeBytes) {
+			return nil
+		}
+		return d.unpacker.ByteArray()
+	case packstream.PackedTrue, packstream.PackedFalse:
+		if !d.require(TypeBoolean) {
+			return nil
+		}
+		return d.unpacker.Bool()
+	case packstream.PackedUUID:
+		if !d.require(TypeUUID) {
+			return nil
+		}
+		return dbtype.UUID(d.unpacker.UUID())
+	case packstream.PackedArray:
+		return d.list()
+	case packstream.PackedStruct:
+		return d.structure()
+	case packstream.PackedNil:
+		d.malformed("null is not a Neo4j property type")
+		return nil
+	default:
+		d.unsupported("a PackStream type this driver does not recognise")
+		return nil
+	}
+}
+
+func (d *decoder) list() any {
+	if !d.require(TypeList) {
+		return nil
+	}
+	length := d.unpacker.Len()
+	if d.unpacker.Err != nil {
+		return nil
+	}
+	items := make([]any, 0, min(length, 1024))
+	for i := uint32(0); i < length; i++ {
+		item := d.value()
+		if d.err != nil {
+			return nil
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func (d *decoder) structure() any {
+	tag := d.unpacker.StructTag()
+	fields := d.unpacker.Len()
+	if d.unpacker.Err != nil {
+		return nil
+	}
+
+	switch tag {
+	case 'D':
+		return d.date(fields)
+	case 'T':
+		return d.zonedTime(fields)
+	case 't':
+		return d.localTime(fields)
+	case 'd':
+		return d.localDateTime(fields)
+	case 'I':
+		return d.zonedDateTimeOffset(fields)
+	case 'i':
+		return d.zonedDateTimeZoneId(fields)
+	case 'E':
+		return d.duration(fields)
+	case 'X':
+		return d.point2D(fields)
+	case 'Y':
+		return d.point3D(fields)
+	case 'V':
+		return d.vector(fields)
+	default:
+		d.unsupported("a structure tagged %#x", tag)
+		return nil
+	}
+}
+
+func (d *decoder) fieldCount(name string, expected, actual uint32) bool {
+	if actual != expected {
+		d.malformed("%s should have %d fields but has %d", name, expected, actual)
+		return false
+	}
+	return true
+}
+
+func (d *decoder) int() int64 {
+	d.unpacker.Next()
+	if d.unpacker.Curr != packstream.PackedInt {
+		d.malformed("expected an integer field")
+		return 0
+	}
+	return d.unpacker.Int()
+}
+
+func (d *decoder) float() float64 {
+	d.unpacker.Next()
+	if d.unpacker.Curr != packstream.PackedFloat {
+		d.malformed("expected a float field")
+		return 0
+	}
+	return d.unpacker.Float()
+}
+
+func (d *decoder) string() string {
+	d.unpacker.Next()
+	if d.unpacker.Curr != packstream.PackedStr {
+		d.malformed("expected a string field")
+		return ""
+	}
+	return d.unpacker.String()
+}
+
+func (d *decoder) bytes() []byte {
+	d.unpacker.Next()
+	if d.unpacker.Curr != packstream.PackedByteArray {
+		d.malformed("expected a byte array field")
+		return nil
+	}
+	return d.unpacker.ByteArray()
+}
+
+func (d *decoder) date(fields uint32) any {
+	if !d.require(TypeDate) || !d.fieldCount("Date", 1, fields) {
+		return nil
+	}
+	days := d.int()
+	if d.err != nil {
+		return nil
+	}
+	return dbtype.Date(time.Unix(days*secondsPerDay, 0).UTC())
+}
+
+func (d *decoder) zonedTime(fields uint32) any {
+	if !d.require(TypeZonedTime) || !d.fieldCount("Time", 2, fields) {
+		return nil
+	}
+	nanos := d.int()
+	offset := d.int()
+	if d.err != nil {
+		return nil
+	}
+	seconds := nanos / int64(time.Second)
+	nanos -= seconds * int64(time.Second)
+	zone := time.FixedZone("Offset", int(offset))
+	return dbtype.Time(time.Date(0, 0, 0, 0, 0, int(seconds), int(nanos), zone))
+}
+
+func (d *decoder) localTime(fields uint32) any {
+	if !d.require(TypeLocalTime) || !d.fieldCount("LocalTime", 1, fields) {
+		return nil
+	}
+	nanos := d.int()
+	if d.err != nil {
+		return nil
+	}
+	seconds := nanos / int64(time.Second)
+	nanos -= seconds * int64(time.Second)
+	return dbtype.LocalTime(time.Date(0, 0, 0, 0, 0, int(seconds), int(nanos), time.Local))
+}
+
+func (d *decoder) localDateTime(fields uint32) any {
+	if !d.require(TypeLocalDateTime) || !d.fieldCount("LocalDateTime", 2, fields) {
+		return nil
+	}
+	seconds := d.int()
+	nanos := d.int()
+	if d.err != nil {
+		return nil
+	}
+	// Matches how the driver hydrates a LocalDateTime off the wire.
+	t := time.Unix(seconds, nanos).UTC()
+	return dbtype.LocalDateTime(time.Date(
+		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local))
+}
+
+func (d *decoder) zonedDateTimeOffset(fields uint32) any {
+	if !d.require(TypeZonedDateTime) || !d.fieldCount("DateTime", 3, fields) {
+		return nil
+	}
+	seconds := d.int()
+	nanos := d.int()
+	offset := d.int()
+	if d.err != nil {
+		return nil
+	}
+	zone := time.FixedZone("Offset", int(offset))
+	return time.Unix(seconds, nanos).In(zone)
+}
+
+func (d *decoder) zonedDateTimeZoneId(fields uint32) any {
+	if !d.require(TypeZonedDateTime) || !d.fieldCount("DateTimeZoneId", 3, fields) {
+		return nil
+	}
+	seconds := d.int()
+	nanos := d.int()
+	id := d.string()
+	if d.err != nil {
+		return nil
+	}
+	zone, err := time.LoadLocation(id)
+	if err != nil {
+		d.malformed("unknown time zone %q: %s", id, err)
+		return nil
+	}
+	return time.Unix(seconds, nanos).In(zone)
+}
+
+func (d *decoder) duration(fields uint32) any {
+	if !d.require(TypeDuration) || !d.fieldCount("Duration", 4, fields) {
+		return nil
+	}
+	months := d.int()
+	days := d.int()
+	seconds := d.int()
+	nanos := d.int()
+	if d.err != nil {
+		return nil
+	}
+	return dbtype.Duration{Months: months, Days: days, Seconds: seconds, Nanos: int(nanos)}
+}
+
+func (d *decoder) point2D(fields uint32) any {
+	if !d.require(TypePoint) || !d.fieldCount("Point2D", 3, fields) {
+		return nil
+	}
+	srid := d.int()
+	x := d.float()
+	y := d.float()
+	if d.err != nil {
+		return nil
+	}
+	return dbtype.Point2D{SpatialRefId: uint32(srid), X: x, Y: y}
+}
+
+func (d *decoder) point3D(fields uint32) any {
+	if !d.require(TypePoint) || !d.fieldCount("Point3D", 4, fields) {
+		return nil
+	}
+	srid := d.int()
+	x := d.float()
+	y := d.float()
+	z := d.float()
+	if d.err != nil {
+		return nil
+	}
+	return dbtype.Point3D{SpatialRefId: uint32(srid), X: x, Y: y, Z: z}
+}
+
+func (d *decoder) vector(fields uint32) any {
+	if !d.require(TypeVector) || !d.fieldCount("Vector", 2, fields) {
+		return nil
+	}
+	marker := d.bytes()
+	elements := d.bytes()
+	if d.err != nil {
+		return nil
+	}
+	if len(marker) != 1 {
+		d.malformed("a Vector type marker should be 1 byte but is %d", len(marker))
+		return nil
+	}
+
+	switch marker[0] {
+	case 0xc1:
+		return decodeVector[float64](d, elements, 8, func(b []byte) float64 {
+			return math.Float64frombits(binary.BigEndian.Uint64(b))
+		})
+	case 0xc6:
+		return decodeVector[float32](d, elements, 4, func(b []byte) float32 {
+			return math.Float32frombits(binary.BigEndian.Uint32(b))
+		})
+	case 0xc8:
+		return decodeVector[int8](d, elements, 1, func(b []byte) int8 { return int8(b[0]) })
+	case 0xc9:
+		return decodeVector[int16](d, elements, 2, func(b []byte) int16 {
+			return int16(binary.BigEndian.Uint16(b))
+		})
+	case 0xca:
+		return decodeVector[int32](d, elements, 4, func(b []byte) int32 {
+			return int32(binary.BigEndian.Uint32(b))
+		})
+	case 0xcb:
+		return decodeVector[int64](d, elements, 8, func(b []byte) int64 {
+			return int64(binary.BigEndian.Uint64(b))
+		})
+	default:
+		d.unsupported("a Vector with element marker %#x", marker[0])
+		return nil
+	}
+}
+
+func decodeVector[T dbtype.VectorElement](d *decoder, elements []byte, width int, read func([]byte) T) any {
+	if len(elements)%width != 0 {
+		d.malformed("Vector values should be a multiple of %d bytes but are %d", width, len(elements))
+		return nil
+	}
+	elems := make([]T, 0, len(elements)/width)
+	for i := 0; i < len(elements); i += width {
+		elems = append(elems, read(elements[i:i+width]))
+	}
+	return dbtype.Vector[T]{Elems: elems}
+}

--- a/neo4j/internal/propertyencryption/decode_test.go
+++ b/neo4j/internal/propertyencryption/decode_test.go
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"encoding/hex"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/dbtype"
+)
+
+// TestRoundTrip encodes and decodes every property type, checking each comes back unchanged
+// and re-encodes to the same bytes.
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	london, err := time.LoadLocation("Europe/London")
+	if err != nil {
+		t.Skipf("no tzdata available: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		value any
+		want  any
+	}{
+		{name: "true", value: true},
+		{name: "false", value: false},
+		{name: "zero", value: int64(0)},
+		{name: "negative", value: int64(-1)},
+		{name: "int64 min", value: int64(-9223372036854775808)},
+		{name: "int64 max", value: int64(9223372036854775807)},
+		{name: "int widens to int64", value: 42, want: int64(42)},
+		{name: "float", value: 3.25},
+		{name: "negative zero float", value: math_NegZero},
+		{name: "empty string", value: ""},
+		{name: "string", value: "hello world"},
+		{name: "multi byte string", value: "héllo wörld 🙂"},
+		{name: "empty bytes", value: []byte{}},
+		{name: "bytes", value: []byte{0, 1, 2, 255}},
+		{name: "empty list", value: []any{}},
+		{name: "list", value: []any{int64(1), int64(2)}},
+		{name: "list of strings", value: []string{"a", "b"}, want: []any{"a", "b"}},
+		{name: "long list", value: longList(), want: longListDecoded()},
+		{
+			name:  "mixed list",
+			value: []any{int64(1), "a", true},
+			want:  []any{int64(1), "a", true},
+		},
+		{name: "uuid", value: dbtype.UUID{1, 2, 3}},
+		{name: "duration", value: dbtype.Duration{Months: 1, Days: 2, Seconds: 3, Nanos: 4}},
+		{name: "negative duration", value: dbtype.Duration{Months: -1, Days: -2, Seconds: -3, Nanos: 4}},
+		{name: "point 2d", value: dbtype.Point2D{SpatialRefId: 7203, X: 1.5, Y: -2.5}},
+		{name: "point 3d", value: dbtype.Point3D{SpatialRefId: 9157, X: 1.5, Y: -2.5, Z: 0}},
+		{name: "vector int8", value: dbtype.Vector[int8]{Elems: []int8{1, -1, 127}}},
+		{name: "vector int16", value: dbtype.Vector[int16]{Elems: []int16{1, -32768}}},
+		{name: "vector int32", value: dbtype.Vector[int32]{Elems: []int32{1, -2}}},
+		{name: "vector int64", value: dbtype.Vector[int64]{Elems: []int64{1, -2}}},
+		{name: "vector float32", value: dbtype.Vector[float32]{Elems: []float32{1.5, -2.5}}},
+		{name: "vector float64", value: dbtype.Vector[float64]{Elems: []float64{1.5, -2.5}}},
+		{name: "empty vector", value: dbtype.Vector[float64]{Elems: []float64{}}},
+		{name: "date", value: dbtype.Date(time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC))},
+		{name: "date before the epoch", value: dbtype.Date(time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{name: "local time", value: dbtype.LocalTime(time.Date(0, 0, 0, 23, 59, 59, 999999999, time.UTC))},
+		{name: "zoned time", value: dbtype.Time(time.Date(0, 0, 0, 1, 2, 3, 4, offsetZone))},
+		{
+			name:  "zoned time with a negative offset",
+			value: dbtype.Time(time.Date(0, 0, 0, 1, 2, 3, 4, time.FixedZone("Offset", -18000))),
+		},
+		{
+			name:  "local date time",
+			value: dbtype.LocalDateTime(time.Date(2026, 8, 21, 10, 30, 0, 500, time.UTC)),
+		},
+		{name: "zoned date time with an offset", value: time.Date(2026, 8, 21, 10, 0, 0, 7, offsetZone)},
+		{name: "zoned date time with a zone id", value: time.Date(2026, 8, 21, 10, 0, 0, 7, london)},
+		{
+			name:  "zoned date time before the epoch",
+			value: time.Date(1900, 1, 1, 10, 0, 0, 0, offsetZone),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := test.want
+			if want == nil {
+				want = test.value
+			}
+
+			encoded, err := EncodeValue(test.value)
+			if err != nil {
+				t.Fatalf("EncodeValue(%#v) returned %v", test.value, err)
+			}
+			decoded, err := DecodeValue(encoded.Bytes, encoded.TypeName, encoded.Baseline)
+			if err != nil {
+				t.Fatalf("DecodeValue returned %v", err)
+			}
+			if !sameValue(decoded, want) {
+				t.Fatalf("round tripped %#v to %#v", want, decoded)
+			}
+
+			// Re-encoding must land on the same bytes.
+			reencoded, err := EncodeValue(decoded)
+			if err != nil {
+				t.Fatalf("re-encoding the decoded value returned %v", err)
+			}
+			if !reflect.DeepEqual(reencoded.Bytes, encoded.Bytes) {
+				t.Errorf("re-encoded to %x, want %x", reencoded.Bytes, encoded.Bytes)
+			}
+		})
+	}
+}
+
+// TestDecodeValueRejectsUnsupportedBaseline covers baselines outside the supported range.
+func TestDecodeValueRejectsUnsupportedBaseline(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := EncodeValue("hello world")
+	if err != nil {
+		t.Fatalf("EncodeValue returned %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		recorded Version
+	}{
+		{name: "newer major", recorded: Version{Major: 2, Minor: 0}},
+		{name: "newer minor", recorded: Version{Major: 1, Minor: 1}},
+		{name: "older major", recorded: Version{Major: 0, Minor: 9}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			decoded, err := DecodeValue(encoded.Bytes, TypeString, test.recorded)
+			if err != nil {
+				t.Fatalf("DecodeValue returned %v, want an UnsupportedType", err)
+			}
+			unsupported, ok := decoded.(*dbtype.UnsupportedType)
+			if !ok {
+				t.Fatalf("DecodeValue returned %T, want *dbtype.UnsupportedType", decoded)
+			}
+			if unsupported.Name != TypeString {
+				t.Errorf("Name is %q, want %q", unsupported.Name, TypeString)
+			}
+			if unsupported.MinimumProtocolVersion.Major != test.recorded.Major ||
+				unsupported.MinimumProtocolVersion.Minor != test.recorded.Minor {
+				t.Errorf("version is %v, want %s", unsupported.MinimumProtocolVersion, test.recorded)
+			}
+			if unsupported.Message == nil || *unsupported.Message == "" {
+				t.Error("Message is empty, users need to be told why the value cannot be read")
+			}
+		})
+	}
+}
+
+// TestDecodeValueRejectsUnknownEncodings checks encodings outside scheme 1.0 surface as an
+// UnsupportedType rather than a wrong value or a panic.
+func TestDecodeValueRejectsUnknownEncodings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		plaintext string
+	}{
+		{name: "legacy date time with an offset", plaintext: "b3460102c90e10"},
+		{name: "legacy date time with a zone id", plaintext: "b3660102816c"},
+		{name: "node", plaintext: "b34e0190a0"},
+		{name: "unassigned struct tag", plaintext: "b17a01"},
+		{name: "dictionary", plaintext: "a18161 01"},
+		{name: "unknown vector element marker", plaintext: "b256cc01ffcc0201ff"},
+		{name: "list holding a dictionary", plaintext: "91a0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			plaintext := mustHex(t, test.plaintext)
+			decoded, err := DecodeValue(plaintext, "SOMETHING", baseline10)
+			if err != nil {
+				t.Fatalf("DecodeValue returned %v, want an UnsupportedType", err)
+			}
+			unsupported, ok := decoded.(*dbtype.UnsupportedType)
+			if !ok {
+				t.Fatalf("DecodeValue returned %#v, want *dbtype.UnsupportedType", decoded)
+			}
+			if unsupported.Message == nil || *unsupported.Message == "" {
+				t.Error("Message is empty")
+			}
+		})
+	}
+}
+
+// TestDecodeValueRejectsMalformedPlaintext covers bytes that are not a valid encoding.
+func TestDecodeValueRejectsMalformedPlaintext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		plaintext string
+	}{
+		{name: "empty", plaintext: ""},
+		{name: "null", plaintext: "c0"},
+		{name: "truncated string", plaintext: "8b68656c6c6f"},
+		{name: "truncated list", plaintext: "930102"},
+		{name: "trailing bytes", plaintext: "920102cb"},
+		{name: "date with the wrong field count", plaintext: "b2440101"},
+		{name: "point with a non float field", plaintext: "b358c91c2301c14000000000000000"},
+		{name: "vector with a wide type marker", plaintext: "b256cc02c8c8cc0201ff"},
+		{name: "vector with a partial element", plaintext: "b256cc01c9cc0301ff02"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			plaintext := mustHex(t, test.plaintext)
+			decoded, err := DecodeValue(plaintext, TypeString, baseline10)
+			if err == nil {
+				t.Fatalf("DecodeValue returned %#v, want an error", decoded)
+			}
+		})
+	}
+}
+
+// TestDecodeValueRejectsUnknownZone checks an unrecognised zone fails rather than resolving
+// to a different instant.
+func TestDecodeValueRejectsUnknownZone(t *testing.T) {
+	t.Parallel()
+
+	// DateTimeZoneId(0, 0, "Mars/Olympus_Mons").
+	plaintext := mustHex(t, "b3690000"+"d111"+hex.EncodeToString([]byte("Mars/Olympus_Mons")))
+	decoded, err := DecodeValue(plaintext, TypeZonedDateTime, baseline10)
+	if err == nil {
+		t.Fatalf("DecodeValue returned %#v, want an error", decoded)
+	}
+	var malformed *MalformedError
+	if !errors.As(err, &malformed) {
+		t.Fatalf("DecodeValue returned %T, want a *MalformedError", err)
+	}
+}
+
+var math_NegZero = negZero()
+
+func negZero() float64 {
+	zero := 0.0
+	return -zero
+}
+
+func longList() []any {
+	items := make([]any, 300)
+	for i := range items {
+		items[i] = int64(i)
+	}
+	return items
+}
+
+func longListDecoded() []any {
+	return longList()
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	clean := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] != ' ' {
+			clean = append(clean, s[i])
+		}
+	}
+	decoded, err := hex.DecodeString(string(clean))
+	if err != nil {
+		t.Fatalf("bad test hex %q: %v", s, err)
+	}
+	return decoded
+}
+
+// sameValue compares two property values. Local temporal types are hydrated into the process
+// zone so only their wall clock is compared, while a zoned date time keeps instant and zone.
+func sameValue(got, want any) bool {
+	switch w := want.(type) {
+	case time.Time:
+		g, ok := got.(time.Time)
+		return ok && g.Equal(w) && g.Location().String() == w.Location().String()
+	case dbtype.Date:
+		g, ok := got.(dbtype.Date)
+		if !ok {
+			return false
+		}
+		gy, gm, gd := time.Time(g).Date()
+		wy, wm, wd := time.Time(w).Date()
+		return gy == wy && gm == wm && gd == wd
+	case dbtype.LocalTime:
+		g, ok := got.(dbtype.LocalTime)
+		return ok && sameClock(time.Time(g), time.Time(w))
+	case dbtype.LocalDateTime:
+		g, ok := got.(dbtype.LocalDateTime)
+		if !ok {
+			return false
+		}
+		gy, gm, gd := time.Time(g).Date()
+		wy, wm, wd := time.Time(w).Date()
+		return gy == wy && gm == wm && gd == wd && sameClock(time.Time(g), time.Time(w))
+	case dbtype.Time:
+		g, ok := got.(dbtype.Time)
+		if !ok {
+			return false
+		}
+		_, gOffset := time.Time(g).Zone()
+		_, wOffset := time.Time(w).Zone()
+		return gOffset == wOffset && sameClock(time.Time(g), time.Time(w))
+	default:
+		return reflect.DeepEqual(got, want)
+	}
+}
+
+func sameClock(a, b time.Time) bool {
+	ah, am, as := a.Clock()
+	bh, bm, bs := b.Clock()
+	return ah == bh && am == bm && as == bs && a.Nanosecond() == b.Nanosecond()
+}

--- a/neo4j/internal/propertyencryption/encode.go
+++ b/neo4j/internal/propertyencryption/encode.go
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/dbtype"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/packstream"
+)
+
+const secondsPerDay = 60 * 60 * 24
+
+// Encoded is a value encoded to plaintext bytes, with the metadata recorded alongside it.
+type Encoded struct {
+	Bytes    []byte
+	TypeName string
+	// Baseline is the lowest scheme version able to decode Bytes, the maximum baseline of
+	// every property type the value contains.
+	Baseline Version
+}
+
+// EncodeValue encodes a Neo4j property value into plaintext bytes.
+func EncodeValue(value any) (Encoded, error) {
+	return encode(value, typeBaselines)
+}
+
+// EncodeAAD encodes a value for use as additional authenticated data, accepting only the
+// property types a caller can reliably reproduce.
+func EncodeAAD(value any) (Encoded, error) {
+	return encode(value, aadTypeBaselines)
+}
+
+var aadTypeBaselines = func() map[string]Version {
+	m := make(map[string]Version, len(aadTypes))
+	for name := range aadTypes {
+		m[name] = typeBaselines[name]
+	}
+	return m
+}()
+
+func encode(value any, permitted map[string]Version) (Encoded, error) {
+	e := encoder{permitted: permitted}
+	e.packer.Begin(make([]byte, 0, 64))
+	typeName := e.value(value, false)
+	buf, packErr := e.packer.End()
+	if e.err != nil {
+		return Encoded{}, e.err
+	}
+	if packErr != nil {
+		return Encoded{}, packErr
+	}
+	return Encoded{Bytes: buf, TypeName: typeName, Baseline: e.baseline}, nil
+}
+
+type encoder struct {
+	packer    packstream.Packer
+	permitted map[string]Version
+	baseline  Version
+	err       error
+}
+
+func (e *encoder) setErr(format string, args ...any) {
+	if e.err == nil {
+		e.err = &ValueError{Message: fmt.Sprintf(format, args...)}
+	}
+}
+
+// accept raises the running baseline for an encountered type and reports whether it may be
+// encoded here.
+func (e *encoder) accept(typeName string) bool {
+	baseline, ok := e.permitted[typeName]
+	if !ok {
+		if _, isProperty := typeBaselines[typeName]; isProperty {
+			e.setErr("%s is not supported as additional authenticated data", typeName)
+		} else {
+			e.setErr("%s is not a Neo4j property type", typeName)
+		}
+		return false
+	}
+	e.baseline = e.baseline.max(baseline)
+	return true
+}
+
+// value encodes a single value and returns its property type name. inList restricts it to
+// the types a Neo4j list may hold.
+func (e *encoder) value(x any, inList bool) string {
+	if e.err != nil {
+		return ""
+	}
+	if x == nil {
+		if inList {
+			e.setErr("a list stored as a property cannot contain null")
+		} else {
+			e.setErr("null is not a Neo4j property type")
+		}
+		return ""
+	}
+
+	switch v := x.(type) {
+	case bool:
+		return e.pack(TypeBoolean, func() { e.packer.Bool(v) })
+	case string:
+		return e.pack(TypeString, func() { e.packer.String(v) })
+	case []byte:
+		return e.pack(TypeBytes, func() { e.packer.Bytes(v) })
+	case int:
+		return e.packInt(int64(v))
+	case int8:
+		return e.packInt(int64(v))
+	case int16:
+		return e.packInt(int64(v))
+	case int32:
+		return e.packInt(int64(v))
+	case int64:
+		return e.packInt(v)
+	case uint:
+		return e.packUint(uint64(v))
+	case uint8:
+		return e.packInt(int64(v))
+	case uint16:
+		return e.packInt(int64(v))
+	case uint32:
+		return e.packInt(int64(v))
+	case uint64:
+		return e.packUint(v)
+	case float32:
+		return e.pack(TypeFloat, func() { e.packer.Float64(float64(v)) })
+	case float64:
+		return e.pack(TypeFloat, func() { e.packer.Float64(v) })
+	case dbtype.UUID:
+		return e.pack(TypeUUID, func() { e.packer.UUID(v) })
+	case dbtype.Date:
+		return e.pack(TypeDate, func() { e.packDate(v) })
+	case dbtype.Time:
+		return e.pack(TypeZonedTime, func() { e.packZonedTime(v) })
+	case dbtype.LocalTime:
+		return e.pack(TypeLocalTime, func() { e.packLocalTime(v) })
+	case dbtype.LocalDateTime:
+		return e.pack(TypeLocalDateTime, func() { e.packLocalDateTime(v) })
+	case time.Time:
+		return e.pack(TypeZonedDateTime, func() { e.packZonedDateTime(v) })
+	case dbtype.Duration:
+		return e.pack(TypeDuration, func() { e.packDuration(v) })
+	case dbtype.Point2D:
+		return e.pack(TypePoint, func() { e.packPoint2D(v) })
+	case dbtype.Point3D:
+		return e.pack(TypePoint, func() { e.packPoint3D(v) })
+	case dbtype.Vector[int8]:
+		return e.packVector(inList, func() { e.packer.VectorInt8(v.Elems) })
+	case dbtype.Vector[int16]:
+		return e.packVector(inList, func() { e.packer.VectorInt16(v.Elems) })
+	case dbtype.Vector[int32]:
+		return e.packVector(inList, func() { e.packer.VectorInt32(v.Elems) })
+	case dbtype.Vector[int64]:
+		return e.packVector(inList, func() { e.packer.VectorInt64(v.Elems) })
+	case dbtype.Vector[float32]:
+		return e.packVector(inList, func() { e.packer.VectorFloat32(v.Elems) })
+	case dbtype.Vector[float64]:
+		return e.packVector(inList, func() { e.packer.VectorFloat64(v.Elems) })
+	}
+
+	return e.reflected(x, inList)
+}
+
+// reflected handles pointers and slices.
+func (e *encoder) reflected(x any, inList bool) string {
+	rv := reflect.ValueOf(x)
+	switch rv.Kind() {
+	case reflect.Pointer:
+		if rv.IsNil() {
+			return e.value(nil, inList)
+		}
+		return e.value(rv.Elem().Interface(), inList)
+	case reflect.Slice:
+		if inList {
+			e.setErr("a list stored as a property cannot contain another list")
+			return ""
+		}
+		if !e.accept(TypeList) {
+			return ""
+		}
+		e.packer.ArrayHeader(rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			e.value(rv.Index(i).Interface(), true)
+			if e.err != nil {
+				return ""
+			}
+		}
+		return TypeList
+	default:
+		e.setErr("%s is not a Neo4j property type", reflect.TypeOf(x))
+		return ""
+	}
+}
+
+func (e *encoder) pack(typeName string, write func()) string {
+	if !e.accept(typeName) {
+		return ""
+	}
+	write()
+	return typeName
+}
+
+func (e *encoder) packInt(i int64) string {
+	return e.pack(TypeInteger, func() { e.packer.Int64(i) })
+}
+
+func (e *encoder) packUint(u uint64) string {
+	return e.pack(TypeInteger, func() { e.packer.Uint64(u) })
+}
+
+func (e *encoder) packVector(inList bool, write func()) string {
+	if inList {
+		e.setErr("a list stored as a property cannot contain a vector")
+		return ""
+	}
+	return e.pack(TypeVector, write)
+}
+
+func (e *encoder) packDate(d dbtype.Date) {
+	t := time.Time(d)
+	_, offset := t.Zone()
+	// Floored, not truncated, so a date before 1970 lands on the day it names.
+	seconds := t.Unix() + int64(offset)
+	days := seconds / secondsPerDay
+	if seconds%secondsPerDay < 0 {
+		days--
+	}
+	e.packer.StructHeader('D', 1)
+	e.packer.Int64(days)
+}
+
+func (e *encoder) packZonedTime(zt dbtype.Time) {
+	t := time.Time(zt)
+	_, offset := t.Zone()
+	midnight := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	e.packer.StructHeader('T', 2)
+	e.packer.Int64(t.Sub(midnight).Nanoseconds())
+	e.packer.Int(offset)
+}
+
+func (e *encoder) packLocalTime(lt dbtype.LocalTime) {
+	t := time.Time(lt)
+	nanos := int64(time.Hour)*int64(t.Hour()) +
+		int64(time.Minute)*int64(t.Minute()) +
+		int64(time.Second)*int64(t.Second()) +
+		int64(t.Nanosecond())
+	e.packer.StructHeader('t', 1)
+	e.packer.Int64(nanos)
+}
+
+func (e *encoder) packLocalDateTime(ldt dbtype.LocalDateTime) {
+	t := time.Time(ldt)
+	_, offset := t.Zone()
+	e.packer.StructHeader('d', 2)
+	e.packer.Int64(t.Unix() + int64(offset))
+	e.packer.Int(t.Nanosecond())
+}
+
+// packZonedDateTime always writes the UTC-based structures, whatever Bolt version the
+// connection negotiated.
+func (e *encoder) packZonedDateTime(t time.Time) {
+	if zone, _ := t.Zone(); zone == "Offset" {
+		_, offset := t.Zone()
+		e.packer.StructHeader('I', 3)
+		e.packer.Int64(t.Unix())
+		e.packer.Int(t.Nanosecond())
+		e.packer.Int(offset)
+		return
+	}
+	e.packer.StructHeader('i', 3)
+	e.packer.Int64(t.Unix())
+	e.packer.Int(t.Nanosecond())
+	e.packer.String(t.Location().String())
+}
+
+func (e *encoder) packPoint2D(p dbtype.Point2D) {
+	e.packer.StructHeader('X', 3)
+	e.packer.Uint32(p.SpatialRefId)
+	e.packer.Float64(p.X)
+	e.packer.Float64(p.Y)
+}
+
+func (e *encoder) packPoint3D(p dbtype.Point3D) {
+	e.packer.StructHeader('Y', 4)
+	e.packer.Uint32(p.SpatialRefId)
+	e.packer.Float64(p.X)
+	e.packer.Float64(p.Y)
+	e.packer.Float64(p.Z)
+}
+
+func (e *encoder) packDuration(d dbtype.Duration) {
+	e.packer.StructHeader('E', 4)
+	e.packer.Int64(d.Months)
+	e.packer.Int64(d.Days)
+	e.packer.Int64(d.Seconds)
+	e.packer.Int(d.Nanos)
+}

--- a/neo4j/internal/propertyencryption/encode_test.go
+++ b/neo4j/internal/propertyencryption/encode_test.go
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/dbtype"
+)
+
+var (
+	offsetZone = time.FixedZone("Offset", 3600)
+	baseline10 = Version{Major: 1, Minor: 0}
+)
+
+// TestEncodeValueBytes pins the plaintext encoding of each property type, which other drivers
+// must produce byte for byte.
+func TestEncodeValueBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    any
+		wantHex  string
+		wantType string
+	}{
+		{name: "true", value: true, wantHex: "c3", wantType: TypeBoolean},
+		{name: "false", value: false, wantHex: "c2", wantType: TypeBoolean},
+		{name: "zero", value: 0, wantHex: "00", wantType: TypeInteger},
+		{name: "minus one", value: -1, wantHex: "ff", wantType: TypeInteger},
+		{name: "int32 boundary", value: 32768, wantHex: "ca00008000", wantType: TypeInteger},
+		{name: "int64", value: int64(-9223372036854775808), wantHex: "cb8000000000000000", wantType: TypeInteger},
+		{name: "uint8", value: uint8(200), wantHex: "c900c8", wantType: TypeInteger},
+		{name: "float", value: 3.25, wantHex: "c1400a000000000000", wantType: TypeFloat},
+		{name: "float32 widens", value: float32(0.5), wantHex: "c13fe0000000000000", wantType: TypeFloat},
+		{name: "empty string", value: "", wantHex: "80", wantType: TypeString},
+		{name: "short string", value: "a", wantHex: "8161", wantType: TypeString},
+		{name: "string", value: "hello world", wantHex: "8b68656c6c6f20776f726c64", wantType: TypeString},
+		{
+			// Encoded as supplied, without Unicode normalisation, so this decomposed form
+			// does not match the composed one.
+			name: "string is not normalised", value: "é",
+			wantHex: "8365cc81", wantType: TypeString,
+		},
+		{name: "empty bytes", value: []byte{}, wantHex: "cc00", wantType: TypeBytes},
+		{name: "bytes", value: []byte{0, 1, 2}, wantHex: "cc03000102", wantType: TypeBytes},
+		{name: "list", value: []any{1, 2}, wantHex: "920102", wantType: TypeList},
+		{name: "empty list", value: []any{}, wantHex: "90", wantType: TypeList},
+		{name: "typed list", value: []string{"a"}, wantHex: "918161", wantType: TypeList},
+		{
+			name:    "uuid",
+			value:   dbtype.UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+			wantHex: "e0000102030405060708090a0b0c0d0e0f", wantType: TypeUUID,
+		},
+		{
+			name:    "date",
+			value:   dbtype.Date(time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC)),
+			wantHex: "b14401", wantType: TypeDate,
+		},
+		{
+			// Truncating division would put this on 1970-01-01.
+			name:    "date before the epoch floors",
+			value:   dbtype.Date(time.Date(1969, 12, 31, 12, 0, 0, 0, time.UTC)),
+			wantHex: "b144ff", wantType: TypeDate,
+		},
+		{
+			name:    "duration",
+			value:   dbtype.Duration{Months: 1, Days: 2, Seconds: 3, Nanos: 4},
+			wantHex: "b44501020304", wantType: TypeDuration,
+		},
+		{
+			name:    "point 2d",
+			value:   dbtype.Point2D{SpatialRefId: 7203, X: 1, Y: 2},
+			wantHex: "b358c91c23c13ff0000000000000c14000000000000000", wantType: TypePoint,
+		},
+		{
+			name:     "point 3d",
+			value:    dbtype.Point3D{SpatialRefId: 9157, X: 1, Y: 2, Z: 3},
+			wantHex:  "b459c923c5c13ff0000000000000c14000000000000000c1400800" + "0000000000",
+			wantType: TypePoint,
+		},
+		{
+			name:    "vector",
+			value:   dbtype.Vector[int8]{Elems: []int8{1, -1}},
+			wantHex: "b256cc01c8cc0201ff", wantType: TypeVector,
+		},
+		{
+			name:    "local time",
+			value:   dbtype.LocalTime(time.Date(0, 0, 0, 0, 0, 1, 2, time.UTC)),
+			wantHex: "b174ca3b9aca02", wantType: TypeLocalTime,
+		},
+		{
+			name:    "zoned date time with offset",
+			value:   time.Unix(1, 2).In(offsetZone),
+			wantHex: "b3490102c90e10", wantType: TypeZonedDateTime,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			encoded, err := EncodeValue(test.value)
+			if err != nil {
+				t.Fatalf("EncodeValue(%#v) returned %v", test.value, err)
+			}
+			if got := hex.EncodeToString(encoded.Bytes); got != test.wantHex {
+				t.Errorf("encoded to %s, want %s", got, test.wantHex)
+			}
+			if encoded.TypeName != test.wantType {
+				t.Errorf("type name is %q, want %q", encoded.TypeName, test.wantType)
+			}
+			if encoded.Baseline != baseline10 {
+				t.Errorf("baseline is %s, want %s", encoded.Baseline, baseline10)
+			}
+		})
+	}
+}
+
+// TestEncodeValueUsesUtcDateTimeStructures checks the UTC structures are always used, since
+// the encoding does not follow the connection's Bolt version.
+func TestEncodeValueUsesUtcDateTimeStructures(t *testing.T) {
+	t.Parallel()
+
+	london, err := time.LoadLocation("Europe/London")
+	if err != nil {
+		t.Skipf("no tzdata available: %v", err)
+	}
+
+	named, err := EncodeValue(time.Date(2026, 8, 21, 10, 0, 0, 0, london))
+	if err != nil {
+		t.Fatalf("EncodeValue returned %v", err)
+	}
+	if tag := named.Bytes[1]; tag != 'i' {
+		t.Errorf("zoned date time with a zone id used tag %q, want %q", tag, 'i')
+	}
+
+	offset, err := EncodeValue(time.Date(2026, 8, 21, 10, 0, 0, 0, offsetZone))
+	if err != nil {
+		t.Fatalf("EncodeValue returned %v", err)
+	}
+	if tag := offset.Bytes[1]; tag != 'I' {
+		t.Errorf("zoned date time with an offset used tag %q, want %q", tag, 'I')
+	}
+}
+
+// TestEncodeValueDereferencesPointers checks a pointer encodes as the value it points at.
+func TestEncodeValueDereferencesPointers(t *testing.T) {
+	t.Parallel()
+
+	value := "hello world"
+	encoded, err := EncodeValue(&value)
+	if err != nil {
+		t.Fatalf("EncodeValue returned %v", err)
+	}
+	if got := hex.EncodeToString(encoded.Bytes); got != "8b68656c6c6f20776f726c64" {
+		t.Errorf("encoded to %s", got)
+	}
+}
+
+// TestEncodeValueRejects covers values that are not Neo4j property types.
+func TestEncodeValueRejects(t *testing.T) {
+	t.Parallel()
+
+	var nilPointer *string
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "nil", value: nil},
+		{name: "nil pointer", value: nilPointer},
+		{name: "map", value: map[string]any{"a": 1}},
+		{name: "struct", value: struct{ A int }{A: 1}},
+		{name: "channel", value: make(chan int)},
+		{name: "array", value: [2]int{1, 2}},
+		{name: "node", value: dbtype.Node{}},
+		{name: "null in a list", value: []any{1, nil}},
+		{name: "list in a list", value: []any{[]any{1}}},
+		{name: "vector in a list", value: []any{dbtype.Vector[int8]{Elems: []int8{1}}}},
+		{name: "map in a list", value: []any{map[string]any{}}},
+		{name: "uint64 beyond int64", value: uint64(1) << 63},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := EncodeValue(test.value); err == nil {
+				t.Fatalf("EncodeValue(%#v) succeeded, want an error", test.value)
+			}
+		})
+	}
+}
+
+// TestEncodeAADAcceptsOnlyReproducibleTypes checks the AAD subset, which excludes types whose
+// representation can vary between two equal values.
+func TestEncodeAADAcceptsOnlyReproducibleTypes(t *testing.T) {
+	t.Parallel()
+
+	accepted := []any{
+		true,
+		[]byte{1},
+		dbtype.Date(time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)),
+		int64(1),
+		dbtype.LocalTime(time.Date(0, 0, 0, 1, 0, 0, 0, time.UTC)),
+		dbtype.Point2D{SpatialRefId: 7203, X: 1, Y: 2},
+		dbtype.Point3D{SpatialRefId: 9157, X: 1, Y: 2, Z: 3},
+		"row-42",
+		dbtype.Time(time.Date(0, 0, 0, 1, 0, 0, 0, offsetZone)),
+		dbtype.UUID{1},
+	}
+	for _, value := range accepted {
+		if _, err := EncodeAAD(value); err != nil {
+			t.Errorf("EncodeAAD(%T) returned %v, want success", value, err)
+		}
+	}
+
+	rejected := []any{
+		1.5,
+		dbtype.Duration{Months: 1},
+		[]any{1},
+		dbtype.LocalDateTime(time.Now()),
+		dbtype.Vector[int8]{Elems: []int8{1}},
+		time.Now(),
+	}
+	for _, value := range rejected {
+		_, err := EncodeAAD(value)
+		if err == nil {
+			t.Errorf("EncodeAAD(%T) succeeded, want an error", value)
+			continue
+		}
+		var valueErr *ValueError
+		if !errors.As(err, &valueErr) {
+			t.Errorf("EncodeAAD(%T) returned %T, want a *ValueError", value, err)
+		}
+	}
+}
+
+// TestEncodeAADMatchesValueEncoding checks AAD encodes to the same bytes it would as a value.
+func TestEncodeAADMatchesValueEncoding(t *testing.T) {
+	t.Parallel()
+
+	value := "row-42"
+	asValue, err := EncodeValue(value)
+	if err != nil {
+		t.Fatalf("EncodeValue returned %v", err)
+	}
+	asAAD, err := EncodeAAD(value)
+	if err != nil {
+		t.Fatalf("EncodeAAD returned %v", err)
+	}
+	if hex.EncodeToString(asAAD.Bytes) != hex.EncodeToString(asValue.Bytes) {
+		t.Errorf("AAD encoded to %x but the same value encoded to %x", asAAD.Bytes, asValue.Bytes)
+	}
+	if got := hex.EncodeToString(asAAD.Bytes); got != "86726f772d3432" {
+		t.Errorf("AAD encoded to %s, want the bytes behind the TestKit aad-bound fixture", got)
+	}
+}

--- a/neo4j/internal/propertyencryption/scheme.go
+++ b/neo4j/internal/propertyencryption/scheme.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package propertyencryption encodes Neo4j property values to bytes, encrypts them, and
+// reverses both.
+//
+// The encoding is versioned by the Bolt Value Encoding Scheme rather than by the Bolt
+// protocol, and so is kept separate from internal/bolt: an encrypted value must decode
+// identically whatever protocol version its connection negotiated, and whatever changes are
+// later made to the wire format.
+package propertyencryption
+
+import "fmt"
+
+// The Bolt Value Encoding Scheme version implemented here.
+const (
+	schemeMajor = 1
+	schemeMinor = 0
+)
+
+// Neo4j property type names, recorded with an encrypted value. They describe a value the
+// driver cannot decode and MUST NOT be used to decide how a value is decoded.
+const (
+	TypeBoolean       = "BOOLEAN"
+	TypeBytes         = "BYTES"
+	TypeDate          = "DATE"
+	TypeDuration      = "DURATION"
+	TypeFloat         = "FLOAT"
+	TypeInteger       = "INTEGER"
+	TypeList          = "LIST"
+	TypeLocalDateTime = "LOCAL DATETIME"
+	TypeLocalTime     = "LOCAL TIME"
+	TypePoint         = "POINT"
+	TypeString        = "STRING"
+	TypeUUID          = "UUID"
+	TypeVector        = "VECTOR"
+	TypeZonedDateTime = "ZONED DATETIME"
+	TypeZonedTime     = "ZONED TIME"
+)
+
+// Version is a Bolt Value Encoding Scheme version.
+type Version struct {
+	Major int
+	Minor int
+}
+
+// Implemented returns the scheme version implemented here.
+func Implemented() Version {
+	return Version{Major: schemeMajor, Minor: schemeMinor}
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+// atLeast reports whether v is greater than or equal to other.
+func (v Version) atLeast(other Version) bool {
+	if v.Major != other.Major {
+		return v.Major > other.Major
+	}
+	return v.Minor >= other.Minor
+}
+
+// max returns the greater of v and other.
+func (v Version) max(other Version) Version {
+	if v.atLeast(other) {
+		return v
+	}
+	return other
+}
+
+// typeBaselines maps each property type to the scheme version that introduced its encoding.
+// A new minor version adds rows for the types it introduces, for example a type added in 1.1
+// gets {Major: 1, Minor: 1}, and leaves existing rows untouched.
+var typeBaselines = map[string]Version{
+	TypeBoolean:       {Major: 1, Minor: 0},
+	TypeBytes:         {Major: 1, Minor: 0},
+	TypeDate:          {Major: 1, Minor: 0},
+	TypeDuration:      {Major: 1, Minor: 0},
+	TypeFloat:         {Major: 1, Minor: 0},
+	TypeInteger:       {Major: 1, Minor: 0},
+	TypeList:          {Major: 1, Minor: 0},
+	TypeLocalDateTime: {Major: 1, Minor: 0},
+	TypeLocalTime:     {Major: 1, Minor: 0},
+	TypePoint:         {Major: 1, Minor: 0},
+	TypeString:        {Major: 1, Minor: 0},
+	TypeUUID:          {Major: 1, Minor: 0},
+	TypeVector:        {Major: 1, Minor: 0},
+	TypeZonedDateTime: {Major: 1, Minor: 0},
+	TypeZonedTime:     {Major: 1, Minor: 0},
+}
+
+// aadTypes is the subset of property types permitted as additional authenticated data,
+// excluding those whose representation can differ between two equivalent values.
+var aadTypes = map[string]struct{}{
+	TypeBoolean:   {},
+	TypeBytes:     {},
+	TypeDate:      {},
+	TypeInteger:   {},
+	TypeLocalTime: {},
+	TypePoint:     {},
+	TypeString:    {},
+	TypeUUID:      {},
+	TypeZonedTime: {},
+}
+
+// ValueError reports a value that cannot be encoded under this scheme.
+type ValueError struct {
+	Message string
+}
+
+func (e *ValueError) Error() string {
+	return e.Message
+}

--- a/neo4j/internal/propertyencryption/structure.go
+++ b/neo4j/internal/propertyencryption/structure.go
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/packstream"
+)
+
+const (
+	// encryptedValueVersion versions the outer binary format, independently of the Encrypted
+	// structure and the encoding scheme.
+	encryptedValueVersion = 0x01
+	encryptedTag          = 0x65
+	encryptedFields       = 6
+)
+
+// Metadata keys written by the Envelope profile.
+const (
+	MetadataKeyID                  = "key_id"
+	MetadataIV                     = "iv"
+	MetadataAAD                    = "aad"
+	MetadataAADEncodingSchemeMajor = "aad_encoding_scheme_major"
+	MetadataAADEncodingSchemeMinor = "aad_encoding_scheme_minor"
+)
+
+// Encrypted carries an encrypted value together with what is needed to decrypt and interpret
+// it. It is a driver-defined structure and is not sent over the wire.
+type Encrypted struct {
+	ProfileName  string
+	CipherOutput []byte
+	TypeName     string
+	Baseline     Version
+	Metadata     Metadata
+}
+
+// Metadata is the profile-specific metadata dictionary of an Encrypted structure.
+type Metadata struct {
+	strings map[string]string
+	bytes   map[string][]byte
+	ints    map[string]int64
+}
+
+func (m *Metadata) SetString(key, value string) {
+	if m.strings == nil {
+		m.strings = map[string]string{}
+	}
+	m.strings[key] = value
+}
+
+func (m *Metadata) SetBytes(key string, value []byte) {
+	if m.bytes == nil {
+		m.bytes = map[string][]byte{}
+	}
+	m.bytes[key] = value
+}
+
+func (m *Metadata) SetInt(key string, value int64) {
+	if m.ints == nil {
+		m.ints = map[string]int64{}
+	}
+	m.ints[key] = value
+}
+
+func (m *Metadata) String(key string) (string, bool) {
+	v, ok := m.strings[key]
+	return v, ok
+}
+
+func (m *Metadata) Bytes(key string) ([]byte, bool) {
+	v, ok := m.bytes[key]
+	return v, ok
+}
+
+func (m *Metadata) Int(key string) (int64, bool) {
+	v, ok := m.ints[key]
+	return v, ok
+}
+
+func (m *Metadata) len() int {
+	return len(m.strings) + len(m.bytes) + len(m.ints)
+}
+
+// sortedKeys returns every key in ascending order of its UTF-8 bytes. The ordering is part
+// of the format.
+func (m *Metadata) sortedKeys() []string {
+	keys := make([]string, 0, m.len())
+	for key := range m.strings {
+		keys = append(keys, key)
+	}
+	for key := range m.bytes {
+		keys = append(keys, key)
+	}
+	for key := range m.ints {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// EncodeEncrypted encodes an Encrypted structure into the bytes handed to the user, a
+// one-byte encoding version followed by the unchunked structure.
+func EncodeEncrypted(e Encrypted) ([]byte, error) {
+	var packer packstream.Packer
+	packer.Begin(append(make([]byte, 0, 128), encryptedValueVersion))
+	packer.StructHeader(encryptedTag, encryptedFields)
+	packer.String(e.ProfileName)
+	packer.Bytes(e.CipherOutput)
+	packer.String(e.TypeName)
+	packer.Int(e.Baseline.Major)
+	packer.Int(e.Baseline.Minor)
+
+	packer.MapHeader(e.Metadata.len())
+	for _, key := range e.Metadata.sortedKeys() {
+		packer.String(key)
+		switch {
+		case has(e.Metadata.strings, key):
+			packer.String(e.Metadata.strings[key])
+		case has(e.Metadata.bytes, key):
+			packer.Bytes(e.Metadata.bytes[key])
+		default:
+			packer.Int64(e.Metadata.ints[key])
+		}
+	}
+
+	return packer.End()
+}
+
+func has[T any](m map[string]T, key string) bool {
+	_, ok := m[key]
+	return ok
+}
+
+// DecodeEncrypted decodes the bytes produced by EncodeEncrypted.
+func DecodeEncrypted(value []byte) (Encrypted, error) {
+	if len(value) == 0 {
+		return Encrypted{}, &MalformedError{Message: "an encrypted value cannot be empty"}
+	}
+	if value[0] != encryptedValueVersion {
+		return Encrypted{}, &MalformedError{Message: fmt.Sprintf(
+			"unknown encrypted value encoding version %#x, this driver supports %#x",
+			value[0], encryptedValueVersion)}
+	}
+
+	d := decoder{recorded: Implemented()}
+	d.unpacker.Reset(value[1:])
+
+	d.unpacker.Next()
+	if d.unpacker.Curr != packstream.PackedStruct {
+		return Encrypted{}, &MalformedError{Message: "an encrypted value must hold a structure"}
+	}
+	if tag := d.unpacker.StructTag(); tag != encryptedTag {
+		return Encrypted{}, &MalformedError{Message: fmt.Sprintf(
+			"expected the Encrypted structure tag %#x but found %#x", encryptedTag, tag)}
+	}
+	if fields := d.unpacker.Len(); fields != encryptedFields {
+		return Encrypted{}, &MalformedError{Message: fmt.Sprintf(
+			"the Encrypted structure should have %d fields but has %d", encryptedFields, fields)}
+	}
+
+	encrypted := Encrypted{
+		ProfileName:  d.string(),
+		CipherOutput: d.bytes(),
+		TypeName:     d.string(),
+	}
+	encrypted.Baseline = Version{Major: int(d.int()), Minor: int(d.int())}
+	encrypted.Metadata = d.metadata()
+
+	if d.err != nil {
+		return Encrypted{}, d.err
+	}
+	if d.unpacker.Err != nil {
+		return Encrypted{}, &MalformedError{Message: d.unpacker.Err.Error()}
+	}
+	return encrypted, nil
+}
+
+func (d *decoder) metadata() Metadata {
+	var metadata Metadata
+	d.unpacker.Next()
+	if d.unpacker.Curr != packstream.PackedMap {
+		d.malformed("the Encrypted metadata must be a dictionary")
+		return metadata
+	}
+	entries := d.unpacker.Len()
+	if d.unpacker.Err != nil {
+		return metadata
+	}
+
+	for i := uint32(0); i < entries; i++ {
+		key := d.string()
+		if d.err != nil {
+			return metadata
+		}
+		d.unpacker.Next()
+		switch d.unpacker.Curr {
+		case packstream.PackedStr:
+			metadata.SetString(key, d.unpacker.String())
+		case packstream.PackedByteArray:
+			metadata.SetBytes(key, d.unpacker.ByteArray())
+		case packstream.PackedInt:
+			metadata.SetInt(key, d.unpacker.Int())
+		default:
+			// A later profile version may add metadata this driver has no use for.
+			d.skip()
+			if d.err != nil {
+				return metadata
+			}
+		}
+	}
+	return metadata
+}
+
+// skip advances past the value the unpacker is currently positioned on.
+func (d *decoder) skip() {
+	switch d.unpacker.Curr {
+	case packstream.PackedInt, packstream.PackedFloat, packstream.PackedTrue,
+		packstream.PackedFalse, packstream.PackedNil:
+		d.discardScalar()
+	case packstream.PackedStr:
+		_ = d.unpacker.String()
+	case packstream.PackedByteArray:
+		_ = d.unpacker.ByteArray()
+	case packstream.PackedUUID:
+		_ = d.unpacker.UUID()
+	case packstream.PackedArray:
+		length := d.unpacker.Len()
+		for i := uint32(0); i < length && d.unpacker.Err == nil; i++ {
+			d.unpacker.Next()
+			d.skip()
+		}
+	case packstream.PackedMap:
+		entries := d.unpacker.Len()
+		for i := uint32(0); i < entries*2 && d.unpacker.Err == nil; i++ {
+			d.unpacker.Next()
+			d.skip()
+		}
+	case packstream.PackedStruct:
+		d.unpacker.StructTag()
+		fields := d.unpacker.Len()
+		for i := uint32(0); i < fields && d.unpacker.Err == nil; i++ {
+			d.unpacker.Next()
+			d.skip()
+		}
+	default:
+		d.malformed("cannot skip an unrecognised PackStream marker")
+	}
+}
+
+func (d *decoder) discardScalar() {
+	switch d.unpacker.Curr {
+	case packstream.PackedInt:
+		_ = d.unpacker.Int()
+	case packstream.PackedFloat:
+		_ = d.unpacker.Float()
+	}
+}

--- a/neo4j/internal/propertyencryption/structure_test.go
+++ b/neo4j/internal/propertyencryption/structure_test.go
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// Encrypted values taken verbatim from TestKit's deterministic fixtures.
+const (
+	fixtureBoolean = "01b6658d64657465726d696e69737469" +
+		"63cc11877fe22670d0d3433e2a9c4dd5" +
+		"fd17994b87424f4f4c45414e0100a282" +
+		"6976cc0c000102030405060708090a0b" +
+		"866b65795f69648b746573746b69742d" +
+		"6b6579"
+
+	fixtureAADBound = "01b6658d64657465726d696e69737469" +
+		"63cc1a3a8af0d3820a0a549d75e42e59" +
+		"6a18ff85ee74fb51dce4bc0300865354" +
+		"52494e470100a583616164cc0786726f" +
+		"772d3432d0196161645f656e636f6469" +
+		"6e675f736368656d655f6d616a6f7201" +
+		"d0196161645f656e636f64696e675f73" +
+		"6368656d655f6d696e6f7200826976cc" +
+		"0c48494a4b4c4d4e4f50515253866b65" +
+		"795f69648b746573746b69742d6b6579"
+
+	fixtureKeyID = "testkit-key"
+)
+
+// TestDecodeEncryptedFixtures checks every field of a decoded fixture.
+func TestDecodeEncryptedFixtures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without aad", func(t *testing.T) {
+		t.Parallel()
+
+		encrypted, err := DecodeEncrypted(mustHex(t, fixtureBoolean))
+		if err != nil {
+			t.Fatalf("DecodeEncrypted returned %v", err)
+		}
+		if encrypted.ProfileName != "deterministic" {
+			t.Errorf("profile is %q", encrypted.ProfileName)
+		}
+		if encrypted.TypeName != TypeBoolean {
+			t.Errorf("type name is %q", encrypted.TypeName)
+		}
+		if encrypted.Baseline != baseline10 {
+			t.Errorf("baseline is %s, want 1.0", encrypted.Baseline)
+		}
+		// One plaintext byte plus the authentication tag.
+		if len(encrypted.CipherOutput) != 17 {
+			t.Errorf("cipher output is %d bytes, want 17", len(encrypted.CipherOutput))
+		}
+		if keyID, ok := encrypted.Metadata.String(MetadataKeyID); !ok || keyID != fixtureKeyID {
+			t.Errorf("key id is %q (present: %t), want %q", keyID, ok, fixtureKeyID)
+		}
+		iv, ok := encrypted.Metadata.Bytes(MetadataIV)
+		if !ok || len(iv) != 12 {
+			t.Errorf("iv is %x (present: %t), want 12 bytes", iv, ok)
+		}
+		if _, ok := encrypted.Metadata.Bytes(MetadataAAD); ok {
+			t.Error("aad is present, it must be omitted when the caller supplied none")
+		}
+		if got := encrypted.Metadata.len(); got != 2 {
+			t.Errorf("metadata has %d entries, want 2", got)
+		}
+	})
+
+	t.Run("with aad", func(t *testing.T) {
+		t.Parallel()
+
+		encrypted, err := DecodeEncrypted(mustHex(t, fixtureAADBound))
+		if err != nil {
+			t.Fatalf("DecodeEncrypted returned %v", err)
+		}
+		if encrypted.TypeName != TypeString {
+			t.Errorf("type name is %q", encrypted.TypeName)
+		}
+		aad, ok := encrypted.Metadata.Bytes(MetadataAAD)
+		if !ok {
+			t.Fatal("aad is missing")
+		}
+		// The stored AAD is the encoded value, not the raw text.
+		if got := hex.EncodeToString(aad); got != "86726f772d3432" {
+			t.Errorf("aad is %s, want the encoding of the string row-42", got)
+		}
+		major, ok := encrypted.Metadata.Int(MetadataAADEncodingSchemeMajor)
+		if !ok || major != 1 {
+			t.Errorf("aad scheme major is %d (present: %t), want 1", major, ok)
+		}
+		minor, ok := encrypted.Metadata.Int(MetadataAADEncodingSchemeMinor)
+		if !ok || minor != 0 {
+			t.Errorf("aad scheme minor is %d (present: %t), want 0", minor, ok)
+		}
+		if got := encrypted.Metadata.len(); got != 5 {
+			t.Errorf("metadata has %d entries, want 5", got)
+		}
+	})
+}
+
+// TestEncodeEncryptedMatchesFixtures re-encodes the fixtures byte for byte, pinning the
+// structure tag, field order, metadata value types and key ordering.
+func TestEncodeEncryptedMatchesFixtures(t *testing.T) {
+	t.Parallel()
+
+	for name, fixture := range map[string]string{
+		"without aad": fixtureBoolean,
+		"with aad":    fixtureAADBound,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			decoded, err := DecodeEncrypted(mustHex(t, fixture))
+			if err != nil {
+				t.Fatalf("DecodeEncrypted returned %v", err)
+			}
+			encoded, err := EncodeEncrypted(decoded)
+			if err != nil {
+				t.Fatalf("EncodeEncrypted returned %v", err)
+			}
+			if got := hex.EncodeToString(encoded); got != fixture {
+				t.Errorf("re-encoded to\n%s\nwant\n%s", got, fixture)
+			}
+		})
+	}
+}
+
+// TestEncodeEncryptedSortsMetadata checks metadata key ordering. Keys are inserted out of
+// order because randomised map iteration would otherwise make an unsorted implementation
+// fail only intermittently.
+func TestEncodeEncryptedSortsMetadata(t *testing.T) {
+	t.Parallel()
+
+	var metadata Metadata
+	metadata.SetString(MetadataKeyID, "0")
+	metadata.SetBytes(MetadataIV, []byte{1})
+	metadata.SetInt(MetadataAADEncodingSchemeMinor, 0)
+	metadata.SetInt(MetadataAADEncodingSchemeMajor, 1)
+	metadata.SetBytes(MetadataAAD, []byte{2})
+
+	want := []string{
+		MetadataAAD,
+		MetadataAADEncodingSchemeMajor,
+		MetadataAADEncodingSchemeMinor,
+		MetadataIV,
+		MetadataKeyID,
+	}
+	for attempt := 0; attempt < 20; attempt++ {
+		got := metadata.sortedKeys()
+		if len(got) != len(want) {
+			t.Fatalf("got %d keys, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("key %d is %q, want %q", i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestEncodeEncryptedSortsByUtf8Bytes checks the ordering is over raw UTF-8 bytes.
+func TestEncodeEncryptedSortsByUtf8Bytes(t *testing.T) {
+	t.Parallel()
+
+	var metadata Metadata
+	metadata.SetString("é", "")
+	metadata.SetString("z", "")
+	metadata.SetString("Z", "")
+	metadata.SetString("aa", "")
+	metadata.SetString("a", "")
+
+	want := []string{"Z", "a", "aa", "z", "é"}
+	got := metadata.sortedKeys()
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("keys sorted to %q, want %q", got, want)
+		}
+	}
+}
+
+// TestEncodeEncryptedRoundTrip covers a structure this driver produced itself.
+func TestEncodeEncryptedRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var metadata Metadata
+	metadata.SetString(MetadataKeyID, "a-key")
+	metadata.SetBytes(MetadataIV, []byte{1, 2, 3})
+
+	want := Encrypted{
+		ProfileName:  "profile",
+		CipherOutput: []byte{9, 8, 7},
+		TypeName:     TypeString,
+		Baseline:     baseline10,
+		Metadata:     metadata,
+	}
+	encoded, err := EncodeEncrypted(want)
+	if err != nil {
+		t.Fatalf("EncodeEncrypted returned %v", err)
+	}
+	if encoded[0] != 0x01 {
+		t.Errorf("encoding version byte is %#x, want 0x01", encoded[0])
+	}
+	if encoded[2] != 0x65 {
+		t.Errorf("structure tag is %#x, want 0x65", encoded[2])
+	}
+
+	got, err := DecodeEncrypted(encoded)
+	if err != nil {
+		t.Fatalf("DecodeEncrypted returned %v", err)
+	}
+	if got.ProfileName != want.ProfileName || got.TypeName != want.TypeName ||
+		got.Baseline != want.Baseline {
+		t.Errorf("round tripped to %+v, want %+v", got, want)
+	}
+	if keyID, _ := got.Metadata.String(MetadataKeyID); keyID != "a-key" {
+		t.Errorf("key id round tripped to %q", keyID)
+	}
+}
+
+// TestDecodeEncryptedIgnoresUnknownMetadata covers metadata a later profile version may add.
+func TestDecodeEncryptedIgnoresUnknownMetadata(t *testing.T) {
+	t.Parallel()
+
+	const prefix = fieldVersion + fieldHeader + fieldProfile + fieldCipher + fieldTypeName +
+		fieldMajor + fieldMinor
+
+	// Each case adds one metadata entry this driver has no use for, alongside the iv it
+	// does read. The shapes cover every branch the skip has to walk over.
+	unknown := map[string]string{
+		"boolean":            "82" + "7a7a" + "c3",
+		"null":               "82" + "7a7a" + "c0",
+		"float":              "82" + "7a7a" + "c1400a000000000000",
+		"uuid":               "82" + "7a7a" + "e0000102030405060708090a0b0c0d0e0f",
+		"list":               "82" + "7a7a" + "9201c3",
+		"nested list":        "82" + "7a7a" + "91" + "920102",
+		"dictionary":         "82" + "7a7a" + "a1" + "8161" + "01",
+		"nested dictionary":  "82" + "7a7a" + "a1" + "8161" + "a1" + "8162" + "c3",
+		"structure":          "82" + "7a7a" + "b144" + "01",
+		"structure of lists": "82" + "7a7a" + "b17a" + "920102",
+	}
+
+	for name, entry := range unknown {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			value := prefix + "a2" + "826976" + "cc0101" + entry
+			decoded, err := DecodeEncrypted(mustHex(t, value))
+			if err != nil {
+				t.Fatalf("DecodeEncrypted returned %v", err)
+			}
+			if iv, ok := decoded.Metadata.Bytes(MetadataIV); !ok || len(iv) != 1 {
+				t.Errorf("iv is %x (present: %t)", iv, ok)
+			}
+		})
+	}
+}
+
+// The fields of a well-formed encrypted value, so the cases below can name what they change.
+const (
+	fieldVersion  = "01"
+	fieldHeader   = "b665"           // structure, 6 fields, tag "e"
+	fieldProfile  = "8170"           // "p"
+	fieldCipher   = "cc00"           // empty
+	fieldTypeName = "86535452494e47" // "STRING"
+	fieldMajor    = "01"
+	fieldMinor    = "00"
+	fieldMetadata = "a0" // empty
+
+	validEncrypted = fieldVersion + fieldHeader + fieldProfile + fieldCipher +
+		fieldTypeName + fieldMajor + fieldMinor + fieldMetadata
+)
+
+// TestDecodeEncryptedRejects covers bytes that are not a valid encrypted value.
+func TestDecodeEncryptedRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "unknown encoding version",
+			value: "02" + fieldHeader + fieldProfile + fieldCipher + fieldTypeName +
+				fieldMajor + fieldMinor + fieldMetadata},
+		{name: "not a structure", value: fieldVersion + "8161"},
+		{name: "wrong structure tag",
+			value: fieldVersion + "b666" + fieldProfile + fieldCipher + fieldTypeName +
+				fieldMajor + fieldMinor + fieldMetadata},
+		{name: "too few fields",
+			value: fieldVersion + "b565" + fieldProfile + fieldCipher + fieldTypeName +
+				fieldMajor + fieldMinor},
+		{name: "profile name is not a string",
+			value: fieldVersion + fieldHeader + "01" + fieldCipher + fieldTypeName +
+				fieldMajor + fieldMinor + fieldMetadata},
+		{name: "metadata is not a dictionary",
+			value: fieldVersion + fieldHeader + fieldProfile + fieldCipher + fieldTypeName +
+				fieldMajor + fieldMinor + "c3"},
+		{name: "truncated", value: fieldVersion + fieldHeader + fieldProfile + fieldCipher},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			decoded, err := DecodeEncrypted(mustHex(t, test.value))
+			if err == nil {
+				t.Fatalf("DecodeEncrypted returned %+v, want an error", decoded)
+			}
+		})
+	}
+}
+
+// TestDecodeEncryptedAcceptsTheUnmutatedValue checks the value the cases above mutate does
+// itself decode, so none of them can pass for the wrong reason.
+func TestDecodeEncryptedAcceptsTheUnmutatedValue(t *testing.T) {
+	t.Parallel()
+
+	if _, err := DecodeEncrypted(mustHex(t, validEncrypted)); err != nil {
+		t.Fatalf("DecodeEncrypted returned %v", err)
+	}
+}

--- a/neo4j/propertyencryption/encryption.go
+++ b/neo4j/propertyencryption/encryption.go
@@ -1,0 +1,492 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package propertyencryption encrypts and decrypts individual Neo4j property values in the
+// application, so that a value chosen for encryption reaches the database only as ciphertext.
+// The encrypted bytes are portable across Neo4j drivers.
+//
+// Profiles are configured through config.Config.PropertyEncryptionProfiles and reached
+// through neo4j.Driver.PropertyEncryption.
+//
+// Property encryption is a preview feature (see README on what it means in terms of support
+// and compatibility guarantees).
+package propertyencryption
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	ipe "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/propertyencryption"
+)
+
+// keyReferenceKind distinguishes the two ways a data encryption key can be named.
+type keyReferenceKind int
+
+const (
+	keyReferenceNone keyReferenceKind = iota
+	keyReferenceAlias
+	keyReferenceID
+)
+
+// KeyReference names the data encryption key to encrypt with, built with KeyAlias or KeyID.
+// The zero value names no key and is rejected.
+//
+// KeyReference is part of the property encryption preview feature (see README on what it
+// means in terms of support and compatibility guarantees).
+type KeyReference struct {
+	kind  keyReferenceKind
+	value string
+}
+
+// KeyAlias names a key by the alias it was created under, which picks up a rotation once the
+// alias moves to a new key.
+//
+// KeyAlias is part of the property encryption preview feature (see README on what it means in
+// terms of support and compatibility guarantees).
+func KeyAlias(alias string) KeyReference {
+	return KeyReference{kind: keyReferenceAlias, value: alias}
+}
+
+// KeyID names a key by its permanent id, pinning encryption to that key.
+//
+// KeyID is part of the property encryption preview feature (see README on what it means in
+// terms of support and compatibility guarantees).
+func KeyID(id string) KeyReference {
+	return KeyReference{kind: keyReferenceID, value: id}
+}
+
+// EncryptRequest describes one value to encrypt.
+//
+// EncryptRequest is part of the property encryption preview feature (see README on what it
+// means in terms of support and compatibility guarantees).
+type EncryptRequest struct {
+	// Value is the value to encrypt. It must be a Neo4j property type.
+	//
+	// Required.
+	Value any
+	// Key names the data encryption key to use. Build it with KeyAlias or KeyID.
+	//
+	// Required.
+	Key KeyReference
+	// AAD binds the value to a context, such as the node it belongs to. It is authenticated
+	// but not encrypted, and is stored with the value. Passing it again to
+	// Encryption.DecryptWithAAD is what makes a value moved to another context fail to
+	// decrypt.
+	//
+	// AAD accepts bool, string, integer, []byte, dbtype.Date, dbtype.LocalTime, dbtype.Time,
+	// dbtype.Point2D, dbtype.Point3D and dbtype.UUID. The remaining property types are
+	// excluded because two equal values can encode differently.
+	//
+	// Values are not normalised, so a string that may arrive in more than one Unicode form
+	// should be normalised before both encrypting and decrypting.
+	//
+	// Optional.
+	AAD any
+	// Profile names the encryption profile to use. It may be left empty when exactly one
+	// profile is configured.
+	//
+	// Optional.
+	Profile string
+}
+
+// Encryption encrypts and decrypts Neo4j property values, and is obtained from
+// neo4j.Driver.PropertyEncryption. It is safe for concurrent use and needs no connection.
+//
+// Encryption is part of the property encryption preview feature (see README on what it means
+// in terms of support and compatibility guarantees).
+type Encryption struct {
+	profiles map[string]*profileState
+	// sole is the only profile's name when exactly one is configured, so that callers may
+	// leave the profile out.
+	sole string
+	// names lists the configured profiles for error messages.
+	names []string
+	newIV func() ([]byte, error)
+}
+
+// profileState is a configured profile and its caches.
+type profileState struct {
+	profile    EnvelopeProfile
+	aliasCache *ipe.Cache[string]
+	keyCache   *ipe.Cache[*ipe.DataKey]
+}
+
+// New builds an Encryption from profiles. Applications normally configure profiles through
+// config.Config.PropertyEncryptionProfiles and reach the result through
+// neo4j.Driver.PropertyEncryption, but New allows encrypting and decrypting without a driver.
+//
+// New is part of the property encryption preview feature (see README on what it means in
+// terms of support and compatibility guarantees).
+func New(profiles []Profile) (*Encryption, error) {
+	encryption := &Encryption{
+		profiles: make(map[string]*profileState, len(profiles)),
+		names:    make([]string, 0, len(profiles)),
+		newIV:    ipe.NewIV,
+	}
+	for _, profile := range profiles {
+		if profile == nil {
+			return nil, &Error{Message: "a property encryption profile is nil"}
+		}
+		if err := profile.validate(); err != nil {
+			return nil, err
+		}
+		envelope, ok := profile.(EnvelopeProfile)
+		if !ok {
+			return nil, &Error{Message: fmt.Sprintf(
+				"unsupported property encryption profile type %T", profile)}
+		}
+		if _, duplicate := encryption.profiles[envelope.Name]; duplicate {
+			return nil, &Error{Message: "more than one property encryption profile is named " +
+				envelope.Name}
+		}
+		envelope = envelope.withDefaults()
+		encryption.profiles[envelope.Name] = &profileState{
+			profile:    envelope,
+			aliasCache: ipe.NewCache[string](envelope.KeyAliasCacheTTL, envelope.KeyAliasCacheSize),
+			keyCache:   ipe.NewCache[*ipe.DataKey](envelope.KeyCacheTTL, envelope.KeyCacheSize),
+		}
+		encryption.names = append(encryption.names, envelope.Name)
+	}
+	sort.Strings(encryption.names)
+	if len(encryption.names) == 1 {
+		encryption.sole = encryption.names[0]
+	}
+	return encryption, nil
+}
+
+// Encrypt encrypts a property value, returning bytes that carry everything needed to decrypt
+// them. How those bytes are stored is left to the application.
+//
+// Encrypting the same value twice produces different bytes, so encrypted values cannot be
+// compared or searched in Cypher.
+func (e *Encryption) Encrypt(ctx context.Context, request EncryptRequest) ([]byte, error) {
+	state, err := e.profileFor(request.Profile)
+	if err != nil {
+		return nil, err
+	}
+	if request.Key.kind == keyReferenceNone {
+		return nil, &Error{Message: "no encryption key was named, use KeyAlias or KeyID"}
+	}
+
+	encoded, err := ipe.EncodeValue(request.Value)
+	if err != nil {
+		return nil, asError("the value cannot be encrypted", err)
+	}
+
+	var metadata ipe.Metadata
+	var aad []byte
+	if request.AAD != nil {
+		encodedAAD, aadErr := ipe.EncodeAAD(request.AAD)
+		if aadErr != nil {
+			return nil, asError("the additional authenticated data cannot be used", aadErr)
+		}
+		aad = encodedAAD.Bytes
+		metadata.SetBytes(ipe.MetadataAAD, aad)
+		metadata.SetInt(ipe.MetadataAADEncodingSchemeMajor, int64(encodedAAD.Baseline.Major))
+		metadata.SetInt(ipe.MetadataAADEncodingSchemeMinor, int64(encodedAAD.Baseline.Minor))
+	}
+
+	keyID, dataKey, err := state.resolve(ctx, request.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	iv, err := e.newIV()
+	if err != nil {
+		return nil, &Error{Message: "could not create an initialisation vector", Cause: err}
+	}
+	cipherOutput, err := dataKey.Seal(iv, encoded.Bytes, aad)
+	if err != nil {
+		return nil, &Error{Message: "could not encrypt the value", Cause: err}
+	}
+
+	metadata.SetString(ipe.MetadataKeyID, keyID)
+	metadata.SetBytes(ipe.MetadataIV, iv)
+
+	encrypted, err := ipe.EncodeEncrypted(ipe.Encrypted{
+		ProfileName:  state.profile.Name,
+		CipherOutput: cipherOutput,
+		TypeName:     encoded.TypeName,
+		Baseline:     encoded.Baseline,
+		Metadata:     metadata,
+	})
+	if err != nil {
+		return nil, &Error{Message: "could not assemble the encrypted value", Cause: err}
+	}
+	return encrypted, nil
+}
+
+// Decrypt decrypts a value produced by Encrypt, authenticating it against the additional
+// authenticated data stored with it. A value that cannot be authenticated fails rather than
+// returning a partially trusted result.
+//
+// A value encrypted with a type or encoding this driver does not know decrypts to a
+// *dbtype.UnsupportedType rather than failing.
+//
+// Use DecryptWithAAD to authenticate against caller-supplied data instead.
+func (e *Encryption) Decrypt(ctx context.Context, encrypted []byte) (any, error) {
+	return e.decrypt(ctx, encrypted, nil, false)
+}
+
+// DecryptWithAAD decrypts a value, authenticating it against aad rather than the additional
+// authenticated data stored with it. A value that was bound to another context is rejected.
+//
+// aad must be the same value, not an equivalent one, since it is not normalised before it is
+// encoded.
+func (e *Encryption) DecryptWithAAD(ctx context.Context, encrypted []byte, aad any) (any, error) {
+	if aad == nil {
+		return nil, &Error{Message: "no additional authenticated data was supplied, " +
+			"use Decrypt to authenticate against the data stored with the value"}
+	}
+	return e.decrypt(ctx, encrypted, aad, true)
+}
+
+func (e *Encryption) decrypt(ctx context.Context, encrypted []byte, aad any, explicit bool) (any, error) {
+	structure, err := ipe.DecodeEncrypted(encrypted)
+	if err != nil {
+		return nil, asError("the value is not a Neo4j encrypted value", err)
+	}
+
+	state, err := e.profileFor(structure.ProfileName)
+	if err != nil {
+		return nil, err
+	}
+
+	iv, ok := structure.Metadata.Bytes(ipe.MetadataIV)
+	if !ok {
+		return nil, &Error{Message: "the encrypted value has no initialisation vector"}
+	}
+	keyID, ok := structure.Metadata.String(ipe.MetadataKeyID)
+	if !ok {
+		return nil, &Error{Message: "the encrypted value does not say which key encrypted it"}
+	}
+
+	aadBytes, err := aadFor(structure, aad, explicit)
+	if err != nil {
+		return nil, err
+	}
+
+	_, dataKey, err := state.resolve(ctx, KeyID(keyID))
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := dataKey.Open(iv, structure.CipherOutput, aadBytes)
+	if err != nil {
+		return nil, &Error{Message: "could not decrypt the value", Cause: err}
+	}
+
+	value, err := ipe.DecodeValue(plaintext, structure.TypeName, structure.Baseline)
+	if err != nil {
+		return nil, asError("the decrypted value could not be read", err)
+	}
+	return value, nil
+}
+
+// aadFor produces the bytes to authenticate against.
+func aadFor(structure ipe.Encrypted, aad any, explicit bool) ([]byte, error) {
+	if !explicit {
+		stored, _ := structure.Metadata.Bytes(ipe.MetadataAAD)
+		return stored, nil
+	}
+
+	encoded, err := ipe.EncodeAAD(aad)
+	if err != nil {
+		return nil, asError("the additional authenticated data cannot be used", err)
+	}
+
+	// Reproducing the bytes under a different encoding would fail to authenticate without
+	// saying why.
+	major, hasMajor := structure.Metadata.Int(ipe.MetadataAADEncodingSchemeMajor)
+	minor, hasMinor := structure.Metadata.Int(ipe.MetadataAADEncodingSchemeMinor)
+	if !hasMajor || !hasMinor {
+		if _, bound := structure.Metadata.Bytes(ipe.MetadataAAD); !bound {
+			return nil, &Error{Message: "this value was not encrypted with additional " +
+				"authenticated data, decrypt it with Decrypt"}
+		}
+		return encoded.Bytes, nil
+	}
+
+	recorded := ipe.Version{Major: int(major), Minor: int(minor)}
+	if encoded.Baseline != recorded {
+		return nil, &Error{Message: fmt.Sprintf(
+			"the additional authenticated data has to be encoded with Bolt Value Encoding "+
+				"Scheme %s to match this value, but this driver encodes it with %s",
+			recorded, encoded.Baseline)}
+	}
+	return encoded.Bytes, nil
+}
+
+// Keys returns the KeyManager for a profile. Leave profileName empty when one profile is
+// configured.
+func (e *Encryption) Keys(profileName string) (*KeyManager, error) {
+	state, err := e.profileFor(profileName)
+	if err != nil {
+		return nil, err
+	}
+	return &KeyManager{state: state}, nil
+}
+
+// profileFor resolves a profile by name, or the only one when the name is empty.
+func (e *Encryption) profileFor(name string) (*profileState, error) {
+	if name == "" {
+		switch {
+		case len(e.profiles) == 0:
+			return nil, &Error{Message: "no property encryption profiles are configured, " +
+				"set config.Config.PropertyEncryptionProfiles"}
+		case e.sole == "":
+			return nil, &Error{Message: "more than one property encryption profile is " +
+				"configured (" + strings.Join(e.names, ", ") + "), so one must be named"}
+		}
+		name = e.sole
+	}
+	state, ok := e.profiles[name]
+	if !ok {
+		if len(e.names) == 0 {
+			return nil, &Error{Message: "no property encryption profile is named " + name +
+				", none are configured"}
+		}
+		return nil, &Error{Message: "no property encryption profile is named " + name +
+			", the configured profiles are " + strings.Join(e.names, ", ")}
+	}
+	return state, nil
+}
+
+// resolve finds the data encryption key a reference names, consulting the caches first.
+func (s *profileState) resolve(ctx context.Context, reference KeyReference) (string, *ipe.DataKey, error) {
+	id := reference.value
+	if reference.kind == keyReferenceAlias {
+		var err error
+		id, err = s.resolveAlias(ctx, reference.value)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	if dataKey, ok := s.keyCache.Get(id); ok {
+		return id, dataKey, nil
+	}
+
+	key, err := s.profile.KeyRepository.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrKeyNotFound) {
+			return "", nil, &Error{Message: "no encryption key has id " + id +
+				" in profile " + s.profile.Name, Cause: err}
+		}
+		return "", nil, wrap("could not look up encryption key "+id, err)
+	}
+
+	dataKey, err := s.decapsulate(ctx, key)
+	if err != nil {
+		return "", nil, err
+	}
+	s.keyCache.Put(id, dataKey)
+	return id, dataKey, nil
+}
+
+func (s *profileState) resolveAlias(ctx context.Context, alias string) (string, error) {
+	if id, ok := s.aliasCache.Get(alias); ok {
+		return id, nil
+	}
+
+	key, err := s.profile.KeyRepository.FindByAlias(ctx, alias)
+	if err != nil {
+		if errors.Is(err, ErrKeyNotFound) {
+			return "", &Error{Message: "no encryption key has alias " + alias +
+				" in profile " + s.profile.Name, Cause: err}
+		}
+		return "", wrap("could not look up encryption key alias "+alias, err)
+	}
+	if key.ID == "" {
+		return "", &Error{Message: "the key repository returned a key with no id for alias " + alias}
+	}
+
+	s.aliasCache.Put(alias, key.ID)
+	// The encapsulation is already to hand, so there is no need to look the key up again.
+	if _, cached := s.keyCache.Get(key.ID); !cached {
+		dataKey, err := s.decapsulate(ctx, key)
+		if err != nil {
+			return "", err
+		}
+		s.keyCache.Put(key.ID, dataKey)
+	}
+	return key.ID, nil
+}
+
+func (s *profileState) decapsulate(ctx context.Context, key EncapsulatedKey) (*ipe.DataKey, error) {
+	dek, err := s.profile.EncapsulationService.Decapsulate(ctx, key.Encapsulation, key.Metadata)
+	if err != nil {
+		return nil, wrap("could not unwrap encryption key "+key.ID, err)
+	}
+	dataKey, err := ipe.DeriveDataKey(dek)
+	if err != nil {
+		return nil, &Error{Message: "could not prepare encryption key " + key.ID, Cause: err}
+	}
+	return dataKey, nil
+}
+
+// KeyManager creates the data encryption keys an EnvelopeProfile encrypts with, and is
+// obtained from Encryption.Keys.
+//
+// KeyManager is part of the property encryption preview feature (see README on what it means
+// in terms of support and compatibility guarantees).
+type KeyManager struct {
+	state *profileState
+}
+
+// Create makes a data encryption key, protects it with the profile's
+// KeyEncapsulationService and stores it under alias, returning it without any key material.
+//
+// Calling Create with an alias already in use rotates it: the alias moves to the new key,
+// while values encrypted under the old one still decrypt, each having recorded its key id.
+func (m *KeyManager) Create(ctx context.Context, alias string) (EncapsulatedKey, error) {
+	if alias == "" {
+		return EncapsulatedKey{}, &Error{Message: "an encryption key alias cannot be empty"}
+	}
+
+	profile := m.state.profile
+	result, err := profile.EncapsulationService.Encapsulate(ctx, map[string]string{})
+	if err != nil {
+		return EncapsulatedKey{}, wrap("could not create an encryption key", err)
+	}
+	if len(result.Key) == 0 {
+		return EncapsulatedKey{}, &Error{
+			Message: "the key encapsulation service returned no key material"}
+	}
+	// Fail before storing a key that cannot be used.
+	dataKey, err := ipe.DeriveDataKey(result.Key)
+	if err != nil {
+		return EncapsulatedKey{}, &Error{
+			Message: "the key encapsulation service returned an unusable key", Cause: err}
+	}
+
+	key, err := profile.KeyRepository.Save(ctx, alias, result.Encapsulation, result.Metadata)
+	if err != nil {
+		return EncapsulatedKey{}, wrap("could not store the new encryption key", err)
+	}
+	if key.ID == "" {
+		return EncapsulatedKey{}, &Error{
+			Message: "the key repository stored the new encryption key without giving it an id"}
+	}
+
+	m.state.aliasCache.Put(alias, key.ID)
+	m.state.keyCache.Put(key.ID, dataKey)
+	return key, nil
+}

--- a/neo4j/propertyencryption/encryption_example_test.go
+++ b/neo4j/propertyencryption/encryption_example_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/config"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/propertyencryption"
+)
+
+// ExampleEncryption shows how to encrypt a property before storing it and decrypt it after
+// reading it back.
+func ExampleEncryption() {
+	ctx := context.Background()
+
+	// A key encryption key would normally come from a key management service.
+	kek := make([]byte, 32)
+	keyService, err := propertyencryption.NewLocalKeyEncapsulationService(kek)
+	if err != nil {
+		panic(err)
+	}
+
+	driver, err := neo4j.NewDriver(getUrl(), neo4j.BasicAuth("neo4j", "password", ""),
+		func(c *config.Config) {
+			c.PropertyEncryptionProfiles = []propertyencryption.Profile{
+				propertyencryption.EnvelopeProfile{
+					Name:                 "customer-pii",
+					EncapsulationService: keyService,
+					KeyRepository:        newKeyRepository(),
+				},
+			}
+		})
+	if err != nil {
+		panic(err)
+	}
+	defer driver.Close(ctx)
+
+	encryption := driver.PropertyEncryption()
+
+	// Data encryption keys are created once, not per value.
+	keys, err := encryption.Keys("customer-pii")
+	if err != nil {
+		panic(err)
+	}
+	if _, err = keys.Create(ctx, "current"); err != nil {
+		panic(err)
+	}
+
+	// Encrypt, binding the value to the customer it belongs to.
+	encrypted, err := encryption.Encrypt(ctx, propertyencryption.EncryptRequest{
+		Value: "078-05-1120",
+		AAD:   "customer-1",
+		Key:   propertyencryption.KeyAlias("current"),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Store the encrypted bytes like any other property.
+	_, err = neo4j.ExecuteQuery(ctx, driver,
+		"CREATE (c:Customer {id: $id, ssn: $ssn})",
+		map[string]any{"id": "customer-1", "ssn": encrypted},
+		neo4j.EagerResultTransformer)
+	if err != nil {
+		panic(err)
+	}
+
+	result, err := neo4j.ExecuteQuery(ctx, driver,
+		"MATCH (c:Customer {id: $id}) RETURN c.ssn AS ssn",
+		map[string]any{"id": "customer-1"},
+		neo4j.EagerResultTransformer)
+	if err != nil {
+		panic(err)
+	}
+	stored, _, err := neo4j.GetRecordValue[[]byte](result.Records[0], "ssn")
+	if err != nil {
+		panic(err)
+	}
+
+	// Decrypt with the AAD it was encrypted with.
+	ssn, err := encryption.DecryptWithAAD(ctx, stored, "customer-1")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(ssn)
+}
+
+// newKeyRepository returns an EncapsulatedKeyRepository. A real one would persist keys, in
+// Neo4j or anywhere else the application already stores data.
+func newKeyRepository() propertyencryption.EncapsulatedKeyRepository {
+	return &exampleKeyRepository{keys: map[string]propertyencryption.EncapsulatedKey{}}
+}
+
+type exampleKeyRepository struct {
+	keys    map[string]propertyencryption.EncapsulatedKey
+	aliases map[string]string
+	nextID  int
+}
+
+func (r *exampleKeyRepository) FindByID(
+	_ context.Context, id string) (propertyencryption.EncapsulatedKey, error) {
+
+	key, ok := r.keys[id]
+	if !ok {
+		return propertyencryption.EncapsulatedKey{}, propertyencryption.ErrKeyNotFound
+	}
+	return key, nil
+}
+
+func (r *exampleKeyRepository) FindByAlias(
+	_ context.Context, alias string) (propertyencryption.EncapsulatedKey, error) {
+
+	id, ok := r.aliases[alias]
+	if !ok {
+		return propertyencryption.EncapsulatedKey{}, propertyencryption.ErrKeyNotFound
+	}
+	return r.keys[id], nil
+}
+
+func (r *exampleKeyRepository) Save(
+	_ context.Context, alias string, encapsulation []byte,
+	metadata map[string]string) (propertyencryption.EncapsulatedKey, error) {
+
+	r.nextID++
+	key := propertyencryption.EncapsulatedKey{
+		ID:            fmt.Sprintf("key-%d", r.nextID),
+		Alias:         alias,
+		Encapsulation: encapsulation,
+		Metadata:      metadata,
+	}
+	if r.aliases == nil {
+		r.aliases = map[string]string{}
+	}
+	r.keys[key.ID] = key
+	r.aliases[alias] = key.ID
+	return key, nil
+}
+
+func (r *exampleKeyRepository) AddAlias(_ context.Context, id, alias string) error {
+	r.aliases[alias] = id
+	return nil
+}
+
+func (r *exampleKeyRepository) DeleteAlias(_ context.Context, _, alias string) error {
+	delete(r.aliases, alias)
+	return nil
+}
+
+func (r *exampleKeyRepository) DeleteByID(_ context.Context, id string) error {
+	delete(r.keys, id)
+	return nil
+}
+
+func getUrl() string {
+	return fmt.Sprintf("%s://%s:%s", os.Getenv("TEST_NEO4J_SCHEME"), os.Getenv("TEST_NEO4J_HOST"), os.Getenv("TEST_NEO4J_PORT"))
+}

--- a/neo4j/propertyencryption/encryption_test.go
+++ b/neo4j/propertyencryption/encryption_test.go
@@ -1,0 +1,901 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/dbtype"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/errorutil"
+	ipe "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/propertyencryption"
+)
+
+// memoryRepository is an EncapsulatedKeyRepository backed by a map, counting calls so that
+// caching can be asserted.
+type memoryRepository struct {
+	mutex   sync.Mutex
+	keys    map[string]EncapsulatedKey
+	aliases map[string]string
+	nextID  int
+
+	findByID    int
+	findByAlias int
+	saves       int
+	// err, when set, is returned by every method.
+	err error
+}
+
+func newMemoryRepository() *memoryRepository {
+	return &memoryRepository{keys: map[string]EncapsulatedKey{}, aliases: map[string]string{}}
+}
+
+func (r *memoryRepository) FindByID(_ context.Context, id string) (EncapsulatedKey, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.findByID++
+	if r.err != nil {
+		return EncapsulatedKey{}, r.err
+	}
+	key, ok := r.keys[id]
+	if !ok {
+		return EncapsulatedKey{}, ErrKeyNotFound
+	}
+	return key, nil
+}
+
+func (r *memoryRepository) FindByAlias(_ context.Context, alias string) (EncapsulatedKey, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.findByAlias++
+	if r.err != nil {
+		return EncapsulatedKey{}, r.err
+	}
+	id, ok := r.aliases[alias]
+	if !ok {
+		return EncapsulatedKey{}, ErrKeyNotFound
+	}
+	return r.keys[id], nil
+}
+
+func (r *memoryRepository) Save(
+	_ context.Context, alias string, encapsulation []byte, metadata map[string]string) (EncapsulatedKey, error) {
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.saves++
+	if r.err != nil {
+		return EncapsulatedKey{}, r.err
+	}
+	id := strconv.Itoa(r.nextID)
+	r.nextID++
+	key := EncapsulatedKey{ID: id, Alias: alias, Encapsulation: encapsulation, Metadata: metadata}
+	r.keys[id] = key
+	r.aliases[alias] = id
+	return key, nil
+}
+
+func (r *memoryRepository) AddAlias(_ context.Context, id, alias string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.aliases[alias] = id
+	return nil
+}
+
+func (r *memoryRepository) DeleteAlias(_ context.Context, _, alias string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	delete(r.aliases, alias)
+	return nil
+}
+
+func (r *memoryRepository) DeleteByID(_ context.Context, id string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	delete(r.keys, id)
+	return nil
+}
+
+func (r *memoryRepository) counts() (findByID, findByAlias int) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.findByID, r.findByAlias
+}
+
+// countingService counts decapsulations, the call the key cache avoids.
+type countingService struct {
+	KeyEncapsulationService
+	mutex          sync.Mutex
+	decapsulations int
+	err            error
+}
+
+func (s *countingService) Decapsulate(
+	ctx context.Context, encapsulation []byte, metadata map[string]string) ([]byte, error) {
+
+	s.mutex.Lock()
+	s.decapsulations++
+	err := s.err
+	s.mutex.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return s.KeyEncapsulationService.Decapsulate(ctx, encapsulation, metadata)
+}
+
+func (s *countingService) count() int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.decapsulations
+}
+
+func testKEK() []byte {
+	kek := make([]byte, ipe.KeySize)
+	for i := range kek {
+		kek[i] = byte(i)
+	}
+	return kek
+}
+
+func newTestService(t *testing.T) *countingService {
+	t.Helper()
+	local, err := NewLocalKeyEncapsulationService(testKEK())
+	if err != nil {
+		t.Fatalf("NewLocalKeyEncapsulationService returned %v", err)
+	}
+	return &countingService{KeyEncapsulationService: local}
+}
+
+// newTestEncryption builds an Encryption with one profile per name, each with its own
+// repository. The first profile's repository is returned.
+func newTestEncryption(t *testing.T, names ...string) (*Encryption, *memoryRepository, *countingService) {
+	t.Helper()
+
+	service := newTestService(t)
+	repository := newMemoryRepository()
+	profiles := make([]Profile, 0, len(names))
+	for i, name := range names {
+		repo := repository
+		if i > 0 {
+			repo = newMemoryRepository()
+		}
+		profiles = append(profiles, EnvelopeProfile{
+			Name:                 name,
+			EncapsulationService: service,
+			KeyRepository:        repo,
+		})
+	}
+	encryption, err := New(profiles)
+	if err != nil {
+		t.Fatalf("New returned %v", err)
+	}
+	return encryption, repository, service
+}
+
+func createKey(t *testing.T, encryption *Encryption, profile, alias string) EncapsulatedKey {
+	t.Helper()
+
+	keys, err := encryption.Keys(profile)
+	if err != nil {
+		t.Fatalf("Keys returned %v", err)
+	}
+	key, err := keys.Create(context.Background(), alias)
+	if err != nil {
+		t.Fatalf("Create returned %v", err)
+	}
+	return key
+}
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, _, _ := newTestEncryption(t, "p")
+	createKey(t, encryption, "", "k1")
+
+	values := []any{
+		true,
+		int64(-42),
+		3.25,
+		"hello world",
+		[]byte{0, 1, 2},
+		[]any{int64(1), int64(2)},
+		dbtype.UUID{1, 2, 3},
+	}
+
+	for _, value := range values {
+		t.Run(fmt.Sprintf("%T", value), func(t *testing.T) {
+			encrypted, err := encryption.Encrypt(ctx, EncryptRequest{Value: value, Key: KeyAlias("k1")})
+			if err != nil {
+				t.Fatalf("Encrypt returned %v", err)
+			}
+			decrypted, err := encryption.Decrypt(ctx, encrypted)
+			if err != nil {
+				t.Fatalf("Decrypt returned %v", err)
+			}
+			if fmt.Sprintf("%v", decrypted) != fmt.Sprintf("%v", value) {
+				t.Errorf("round tripped %#v to %#v", value, decrypted)
+			}
+		})
+	}
+}
+
+func TestEncryptIsNotDeterministic(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, _, _ := newTestEncryption(t, "p")
+	createKey(t, encryption, "", "k1")
+
+	request := EncryptRequest{Value: "hello world", Key: KeyAlias("k1")}
+	first, err := encryption.Encrypt(ctx, request)
+	if err != nil {
+		t.Fatalf("Encrypt returned %v", err)
+	}
+	second, err := encryption.Encrypt(ctx, request)
+	if err != nil {
+		t.Fatalf("Encrypt returned %v", err)
+	}
+	if string(first) == string(second) {
+		t.Fatal("encrypting the same value twice produced the same bytes, the iv is not fresh")
+	}
+}
+
+func TestEncryptByKeyID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, _, _ := newTestEncryption(t, "p")
+	key := createKey(t, encryption, "", "k1")
+
+	encrypted, err := encryption.Encrypt(ctx, EncryptRequest{Value: "by id", Key: KeyID(key.ID)})
+	if err != nil {
+		t.Fatalf("Encrypt returned %v", err)
+	}
+	decrypted, err := encryption.Decrypt(ctx, encrypted)
+	if err != nil {
+		t.Fatalf("Decrypt returned %v", err)
+	}
+	if decrypted != "by id" {
+		t.Errorf("decrypted to %#v", decrypted)
+	}
+}
+
+func TestDecryptWithAAD(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, _, _ := newTestEncryption(t, "p")
+	createKey(t, encryption, "", "k1")
+
+	encrypted, err := encryption.Encrypt(ctx, EncryptRequest{
+		Value: "aad-bound",
+		AAD:   "row-42",
+		Key:   KeyAlias("k1"),
+	})
+	if err != nil {
+		t.Fatalf("Encrypt returned %v", err)
+	}
+
+	t.Run("matching aad", func(t *testing.T) {
+		decrypted, err := encryption.DecryptWithAAD(ctx, encrypted, "row-42")
+		if err != nil {
+			t.Fatalf("DecryptWithAAD returned %v", err)
+		}
+		if decrypted != "aad-bound" {
+			t.Errorf("decrypted to %#v", decrypted)
+		}
+	})
+
+	t.Run("wrong aad", func(t *testing.T) {
+		if _, err := encryption.DecryptWithAAD(ctx, encrypted, "row-999"); err == nil {
+			t.Fatal("DecryptWithAAD accepted the wrong aad")
+		}
+	})
+
+	t.Run("persisted aad", func(t *testing.T) {
+		decrypted, err := encryption.Decrypt(ctx, encrypted)
+		if err != nil {
+			t.Fatalf("Decrypt returned %v", err)
+		}
+		if decrypted != "aad-bound" {
+			t.Errorf("decrypted to %#v", decrypted)
+		}
+	})
+
+	t.Run("nil aad", func(t *testing.T) {
+		if _, err := encryption.DecryptWithAAD(ctx, encrypted, nil); err == nil {
+			t.Fatal("DecryptWithAAD accepted a nil aad")
+		}
+	})
+}
+
+// TestDecryptWithAADOnAnUnboundValue checks supplying AAD for a value that has none is
+// reported as such, not as an authentication failure.
+func TestDecryptWithAADOnAnUnboundValue(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, _, _ := newTestEncryption(t, "p")
+	createKey(t, encryption, "", "k1")
+
+	encrypted, err := encryption.Encrypt(ctx, EncryptRequest{Value: "plain", Key: KeyAlias("k1")})
+	if err != nil {
+		t.Fatalf("Encrypt returned %v", err)
+	}
+	_, err = encryption.DecryptWithAAD(ctx, encrypted, "row-42")
+	if err == nil {
+		t.Fatal("DecryptWithAAD accepted an aad for a value that has none")
+	}
+	var encryptionErr *Error
+	if !errors.As(err, &encryptionErr) {
+		t.Fatalf("DecryptWithAAD returned %T, want an *Error", err)
+	}
+}
+
+// TestCachesAvoidRepeatedKeyResolution checks repeated calls reach neither the repository
+// nor the key encapsulation service.
+func TestCachesAvoidRepeatedKeyResolution(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, repository, service := newTestEncryption(t, "p")
+	createKey(t, encryption, "", "k1")
+
+	// Creating the key already cached it, so nothing below should reach the repository or
+	// the key encapsulation service at all.
+	beforeID, beforeAlias := repository.counts()
+	beforeDecapsulations := service.count()
+
+	for i := 0; i < 50; i++ {
+		encrypted, err := encryption.Encrypt(ctx, EncryptRequest{Value: i, Key: KeyAlias("k1")})
+		if err != nil {
+			t.Fatalf("Encrypt returned %v", err)
+		}
+		if _, err := encryption.Decrypt(ctx, encrypted); err != nil {
+			t.Fatalf("Decrypt returned %v", err)
+		}
+	}
+
+	afterID, afterAlias := repository.counts()
+	if afterID != beforeID || afterAlias != beforeAlias {
+		t.Errorf("the repository was consulted %d more times by id and %d more by alias, want none",
+			afterID-beforeID, afterAlias-beforeAlias)
+	}
+	if got := service.count() - beforeDecapsulations; got != 0 {
+		t.Errorf("the key was decapsulated %d more times, want none", got)
+	}
+}
+
+// TestResolvingAnAliasDecapsulatesOnce checks the alias path does not fetch the same key
+// twice, once by alias and again by id.
+func TestResolvingAnAliasDecapsulatesOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := newTestService(t)
+	repository := newMemoryRepository()
+	encryption, err := New([]Profile{EnvelopeProfile{
+		Name:                 "p",
+		EncapsulationService: service,
+		KeyRepository:        repository,
+	}})
+	if err != nil {
+		t.Fatalf("New returned %v", err)
+	}
+
+	// Seed the repository directly so nothing is cached, the way a second process would find
+	// a key created elsewhere.
+	result, err := service.Encapsulate(ctx, nil)
+	if err != nil {
+		t.Fatalf("Encapsulate returned %v", err)
+	}
+	if _, err := repository.Save(ctx, "k1", result.Encapsulation, result.Metadata); err != nil {
+		t.Fatalf("Save returned %v", err)
+	}
+
+	if _, err := encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyAlias("k1")}); err != nil {
+		t.Fatalf("Encrypt returned %v", err)
+	}
+	if got := service.count(); got != 1 {
+		t.Errorf("the key was decapsulated %d times for one alias lookup, want 1", got)
+	}
+	findByID, findByAlias := repository.counts()
+	if findByAlias != 1 || findByID != 0 {
+		t.Errorf("the repository saw %d alias and %d id lookups, want 1 and 0", findByAlias, findByID)
+	}
+}
+
+func TestEncryptRejects(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, _, _ := newTestEncryption(t, "p")
+	createKey(t, encryption, "", "k1")
+
+	tests := []struct {
+		name    string
+		request EncryptRequest
+	}{
+		{name: "no key", request: EncryptRequest{Value: "a"}},
+		{name: "unknown alias", request: EncryptRequest{Value: "a", Key: KeyAlias("nope")}},
+		{name: "unknown id", request: EncryptRequest{Value: "a", Key: KeyID("nope")}},
+		{name: "unknown profile", request: EncryptRequest{Value: "a", Key: KeyAlias("k1"), Profile: "nope"}},
+		{name: "nil value", request: EncryptRequest{Key: KeyAlias("k1")}},
+		{name: "map value", request: EncryptRequest{Value: map[string]any{}, Key: KeyAlias("k1")}},
+		{name: "float aad", request: EncryptRequest{Value: "a", AAD: 1.5, Key: KeyAlias("k1")}},
+		{name: "list aad", request: EncryptRequest{Value: "a", AAD: []any{1}, Key: KeyAlias("k1")}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := encryption.Encrypt(ctx, test.request); err == nil {
+				t.Fatal("Encrypt succeeded, want an error")
+			}
+		})
+	}
+}
+
+func TestDecryptRejects(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, _, _ := newTestEncryption(t, "p")
+	createKey(t, encryption, "", "k1")
+
+	encrypted, err := encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyAlias("k1")})
+	if err != nil {
+		t.Fatalf("Encrypt returned %v", err)
+	}
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		if _, err := encryption.Decrypt(ctx, nil); err == nil {
+			t.Fatal("Decrypt accepted no bytes")
+		}
+	})
+	t.Run("not an encrypted value", func(t *testing.T) {
+		t.Parallel()
+		if _, err := encryption.Decrypt(ctx, []byte("just a string")); err == nil {
+			t.Fatal("Decrypt accepted arbitrary bytes")
+		}
+	})
+	t.Run("tampered", func(t *testing.T) {
+		t.Parallel()
+		tampered := append([]byte(nil), encrypted...)
+		tampered[len(tampered)-1] ^= 0xff
+		if _, err := encryption.Decrypt(ctx, tampered); err == nil {
+			t.Fatal("Decrypt accepted an altered value")
+		}
+	})
+	t.Run("unknown profile", func(t *testing.T) {
+		t.Parallel()
+		other, _, _ := newTestEncryption(t, "different")
+		if _, err := other.Decrypt(ctx, encrypted); err == nil {
+			t.Fatal("Decrypt accepted a value from a profile it does not have")
+		}
+	})
+	t.Run("unknown key", func(t *testing.T) {
+		t.Parallel()
+		// A profile of the same name but a repository that has never seen the key.
+		other, _, _ := newTestEncryption(t, "p")
+		if _, err := other.Decrypt(ctx, encrypted); err == nil {
+			t.Fatal("Decrypt accepted a value whose key is unknown")
+		}
+	})
+}
+
+// TestDecryptWithADifferentKeyFails checks two profiles configured alike but with unrelated
+// keys cannot read each other's values.
+func TestDecryptWithADifferentKeyFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	first, _, _ := newTestEncryption(t, "p")
+	createKey(t, first, "", "k1")
+	encrypted, err := first.Encrypt(ctx, EncryptRequest{Value: "secret", Key: KeyAlias("k1")})
+	if err != nil {
+		t.Fatalf("Encrypt returned %v", err)
+	}
+
+	second, _, _ := newTestEncryption(t, "p")
+	createKey(t, second, "", "k1")
+	if _, err := second.Decrypt(ctx, encrypted); err == nil {
+		t.Fatal("a value decrypted under an unrelated key")
+	}
+}
+
+func TestProfileSelection(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("one profile may be left unnamed", func(t *testing.T) {
+		t.Parallel()
+		encryption, _, _ := newTestEncryption(t, "only")
+		createKey(t, encryption, "", "k1")
+		if _, err := encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyAlias("k1")}); err != nil {
+			t.Fatalf("Encrypt returned %v", err)
+		}
+	})
+
+	t.Run("two profiles must be named", func(t *testing.T) {
+		t.Parallel()
+		encryption, _, _ := newTestEncryption(t, "p1", "p2")
+		if _, err := encryption.Keys(""); err == nil {
+			t.Fatal("Keys accepted no profile name with two profiles configured")
+		}
+		_, err := encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyAlias("k1")})
+		if err == nil {
+			t.Fatal("Encrypt accepted no profile name with two profiles configured")
+		}
+	})
+
+	t.Run("a key belongs to one profile", func(t *testing.T) {
+		t.Parallel()
+		encryption, _, _ := newTestEncryption(t, "p1", "p2")
+		createKey(t, encryption, "p1", "k1")
+		_, err := encryption.Encrypt(ctx, EncryptRequest{
+			Value: "a", Key: KeyAlias("k1"), Profile: "p2",
+		})
+		if err == nil {
+			t.Fatal("a key created in p1 was usable from p2")
+		}
+	})
+
+	t.Run("no profiles configured", func(t *testing.T) {
+		t.Parallel()
+		encryption, err := New(nil)
+		if err != nil {
+			t.Fatalf("New returned %v", err)
+		}
+		if _, err := encryption.Keys(""); err == nil {
+			t.Fatal("Keys succeeded with no profiles configured")
+		}
+		if _, err := encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyAlias("k")}); err == nil {
+			t.Fatal("Encrypt succeeded with no profiles configured")
+		}
+	})
+}
+
+func TestNewRejectsBadProfiles(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService(t)
+	repository := newMemoryRepository()
+	valid := EnvelopeProfile{Name: "p", EncapsulationService: service, KeyRepository: repository}
+
+	tests := []struct {
+		name     string
+		profiles []Profile
+	}{
+		{name: "nil profile", profiles: []Profile{nil}},
+		{name: "no name", profiles: []Profile{EnvelopeProfile{
+			EncapsulationService: service, KeyRepository: repository}}},
+		{name: "no encapsulation service", profiles: []Profile{EnvelopeProfile{
+			Name: "p", KeyRepository: repository}}},
+		{name: "no key repository", profiles: []Profile{EnvelopeProfile{
+			Name: "p", EncapsulationService: service}}},
+		{name: "duplicate names", profiles: []Profile{valid, valid}},
+		{name: "negative cache ttl", profiles: []Profile{EnvelopeProfile{
+			Name: "p", EncapsulationService: service, KeyRepository: repository, KeyCacheTTL: -1}}},
+		{name: "negative cache size", profiles: []Profile{EnvelopeProfile{
+			Name: "p", EncapsulationService: service, KeyRepository: repository, KeyCacheSize: -1}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := New(test.profiles); err == nil {
+				t.Fatal("New accepted the profile, want an error")
+			}
+		})
+	}
+}
+
+// TestDriverErrorsFromCallbacksArePropagated checks a driver error raised by a callback
+// reaches the caller unwrapped, so that a retryable failure stays recognisable.
+func TestDriverErrorsFromCallbacksArePropagated(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	neo4jErr := &db.Neo4jError{Code: "Neo.TransientError.General.DatabaseUnavailable"}
+
+	t.Run("from the repository", func(t *testing.T) {
+		t.Parallel()
+
+		service := newTestService(t)
+		repository := newMemoryRepository()
+		encryption, err := New([]Profile{EnvelopeProfile{
+			Name: "p", EncapsulationService: service, KeyRepository: repository}})
+		if err != nil {
+			t.Fatalf("New returned %v", err)
+		}
+		repository.err = neo4jErr
+
+		_, err = encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyAlias("k1")})
+		if !errors.Is(err, neo4jErr) {
+			t.Fatalf("Encrypt returned %v, want the repository's own error", err)
+		}
+		var wrapped *Error
+		if errors.As(err, &wrapped) {
+			t.Error("the driver error was wrapped, which would hide that it is retryable")
+		}
+	})
+
+	t.Run("from the key encapsulation service", func(t *testing.T) {
+		t.Parallel()
+
+		service := newTestService(t)
+		repository := newMemoryRepository()
+		encryption, err := New([]Profile{EnvelopeProfile{
+			Name: "p", EncapsulationService: service, KeyRepository: repository}})
+		if err != nil {
+			t.Fatalf("New returned %v", err)
+		}
+		createKey(t, encryption, "", "k1")
+
+		// Force a cache miss so the service is consulted again.
+		state := encryption.profiles["p"]
+		state.keyCache = ipe.NewCache[*ipe.DataKey](DefaultKeyCacheTTL, DefaultKeyCacheSize)
+		service.err = neo4jErr
+
+		_, err = encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyID("0")})
+		if !errors.Is(err, neo4jErr) {
+			t.Fatalf("Encrypt returned %v, want the service's own error", err)
+		}
+	})
+}
+
+func TestNonDriverErrorsFromCallbacksAreWrapped(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := newTestService(t)
+	repository := newMemoryRepository()
+	encryption, err := New([]Profile{EnvelopeProfile{
+		Name: "p", EncapsulationService: service, KeyRepository: repository}})
+	if err != nil {
+		t.Fatalf("New returned %v", err)
+	}
+
+	plain := errors.New("the key store is on fire")
+	repository.err = plain
+
+	_, err = encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyAlias("k1")})
+	var wrapped *Error
+	if !errors.As(err, &wrapped) {
+		t.Fatalf("Encrypt returned %T, want an *Error", err)
+	}
+	if !errors.Is(err, plain) {
+		t.Error("the original error was not preserved as the cause")
+	}
+}
+
+// TestUsageErrorsArePropagated covers the other driver error a callback might raise.
+func TestUsageErrorsArePropagated(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service := newTestService(t)
+	repository := newMemoryRepository()
+	encryption, err := New([]Profile{EnvelopeProfile{
+		Name: "p", EncapsulationService: service, KeyRepository: repository}})
+	if err != nil {
+		t.Fatalf("New returned %v", err)
+	}
+	usageErr := &errorutil.UsageError{Message: "bad usage"}
+	repository.err = usageErr
+
+	_, err = encryption.Encrypt(ctx, EncryptRequest{Value: "a", Key: KeyAlias("k1")})
+	if !errors.Is(err, usageErr) {
+		t.Fatalf("Encrypt returned %v, want the usage error", err)
+	}
+}
+
+func TestKeyManagerCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("empty alias", func(t *testing.T) {
+		t.Parallel()
+		encryption, _, _ := newTestEncryption(t, "p")
+		keys, err := encryption.Keys("")
+		if err != nil {
+			t.Fatalf("Keys returned %v", err)
+		}
+		if _, err := keys.Create(ctx, ""); err == nil {
+			t.Fatal("Create accepted an empty alias")
+		}
+	})
+
+	t.Run("rotation keeps old values readable", func(t *testing.T) {
+		t.Parallel()
+
+		encryption, _, _ := newTestEncryption(t, "p")
+		createKey(t, encryption, "", "k1")
+		before, err := encryption.Encrypt(ctx, EncryptRequest{Value: "old", Key: KeyAlias("k1")})
+		if err != nil {
+			t.Fatalf("Encrypt returned %v", err)
+		}
+
+		// Creating the alias again makes a new key and moves the alias to it.
+		createKey(t, encryption, "", "k1")
+		after, err := encryption.Encrypt(ctx, EncryptRequest{Value: "new", Key: KeyAlias("k1")})
+		if err != nil {
+			t.Fatalf("Encrypt returned %v", err)
+		}
+
+		decrypted, err := encryption.Decrypt(ctx, before)
+		if err != nil {
+			t.Fatalf("a value encrypted before rotation no longer decrypts: %v", err)
+		}
+		if decrypted != "old" {
+			t.Errorf("decrypted to %#v", decrypted)
+		}
+		if decrypted, err = encryption.Decrypt(ctx, after); err != nil || decrypted != "new" {
+			t.Errorf("decrypted to %#v with %v", decrypted, err)
+		}
+	})
+
+	t.Run("repository without an id", func(t *testing.T) {
+		t.Parallel()
+
+		service := newTestService(t)
+		encryption, err := New([]Profile{EnvelopeProfile{
+			Name: "p", EncapsulationService: service, KeyRepository: idlessRepository{newMemoryRepository()},
+		}})
+		if err != nil {
+			t.Fatalf("New returned %v", err)
+		}
+		keys, err := encryption.Keys("")
+		if err != nil {
+			t.Fatalf("Keys returned %v", err)
+		}
+		if _, err := keys.Create(ctx, "k1"); err == nil {
+			t.Fatal("Create accepted a key with no id, which could never be decrypted")
+		}
+	})
+}
+
+// idlessRepository returns keys without an id, which would leave every value it encrypted
+// undecryptable.
+type idlessRepository struct{ *memoryRepository }
+
+func (idlessRepository) Save(
+	_ context.Context, alias string, encapsulation []byte, metadata map[string]string) (EncapsulatedKey, error) {
+	return EncapsulatedKey{Alias: alias, Encapsulation: encapsulation, Metadata: metadata}, nil
+}
+
+func TestEncryptionIsSafeForConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	encryption, _, _ := newTestEncryption(t, "p")
+	createKey(t, encryption, "", "k1")
+
+	var waitGroup sync.WaitGroup
+	errs := make(chan error, 64)
+	for worker := 0; worker < 8; worker++ {
+		waitGroup.Add(1)
+		go func(worker int) {
+			defer waitGroup.Done()
+			for i := 0; i < 100; i++ {
+				value := fmt.Sprintf("worker %d value %d", worker, i)
+				encrypted, err := encryption.Encrypt(ctx, EncryptRequest{
+					Value: value, AAD: strconv.Itoa(worker), Key: KeyAlias("k1")})
+				if err != nil {
+					errs <- err
+					return
+				}
+				decrypted, err := encryption.DecryptWithAAD(ctx, encrypted, strconv.Itoa(worker))
+				if err != nil {
+					errs <- err
+					return
+				}
+				if decrypted != value {
+					errs <- fmt.Errorf("decrypted %q to %#v", value, decrypted)
+					return
+				}
+			}
+		}(worker)
+	}
+	waitGroup.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestLocalKeyEncapsulationServiceRejectsShortKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, size := range []int{0, 16, 24, 31, 33} {
+		if _, err := NewLocalKeyEncapsulationService(make([]byte, size)); err == nil {
+			t.Errorf("NewLocalKeyEncapsulationService accepted a %d byte key", size)
+		}
+	}
+}
+
+func TestLocalKeyEncapsulationServiceCopiesTheKey(t *testing.T) {
+	t.Parallel()
+
+	kek := testKEK()
+	service, err := NewLocalKeyEncapsulationService(kek)
+	if err != nil {
+		t.Fatalf("NewLocalKeyEncapsulationService returned %v", err)
+	}
+	result, err := service.Encapsulate(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Encapsulate returned %v", err)
+	}
+
+	// Clearing the caller's slice must not affect the service.
+	for i := range kek {
+		kek[i] = 0
+	}
+	if _, err := service.Decapsulate(context.Background(), result.Encapsulation, result.Metadata); err != nil {
+		t.Fatalf("Decapsulate returned %v after the caller cleared its key: %v", err, err)
+	}
+}
+
+func TestLocalKeyEncapsulationServiceRejectsBadMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	service, err := NewLocalKeyEncapsulationService(testKEK())
+	if err != nil {
+		t.Fatalf("NewLocalKeyEncapsulationService returned %v", err)
+	}
+	result, err := service.Encapsulate(ctx, nil)
+	if err != nil {
+		t.Fatalf("Encapsulate returned %v", err)
+	}
+
+	if _, err := service.Decapsulate(ctx, result.Encapsulation, nil); err == nil {
+		t.Error("Decapsulate accepted metadata with no iv")
+	}
+	if _, err := service.Decapsulate(ctx, result.Encapsulation, map[string]string{"iv": "not base64!"}); err == nil {
+		t.Error("Decapsulate accepted an unreadable iv")
+	}
+}
+
+func TestErrorUnwraps(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("underlying")
+	err := &Error{Message: "context", Cause: cause}
+	if err.Error() != "context: underlying" {
+		t.Errorf("Error() is %q", err.Error())
+	}
+	if !errors.Is(err, cause) {
+		t.Error("the cause is not reachable through errors.Is")
+	}
+	if got := (&Error{Message: "alone"}).Error(); got != "alone" {
+		t.Errorf("Error() with no cause is %q", got)
+	}
+}

--- a/neo4j/propertyencryption/encryption_testkit.go
+++ b/neo4j/propertyencryption/encryption_testkit.go
@@ -1,0 +1,40 @@
+//go:build internal_neo4j_go_driver_testkit
+
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	ipe "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/propertyencryption"
+)
+
+// PinIV makes the next Encrypt use iv, and returns a function that restores normal behaviour
+// and reports whether iv was used. It lets TestKit assert byte-exact ciphertext.
+//
+// Reusing an initialisation vector with the same key breaks AES-GCM.
+func (e *Encryption) PinIV(iv []byte) func() bool {
+	used := false
+	e.newIV = func() ([]byte, error) {
+		used = true
+		return iv, nil
+	}
+	return func() bool {
+		e.newIV = ipe.NewIV
+		return used
+	}
+}

--- a/neo4j/propertyencryption/errors.go
+++ b/neo4j/propertyencryption/errors.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"errors"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/errorutil"
+	ipe "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/propertyencryption"
+)
+
+// Error reports a failure to resolve an encryption key, to encrypt, to decrypt, or to
+// interpret an encrypted value.
+//
+// A KeyEncapsulationService or EncapsulatedKeyRepository failure that is already a driver
+// error is returned unchanged, so that a retryable failure stays retryable. Anything else is
+// wrapped, with the original reachable through errors.Unwrap.
+//
+// Error is part of the property encryption preview feature (see README on what it means in
+// terms of support and compatibility guarantees).
+type Error struct {
+	Message string
+	Cause   error
+}
+
+func (e *Error) Error() string {
+	if e.Cause == nil {
+		return e.Message
+	}
+	return e.Message + ": " + e.Cause.Error()
+}
+
+func (e *Error) Unwrap() error {
+	return e.Cause
+}
+
+// wrap turns err into an Error unless it is already a driver error, which the caller needs
+// to classify as raised.
+func wrap(message string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if isDriverError(err) {
+		return err
+	}
+	return &Error{Message: message, Cause: err}
+}
+
+func isDriverError(err error) bool {
+	var neo4jErr *db.Neo4jError
+	var usageErr *errorutil.UsageError
+	var connectivityErr *errorutil.ConnectivityError
+	var tokenErr *errorutil.TokenExpiredError
+	return errors.As(err, &neo4jErr) ||
+		errors.As(err, &usageErr) ||
+		errors.As(err, &connectivityErr) ||
+		errors.As(err, &tokenErr)
+}
+
+// asError converts a codec failure into an Error, keeping message as the description.
+func asError(message string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var valueErr *ipe.ValueError
+	var malformedErr *ipe.MalformedError
+	if errors.As(err, &valueErr) || errors.As(err, &malformedErr) {
+		return &Error{Message: message, Cause: err}
+	}
+	return wrap(message, err)
+}

--- a/neo4j/propertyencryption/keys.go
+++ b/neo4j/propertyencryption/keys.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrKeyNotFound is returned by an EncapsulatedKeyRepository when no key is stored under the
+// requested id or alias.
+//
+// ErrKeyNotFound is part of the property encryption preview feature (see README on what it
+// means in terms of support and compatibility guarantees).
+var ErrKeyNotFound = errors.New("no encapsulated key was found")
+
+// EncapsulatedKey is a data encryption key in protected form.
+//
+// EncapsulatedKey is part of the property encryption preview feature (see README on what it
+// means in terms of support and compatibility guarantees).
+type EncapsulatedKey struct {
+	// ID identifies this key permanently. It is recorded with every value encrypted under
+	// the key and is how the key is found again when decrypting, so it must be unique and
+	// must never be reused.
+	ID string
+	// Alias is the name this key was created under, or empty. Unlike ID, an alias may later
+	// be moved to a different key.
+	Alias string
+	// Encapsulation is the protected form of the key, as produced by a
+	// KeyEncapsulationService.
+	Encapsulation []byte
+	// Metadata is what the KeyEncapsulationService needs back in order to recover the key.
+	Metadata map[string]string
+}
+
+// EncapsulationResult is a new data encryption key together with its protected form.
+//
+// EncapsulationResult is part of the property encryption preview feature (see README on what
+// it means in terms of support and compatibility guarantees).
+type EncapsulationResult struct {
+	// Key is the data encryption key. The driver derives its encryption key from this and
+	// does not retain the value itself.
+	Key []byte
+	// Encapsulation is the protected form of Key.
+	Encapsulation []byte
+	// Metadata is whatever Decapsulate needs to recover Key, such as an initialisation
+	// vector. It is stored with the encapsulation and passed back unchanged.
+	Metadata map[string]string
+}
+
+// KeyEncapsulationService protects data encryption keys, typically by wrapping them with a
+// key held in a key management service.
+//
+// Implementations are called while encrypting and decrypting, so they must be safe for
+// concurrent use and should honour the context. Decapsulated keys are cached, so a round trip
+// here is not paid per value.
+//
+// Errors that are already driver errors are returned to the caller unchanged, keeping a
+// retryable failure retryable. Anything else is wrapped in an Error.
+//
+// See NewLocalKeyEncapsulationService for an implementation using a key held by the
+// application.
+//
+// KeyEncapsulationService is part of the property encryption preview feature (see README on
+// what it means in terms of support and compatibility guarantees).
+type KeyEncapsulationService interface {
+	// Encapsulate supplies a new data encryption key and its protected form. The
+	// implementation chooses the key, since some schemes derive rather than generate it.
+	Encapsulate(ctx context.Context, options map[string]string) (EncapsulationResult, error)
+	// Decapsulate recovers a data encryption key from its protected form, given the metadata
+	// Encapsulate returned for it.
+	Decapsulate(ctx context.Context, encapsulation []byte, metadata map[string]string) ([]byte, error)
+}
+
+// EncapsulatedKeyRepository stores the data encryption keys an EnvelopeProfile uses. Keys are
+// held in encapsulated form, so the repository never sees key material.
+//
+// Implementations are called while encrypting and decrypting, so they must be safe for
+// concurrent use. Lookups should return ErrKeyNotFound when nothing matches.
+//
+// EncapsulatedKeyRepository is part of the property encryption preview feature (see README on
+// what it means in terms of support and compatibility guarantees).
+type EncapsulatedKeyRepository interface {
+	// FindByID returns the key stored under id, or ErrKeyNotFound.
+	FindByID(ctx context.Context, id string) (EncapsulatedKey, error)
+	// FindByAlias returns the key currently bound to alias, or ErrKeyNotFound.
+	FindByAlias(ctx context.Context, alias string) (EncapsulatedKey, error)
+	// Save stores a new key under alias and returns it with the id it was assigned. The id
+	// must be unique and must never be reused.
+	Save(ctx context.Context, alias string, encapsulation []byte, metadata map[string]string) (EncapsulatedKey, error)
+	// AddAlias binds alias to the key stored under id, moving it from another key if it is
+	// already in use.
+	AddAlias(ctx context.Context, id, alias string) error
+	// DeleteAlias unbinds alias from the key stored under id.
+	DeleteAlias(ctx context.Context, id, alias string) error
+	// DeleteByID removes the key stored under id. Values encrypted under it can no longer be
+	// decrypted.
+	DeleteByID(ctx context.Context, id string) error
+}

--- a/neo4j/propertyencryption/local.go
+++ b/neo4j/propertyencryption/local.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	ipe "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/propertyencryption"
+)
+
+// localMetadataIV records the initialisation vector a key was wrapped with.
+const localMetadataIV = "iv"
+
+// LocalKeyEncapsulationService protects data encryption keys with AES-GCM under a key held by
+// the application.
+//
+// The key encryption key must then be stored and rotated by the application, and anything
+// able to read it can read every value encrypted under the profile. A KeyEncapsulationService
+// backed by a key management service avoids both.
+//
+// LocalKeyEncapsulationService is part of the property encryption preview feature (see README
+// on what it means in terms of support and compatibility guarantees).
+type LocalKeyEncapsulationService struct {
+	kek []byte
+}
+
+// NewLocalKeyEncapsulationService returns a service that wraps data encryption keys with kek,
+// which must be 32 bytes. kek is copied, so the caller may reuse or clear it.
+//
+// NewLocalKeyEncapsulationService is part of the property encryption preview feature (see
+// README on what it means in terms of support and compatibility guarantees).
+func NewLocalKeyEncapsulationService(kek []byte) (*LocalKeyEncapsulationService, error) {
+	if len(kek) != ipe.KeySize {
+		return nil, &Error{Message: fmt.Sprintf(
+			"a local key encryption key must be %d bytes but is %d", ipe.KeySize, len(kek))}
+	}
+	return &LocalKeyEncapsulationService{kek: append([]byte(nil), kek...)}, nil
+}
+
+// Encapsulate generates a data encryption key and wraps it with the key encryption key.
+func (s *LocalKeyEncapsulationService) Encapsulate(
+	_ context.Context, _ map[string]string) (EncapsulationResult, error) {
+
+	dek, err := ipe.NewDEK()
+	if err != nil {
+		return EncapsulationResult{}, &Error{Message: "could not create a data encryption key", Cause: err}
+	}
+	encapsulation, iv, err := ipe.WrapKey(s.kek, dek)
+	if err != nil {
+		return EncapsulationResult{}, &Error{Message: "could not wrap the data encryption key", Cause: err}
+	}
+	return EncapsulationResult{
+		Key:           dek,
+		Encapsulation: encapsulation,
+		Metadata:      map[string]string{localMetadataIV: base64.StdEncoding.EncodeToString(iv)},
+	}, nil
+}
+
+// Decapsulate unwraps a data encryption key with the key encryption key.
+func (s *LocalKeyEncapsulationService) Decapsulate(
+	_ context.Context, encapsulation []byte, metadata map[string]string) ([]byte, error) {
+
+	encoded, ok := metadata[localMetadataIV]
+	if !ok {
+		return nil, &Error{Message: "the encapsulated key has no " + localMetadataIV +
+			" metadata and was not wrapped by a local key encapsulation service"}
+	}
+	iv, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, &Error{Message: "the encapsulated key has unreadable " + localMetadataIV +
+			" metadata", Cause: err}
+	}
+	dek, err := ipe.UnwrapKey(s.kek, encapsulation, iv)
+	if err != nil {
+		return nil, &Error{Message: "could not unwrap the data encryption key, " +
+			"the key encryption key may be wrong", Cause: err}
+	}
+	return dek, nil
+}

--- a/neo4j/propertyencryption/profile.go
+++ b/neo4j/propertyencryption/profile.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package propertyencryption
+
+import (
+	"time"
+
+	ipe "github.com/neo4j/neo4j-go-driver/v6/neo4j/internal/propertyencryption"
+)
+
+// Default cache settings for an EnvelopeProfile.
+const (
+	DefaultKeyAliasCacheTTL  = ipe.DefaultKeyAliasCacheTTL
+	DefaultKeyAliasCacheSize = ipe.DefaultKeyAliasCacheSize
+	DefaultKeyCacheTTL       = ipe.DefaultKeyCacheTTL
+	DefaultKeyCacheSize      = ipe.DefaultKeyCacheSize
+)
+
+// Profile describes how a set of values is encrypted. Every encrypted value records the name
+// of the profile that produced it. EnvelopeProfile is the only implementation.
+//
+// Profile is part of the property encryption preview feature (see README on what it means in
+// terms of support and compatibility guarantees).
+type Profile interface {
+	validate() error
+}
+
+// EnvelopeProfile encrypts values with a data encryption key and protects that key
+// separately, so values are encrypted locally while the key protecting them can be held
+// elsewhere, and a key management service is consulted per key rather than per value.
+//
+// Data encryption keys must be created before use, see Encryption.Keys.
+//
+// EnvelopeProfile is part of the property encryption preview feature (see README on what it
+// means in terms of support and compatibility guarantees).
+type EnvelopeProfile struct {
+	// Name identifies this profile and is recorded with every value it encrypts. It must be
+	// unique within a driver and must match on any other driver expected to read those
+	// values.
+	//
+	// Required.
+	Name string
+	// EncapsulationService protects data encryption keys.
+	//
+	// Required.
+	EncapsulationService KeyEncapsulationService
+	// KeyRepository stores data encryption keys in their protected form.
+	//
+	// Required.
+	KeyRepository EncapsulatedKeyRepository
+	// KeyCacheTTL is how long a decapsulated data encryption key is held in memory.
+	//
+	// default: DefaultKeyCacheTTL
+	KeyCacheTTL time.Duration
+	// KeyCacheSize is the most data encryption keys held in memory at once.
+	//
+	// default: DefaultKeyCacheSize
+	KeyCacheSize int
+	// KeyAliasCacheTTL is how long an alias is assumed to still point at the same key, and
+	// so the delay before a rotation performed elsewhere is noticed.
+	//
+	// default: DefaultKeyAliasCacheTTL
+	KeyAliasCacheTTL time.Duration
+	// KeyAliasCacheSize is the most alias mappings held in memory at once.
+	//
+	// default: DefaultKeyAliasCacheSize
+	KeyAliasCacheSize int
+}
+
+func (p EnvelopeProfile) validate() error {
+	switch {
+	case p.Name == "":
+		return &Error{Message: "a property encryption profile must have a name"}
+	case p.EncapsulationService == nil:
+		return &Error{Message: "property encryption profile " + p.Name +
+			" has no EncapsulationService"}
+	case p.KeyRepository == nil:
+		return &Error{Message: "property encryption profile " + p.Name + " has no KeyRepository"}
+	case p.KeyCacheTTL < 0 || p.KeyAliasCacheTTL < 0:
+		return &Error{Message: "property encryption profile " + p.Name +
+			" has a negative cache time to live"}
+	case p.KeyCacheSize < 0 || p.KeyAliasCacheSize < 0:
+		return &Error{Message: "property encryption profile " + p.Name +
+			" has a negative cache size"}
+	}
+	return nil
+}
+
+// withDefaults applies the default cache settings to any left unset.
+func (p EnvelopeProfile) withDefaults() EnvelopeProfile {
+	if p.KeyCacheTTL == 0 {
+		p.KeyCacheTTL = DefaultKeyCacheTTL
+	}
+	if p.KeyCacheSize == 0 {
+		p.KeyCacheSize = DefaultKeyCacheSize
+	}
+	if p.KeyAliasCacheTTL == 0 {
+		p.KeyAliasCacheTTL = DefaultKeyAliasCacheTTL
+	}
+	if p.KeyAliasCacheSize == 0 {
+		p.KeyAliasCacheSize = DefaultKeyAliasCacheSize
+	}
+	return p
+}

--- a/testkit-backend/2cypher.go
+++ b/testkit-backend/2cypher.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strings"
@@ -44,6 +45,8 @@ func nativeToCypher(v any) map[string]any {
 		return valueResponse("CypherBool", x)
 	case float64:
 		return valueResponse("CypherFloat", x)
+	case []byte:
+		return valueResponse("CypherBytes", addSpacesToHex(hex.EncodeToString(x)))
 	case dbtype.Date:
 		date := x.Time()
 		values := map[string]any{

--- a/testkit-backend/2native.go
+++ b/testkit-backend/2native.go
@@ -150,6 +150,16 @@ func cypherToNative(c any) (any, error) {
 			}, nil
 		}
 		panic(fmt.Errorf("unknown spatial reference ID: %s", spatialReference))
+	case "CypherBytes":
+		hexData := strings.ReplaceAll(d["value"].(string), " ", "")
+		if hexData == "" {
+			return []byte{}, nil
+		}
+		decoded, err := hex.DecodeString(hexData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode CypherBytes hex data: %v", err)
+		}
+		return decoded, nil
 	case "CypherVector":
 		dtype := d["dtype"].(string)
 		data := d["data"].(string)

--- a/testkit-backend/backend.go
+++ b/testkit-backend/backend.go
@@ -39,6 +39,7 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/db"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/log"
 	"github.com/neo4j/neo4j-go-driver/v6/neo4j/notifications"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/propertyencryption"
 )
 
 // Handles a testkit backend session.
@@ -68,6 +69,9 @@ type backend struct {
 	resolvedClientCertificates      map[string]auth.ClientCertificate
 	closed                          bool
 	extrasData                      map[string]any
+	// propertyEncryption holds the key repositories the backend created per driver, so
+	// that keys can be seeded directly the way an application would.
+	propertyEncryption map[string]*propertyEncryptionState
 }
 
 // To implement transactional functions a bit of extra state is needed on the
@@ -166,6 +170,7 @@ func newBackend(rd *bufio.Reader, wr io.Writer) *backend {
 		resolvedClientCertificates:      make(map[string]auth.ClientCertificate),
 		closed:                          false,
 		extrasData:                      newBackendExtraData(),
+		propertyEncryption:              make(map[string]*propertyEncryptionState),
 	}
 }
 
@@ -241,7 +246,8 @@ func (b *backend) writeError(err error) {
 		neo4j.IsNeo4jError(err) ||
 		neo4j.IsUsageError(err) ||
 		neo4j.IsConnectivityError(err) ||
-		neo4j.IsTransactionExecutionLimit(err)
+		neo4j.IsTransactionExecutionLimit(err) ||
+		neo4j.IsPropertyEncryptionError(err)
 
 	if isDriverError {
 		var msg, errorType, gqlStatus, gqlStatusDescription, gqlClassification, gqlRawClassification string
@@ -631,6 +637,7 @@ func (b *backend) handleRequest(req map[string]any) {
 		}
 		// Parse URI (or rather type cast)
 		uri := data["uri"].(string)
+		var propertyEncryptionState *propertyEncryptionState
 		driver, err := neo4j.NewDriver(uri, authToken, func(c *config.Config) {
 			// Setup custom logger that redirects log entries back to frontend
 			c.Log = &streamLog{writeLine: b.writeLineLocked}
@@ -695,6 +702,15 @@ func (b *backend) handleRequest(req map[string]any) {
 			if data["disableAutoCommitRetries"] != nil {
 				c.DisableAutoCommitRetries = data["disableAutoCommitRetries"].(bool)
 			}
+			if data["propertyEncryptionProfiles"] != nil {
+				profiles, state, profileErr := buildPropertyEncryptionProfiles(data["propertyEncryptionProfiles"])
+				if profileErr != nil {
+					err = profileErr
+					return
+				}
+				c.PropertyEncryptionProfiles = profiles
+				propertyEncryptionState = state
+			}
 
 			clientCertificateProviderId := data["clientCertificateProviderId"]
 			if clientCertificateProviderId != nil {
@@ -730,6 +746,9 @@ func (b *backend) handleRequest(req map[string]any) {
 
 		idKey := b.nextId()
 		b.drivers[idKey] = driver
+		if propertyEncryptionState != nil {
+			b.propertyEncryption[idKey] = propertyEncryptionState
+		}
 		b.writeResponse("Driver", map[string]any{"id": idKey})
 
 	case "NewClientCertificateProvider":
@@ -1193,6 +1212,137 @@ func (b *backend) handleRequest(req map[string]any) {
 		driver := b.drivers[data["driverId"].(string)]
 		b.writeResponse("DriverIsEncrypted", map[string]any{
 			"encrypted": driver.IsEncrypted(),
+		})
+
+	case "EncryptToBytes":
+		driver := b.drivers[data["driverId"].(string)]
+		reference, err := keyReference(data)
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		value, err := cypherToNative(data["value"])
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		request := propertyencryption.EncryptRequest{
+			Value:   value,
+			Key:     reference,
+			Profile: optionalString(data, "profileName"),
+		}
+		if data["aad"] != nil {
+			aad, err := cypherToNative(data["aad"])
+			if err != nil {
+				b.writeError(err)
+				return
+			}
+			request.AAD = aad
+		}
+
+		encryption := driver.PropertyEncryption()
+		// Pinned by the deterministic tests so the ciphertext is reproducible.
+		restoreIV := func() bool { return true }
+		if data["iv"] != nil {
+			iv, err := decodeTestkitHex(data["iv"])
+			if err != nil {
+				b.writeError(err)
+				return
+			}
+			restoreIV = encryption.PinIV(iv)
+		}
+		encrypted, err := encryption.Encrypt(ctx, request)
+		if used := restoreIV(); err == nil && !used {
+			b.writeError(fmt.Errorf("the pinned initialisation vector was not used"))
+			return
+		}
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		b.writeResponse("EncryptedValue", map[string]any{
+			"encryptedBytes": encodeTestkitHex(encrypted),
+		})
+
+	case "Decrypt":
+		driver := b.drivers[data["driverId"].(string)]
+		encrypted, err := decodeTestkitHex(data["value"])
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+
+		usePersisted, _ := data["usePersistedAad"].(bool)
+		var decrypted any
+		if usePersisted {
+			decrypted, err = driver.PropertyEncryption().Decrypt(ctx, encrypted)
+		} else {
+			if data["aad"] == nil {
+				b.writeError(fmt.Errorf("one of aad or usePersistedAad is required"))
+				return
+			}
+			aad, aadErr := cypherToNative(data["aad"])
+			if aadErr != nil {
+				b.writeError(aadErr)
+				return
+			}
+			decrypted, err = driver.PropertyEncryption().DecryptWithAAD(ctx, encrypted, aad)
+		}
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		b.writeResponse("DecryptedValue", map[string]any{
+			"decryptedValue": nativeToCypher(decrypted),
+		})
+
+	case "CreateEncapsulatedKey":
+		driver := b.drivers[data["driverId"].(string)]
+		keys, err := driver.PropertyEncryption().Keys(optionalString(data, "profileName"))
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		key, err := keys.Create(ctx, data["alias"].(string))
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		b.writeResponse("EncapsulatedKey", map[string]any{
+			"id":    key.ID,
+			"alias": key.Alias,
+		})
+
+	case "ImportEncapsulatedKey":
+		driverId := data["driverId"].(string)
+		state := b.propertyEncryption[driverId]
+		if state == nil {
+			b.writeError(fmt.Errorf("this driver has no property encryption profiles"))
+			return
+		}
+		profileName := data["profileName"].(string)
+		repository := state.repositories[profileName]
+		if repository == nil {
+			b.writeError(fmt.Errorf("no property encryption profile is named %s", profileName))
+			return
+		}
+		encapsulation, err := decodeTestkitHex(data["encapsulation"])
+		if err != nil {
+			b.writeError(err)
+			return
+		}
+		metadata := map[string]string{}
+		if raw, ok := data["metadata"].(map[string]any); ok {
+			for name, value := range raw {
+				metadata[name] = fmt.Sprintf("%v", value)
+			}
+		}
+		// Seeded into the repository directly, not through the driver's API.
+		key := repository.importKey(
+			data["keyId"].(string), data["alias"].(string), encapsulation, metadata)
+		b.writeResponse("EncapsulatedKey", map[string]any{
+			"id":    key.ID,
+			"alias": key.Alias,
 		})
 
 	case "VerifyConnectivity":

--- a/testkit-backend/propertyencryption.go
+++ b/testkit-backend/propertyencryption.go
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j/propertyencryption"
+)
+
+// TestKit has no way to supply a key encapsulation service or key repository, so the backend
+// provides them and drives the driver's API against them.
+
+// testkitKeyRepository is an in-memory EncapsulatedKeyRepository.
+type testkitKeyRepository struct {
+	mutex   sync.Mutex
+	keys    map[string]propertyencryption.EncapsulatedKey
+	aliases map[string]string
+	nextID  int
+}
+
+func newTestkitKeyRepository() *testkitKeyRepository {
+	return &testkitKeyRepository{
+		keys:    map[string]propertyencryption.EncapsulatedKey{},
+		aliases: map[string]string{},
+	}
+}
+
+func (r *testkitKeyRepository) FindByID(
+	_ context.Context, id string) (propertyencryption.EncapsulatedKey, error) {
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	key, ok := r.keys[id]
+	if !ok {
+		return propertyencryption.EncapsulatedKey{}, propertyencryption.ErrKeyNotFound
+	}
+	return key, nil
+}
+
+func (r *testkitKeyRepository) FindByAlias(
+	_ context.Context, alias string) (propertyencryption.EncapsulatedKey, error) {
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	id, ok := r.aliases[alias]
+	if !ok {
+		return propertyencryption.EncapsulatedKey{}, propertyencryption.ErrKeyNotFound
+	}
+	return r.keys[id], nil
+}
+
+func (r *testkitKeyRepository) Save(
+	_ context.Context, alias string, encapsulation []byte,
+	metadata map[string]string) (propertyencryption.EncapsulatedKey, error) {
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	id := strconv.Itoa(r.nextID)
+	r.nextID++
+	return r.store(id, alias, encapsulation, metadata), nil
+}
+
+func (r *testkitKeyRepository) AddAlias(_ context.Context, id, alias string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if _, ok := r.keys[id]; !ok {
+		return propertyencryption.ErrKeyNotFound
+	}
+	r.aliases[alias] = id
+	return nil
+}
+
+func (r *testkitKeyRepository) DeleteAlias(_ context.Context, _, alias string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	delete(r.aliases, alias)
+	return nil
+}
+
+func (r *testkitKeyRepository) DeleteByID(_ context.Context, id string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	delete(r.keys, id)
+	return nil
+}
+
+// importKey seeds the repository with a key made elsewhere, under an id TestKit chooses.
+func (r *testkitKeyRepository) importKey(
+	id, alias string, encapsulation []byte,
+	metadata map[string]string) propertyencryption.EncapsulatedKey {
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.store(id, alias, encapsulation, metadata)
+}
+
+// store records a key. The caller must hold the mutex.
+func (r *testkitKeyRepository) store(
+	id, alias string, encapsulation []byte,
+	metadata map[string]string) propertyencryption.EncapsulatedKey {
+
+	key := propertyencryption.EncapsulatedKey{
+		ID:            id,
+		Alias:         alias,
+		Encapsulation: encapsulation,
+		Metadata:      metadata,
+	}
+	r.keys[id] = key
+	r.aliases[alias] = id
+	return key
+}
+
+// propertyEncryptionState holds the repositories the backend created for a driver.
+type propertyEncryptionState struct {
+	repositories map[string]*testkitKeyRepository
+}
+
+// buildPropertyEncryptionProfiles turns the propertyEncryptionProfiles field of a NewDriver
+// request into configured profiles, and returns the repositories backing them.
+func buildPropertyEncryptionProfiles(
+	raw any) ([]propertyencryption.Profile, *propertyEncryptionState, error) {
+
+	entries, ok := raw.([]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("propertyEncryptionProfiles must be a list, got %T", raw)
+	}
+
+	profiles := make([]propertyencryption.Profile, 0, len(entries))
+	state := &propertyEncryptionState{repositories: map[string]*testkitKeyRepository{}}
+	for _, entry := range entries {
+		fields, ok := entry.(map[string]any)
+		if !ok {
+			return nil, nil, fmt.Errorf("a property encryption profile must be an object, got %T", entry)
+		}
+		name, ok := fields["name"].(string)
+		if !ok {
+			return nil, nil, fmt.Errorf("a property encryption profile must have a name")
+		}
+
+		// The deterministic tests pin the key encryption key.
+		kek := make([]byte, 32)
+		if raw, given := fields["kek"]; given && raw != nil {
+			decoded, err := decodeTestkitHex(raw)
+			if err != nil {
+				return nil, nil, fmt.Errorf("profile %s has an unreadable kek: %w", name, err)
+			}
+			kek = decoded
+		} else if _, err := rand.Read(kek); err != nil {
+			return nil, nil, err
+		}
+
+		service, err := propertyencryption.NewLocalKeyEncapsulationService(kek)
+		if err != nil {
+			return nil, nil, err
+		}
+		repository := newTestkitKeyRepository()
+		state.repositories[name] = repository
+		profiles = append(profiles, propertyencryption.EnvelopeProfile{
+			Name:                 name,
+			EncapsulationService: service,
+			KeyRepository:        repository,
+		})
+	}
+	return profiles, state, nil
+}
+
+// decodeTestkitHex reads the space separated hex TestKit uses for byte fields, for example
+// "0a 1b 2c".
+func decodeTestkitHex(raw any) ([]byte, error) {
+	text, ok := raw.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected a hex string, got %T", raw)
+	}
+	return hex.DecodeString(strings.ReplaceAll(text, " ", ""))
+}
+
+func encodeTestkitHex(value []byte) string {
+	return addSpacesToHex(hex.EncodeToString(value))
+}
+
+// optionalString reads a field that TestKit may send as null.
+func optionalString(data map[string]any, key string) string {
+	if value, ok := data[key].(string); ok {
+		return value
+	}
+	return ""
+}
+
+// keyReference builds the reference from the mutually exclusive keyAlias and keyId fields.
+func keyReference(data map[string]any) (propertyencryption.KeyReference, error) {
+	alias := optionalString(data, "keyAlias")
+	id := optionalString(data, "keyId")
+	switch {
+	case alias != "" && id != "":
+		return propertyencryption.KeyReference{}, fmt.Errorf("keyAlias and keyId are mutually exclusive")
+	case alias != "":
+		return propertyencryption.KeyAlias(alias), nil
+	case id != "":
+		return propertyencryption.KeyID(id), nil
+	default:
+		return propertyencryption.KeyReference{}, fmt.Errorf("one of keyAlias or keyId is required")
+	}
+}

--- a/testkit-backend/z_final_init.go
+++ b/testkit-backend/z_final_init.go
@@ -75,6 +75,7 @@ func init() {
 		"Feature:API:Driver.VerifyConnectivity",
 		//"Feature:API:Driver.SupportsSessionAuth",
 		"Feature:API:Liveness.Check",
+		"Feature:API:PropertyEncryption",
 		"Feature:API:Result.List",
 		"Feature:API:Result.Peek",
 		//"Feature:API:Result.Single",


### PR DESCRIPTION
Closes: DRIVERS-435

Encrypt and decrypt individual property values in the application, so a value chosen for encryption reaches the database only as ciphertext. Encrypted bytes are portable across Neo4j drivers. How they are stored is left to the application.

```go
driver, err := neo4j.NewDriver(uri, auth, func(c *config.Config) {
	c.PropertyEncryptionProfiles = []propertyencryption.Profile{
		propertyencryption.EnvelopeProfile{
			Name:                 "customer-pii",
			EncapsulationService: keyService,
			KeyRepository:        keyRepository,
		},
	}
})

encryption := driver.PropertyEncryption()

keys, err := encryption.Keys("customer-pii")
_, err = keys.Create(ctx, "current")

encrypted, err := encryption.Encrypt(ctx, propertyencryption.EncryptRequest{
	Value: "078-05-1120",
	AAD:   "customer-1",
	Key:   propertyencryption.KeyAlias("current"),
})

_, err = neo4j.ExecuteQuery(ctx, driver,
	"CREATE (c:Customer {id: $id, ssn: $ssn})",
	map[string]any{"id": "customer-1", "ssn": encrypted},
	neo4j.EagerResultTransformer)

ssn, err := encryption.DecryptWithAAD(ctx, stored, "customer-1")
```

See `encryption_example_test.go` for the full round trip.
