### PR TITLE
Port Pin pre-commit staticcheck to the version CI uses

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -13,7 +13,8 @@ verlt() {
 }
 
 go_version=$(go version | grep -o "go\([0-9.]\)\+" | grep -o "\([0-9.]\)\+")
-staticcheck_version="latest"
+# CI's v0.3.3 needs go1.18; v0.7.0+ reports findings CI does not
+staticcheck_version="v0.6.0"
 if verlt $go_version "1.19"; then  # go 1.18 and below
 	staticcheck_version="v0.3.3"
 elif verlt $go_version "1.20"; then  # go 1.19 and below


### PR DESCRIPTION
Port of https://github.com/neo4j/neo4j-go-driver/pull/708

Closes: DRIVERS-539